### PR TITLE
fix(hooks): align Codex hook install

### DIFF
--- a/.airlock/lint.sh
+++ b/.airlock/lint.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${AIRLOCK_BASE_SHA:-}" || -z "${AIRLOCK_HEAD_SHA:-}" ]]; then
+  echo "AIRLOCK_BASE_SHA and AIRLOCK_HEAD_SHA must be set" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+changed_files=()
+while IFS= read -r file; do
+  changed_files+=("$file")
+done < <(git diff --name-only --diff-filter=ACMR "$AIRLOCK_BASE_SHA" "$AIRLOCK_HEAD_SHA")
+
+if ((${#changed_files[@]} == 0)); then
+  exit 0
+fi
+
+prettier_files=()
+eslint_files=()
+has_typescript_changes=0
+
+for file in "${changed_files[@]}"; do
+  [[ -f "$file" ]] || continue
+
+  case "$file" in
+    *.ts|*.tsx|*.mts|*.cts|*.js|*.jsx|*.mjs|*.cjs|*.json|*.md|*.yml|*.yaml)
+      prettier_files+=("$file")
+      ;;
+  esac
+
+  case "$file" in
+    *.ts|*.tsx|*.mts|*.cts|*.js|*.jsx|*.mjs|*.cjs)
+      eslint_files+=("$file")
+      ;;
+  esac
+
+  case "$file" in
+    *.ts|*.tsx|*.mts|*.cts)
+      has_typescript_changes=1
+      ;;
+  esac
+done
+
+if ((${#prettier_files[@]} > 0)); then
+  npx prettier --write "${prettier_files[@]}"
+fi
+
+if ((${#eslint_files[@]} > 0)) && [[ -f eslint.config.mjs ]]; then
+  npx eslint --fix "${eslint_files[@]}"
+fi
+
+if ((${#prettier_files[@]} > 0)); then
+  npx prettier --check "${prettier_files[@]}"
+fi
+
+if ((${#eslint_files[@]} > 0)) && [[ -f eslint.config.mjs ]]; then
+  npx eslint "${eslint_files[@]}"
+fi
+
+if ((has_typescript_changes)); then
+  npx tsc --noEmit
+fi

--- a/.airlock/workflows/main.yml
+++ b/.airlock/workflows/main.yml
@@ -1,0 +1,66 @@
+# Airlock workflow configuration
+# Documentation: https://github.com/airlock-hq/airlock
+
+name: Main Pipeline
+
+on:
+  push:
+    branches: ['**']
+
+jobs:
+  rebase:
+    name: Rebase
+    steps:
+      - name: rebase
+        uses: airlock-hq/airlock/defaults/rebase@main
+
+  critique:
+    name: Critique
+    needs: rebase
+    steps:
+      - name: critique
+        uses: airlock-hq/airlock/defaults/critique@main
+
+  test:
+    name: Test
+    needs: rebase
+    steps:
+      - name: test
+        uses: airlock-hq/airlock/defaults/test@main
+
+  gate:
+    name: Review Gate
+    needs: [critique, test]
+    steps:
+      - name: review
+        uses: airlock-hq/airlock/defaults/gate@main
+        env:
+          # Change to never, low, medium, or high to control when human approval is required.
+          AIRLOCK_RISK_THRESHOLD: medium
+
+  describe:
+    name: Describe
+    needs: gate
+    steps:
+      - name: describe
+        uses: airlock-hq/airlock/defaults/describe@main
+
+  document:
+    name: Document
+    needs: gate
+    steps:
+      - name: document
+        uses: airlock-hq/airlock/defaults/document@main
+        apply-patch: true
+
+  deploy:
+    name: Lint & Push
+    needs: [describe, document]
+    steps:
+      - name: lint
+        uses: airlock-hq/airlock/defaults/lint@main
+        apply-patch: true
+      - name: push
+        uses: airlock-hq/airlock/defaults/push@main
+      - name: create-pr
+        uses: airlock-hq/airlock/defaults/create-pr@main

--- a/.airlock/workflows/main.yml
+++ b/.airlock/workflows/main.yml
@@ -5,7 +5,7 @@ name: Main Pipeline
 
 on:
   push:
-    branches: ['**']
+    branches: ["**"]
 
 jobs:
   rebase:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,31 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: ['dist/**', 'node_modules/**'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['**/*.{js,cjs,mjs,ts,cts,mts}'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+  {
+    files: ['test/**/*.ts', '**/*.test.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.vitest,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,28 @@
 {
-  "name": "gh-axg",
+  "name": "gh-axi",
   "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gh-axg",
+      "name": "gh-axi",
       "version": "0.1.5",
+      "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0"
       },
       "bin": {
-        "gh-axg": "dist/bin/gh-axg.js"
+        "gh-axi": "dist/bin/gh-axi.js"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/node": "^22.0.0",
+        "eslint": "^10.1.0",
+        "globals": "^17.4.0",
+        "prettier": "^3.8.1",
         "tsx": "^4.0.0",
         "typescript": "^5.7.0",
+        "typescript-eslint": "^8.58.0",
         "vitest": "^3.0.0"
       },
       "engines": {
@@ -465,6 +471,186 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -846,10 +1032,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -861,6 +1061,236 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
+      "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/type-utils": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
+      "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
+      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.0",
+        "@typescript-eslint/types": "^8.58.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
+      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
+      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
+      "integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
+      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
+      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.0",
+        "@typescript-eslint/tsconfig-utils": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
+      "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
+      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@vitest/expect": {
@@ -978,6 +1408,46 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -986,6 +1456,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/cac": {
@@ -1025,6 +1518,21 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1052,6 +1560,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1102,6 +1617,161 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
+      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.3",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1110,6 +1780,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expect-type": {
@@ -1121,6 +1801,27 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1139,6 +1840,57 @@
           "optional": true
         }
       }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1168,12 +1920,149 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -1190,6 +2079,22 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -1216,6 +2121,83 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -1284,6 +2266,42 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -1337,6 +2355,42 @@
         "@rollup/rollup-win32-x64-gnu": "4.59.0",
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/siginfo": {
@@ -1444,6 +2498,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -1464,6 +2531,19 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1478,12 +2558,46 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
+      "integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.0",
+        "@typescript-eslint/parser": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/vite": {
       "version": "7.3.1",
@@ -1656,6 +2770,22 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1671,6 +2801,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,9 +41,14 @@
     "@toon-format/toon": "^2.1.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/node": "^22.0.0",
+    "eslint": "^10.1.0",
+    "globals": "^17.4.0",
+    "prettier": "^3.8.1",
     "tsx": "^4.0.0",
     "typescript": "^5.7.0",
+    "typescript-eslint": "^8.58.0",
     "vitest": "^3.0.0"
   }
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -138,17 +138,28 @@ function ensureCodexHook(exePath: string): void {
   };
 
   if (existingIdx >= 0) {
-    const existingHook = matcherBlocks[existingIdx].hooks?.find(
+    const existingBlock = matcherBlocks[existingIdx];
+    const existingHook = existingBlock.hooks?.find(
       (h: any) => typeof h.command === 'string' && h.command.includes(HOOK_ID),
     );
+    const matcher = existingBlock?.matcher;
+    const matcherIsMatchAll = matcher === '' || matcher === '*' || matcher == null;
     if (
       existingHook?.command === hookCommand &&
-      matcherBlocks[existingIdx]?.matcher === '' &&
+      matcherIsMatchAll &&
       existingHook?.type === 'command'
     ) {
       if (!changed) return; // no-op
+    } else if (existingHook) {
+      existingHook.command = hookCommand;
+      existingHook.type = 'command';
+      changed = true;
     } else {
-      matcherBlocks[existingIdx] = matcherBlock;
+      existingBlock.hooks.push({
+        type: 'command' as const,
+        command: hookCommand,
+        timeout: 10,
+      });
       changed = true;
     }
   } else {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -4,15 +4,69 @@
  * Failures are non-fatal — errors log to stderr and never throw.
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 /** Marker used to identify our hook entries in config files. */
-const HOOK_ID = 'gh-axi';
+const HOOK_ID = "gh-axi";
+
+type HookCommand = {
+  type?: string;
+  command?: string;
+  timeout?: number;
+};
+
+type MatcherBlock = {
+  matcher?: string | null;
+  hooks?: HookCommand[];
+};
+
+type HookCollection = {
+  SessionStart?: MatcherBlock[];
+  session_start?: HookCommand[];
+};
+
+type HookConfig = {
+  hooks?: HookCollection;
+  [key: string]: unknown;
+};
 
 function getExePath(): string {
   return process.argv[1];
+}
+
+function ensureHookCollection(config: HookConfig): HookCollection {
+  if (!config.hooks) {
+    config.hooks = {};
+  }
+
+  return config.hooks;
+}
+
+function ensureSessionStartBlocks(hooks: HookCollection): MatcherBlock[] {
+  if (!Array.isArray(hooks.SessionStart)) {
+    hooks.SessionStart = [];
+  }
+
+  return hooks.SessionStart;
+}
+
+function isManagedHook(hook: HookCommand | undefined): boolean {
+  return typeof hook?.command === "string" && hook.command.includes(HOOK_ID);
+}
+
+function createMatcherBlock(command: string): MatcherBlock {
+  return {
+    matcher: "",
+    hooks: [
+      {
+        type: "command",
+        command,
+        timeout: 10,
+      },
+    ],
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -20,50 +74,32 @@ function getExePath(): string {
 // ---------------------------------------------------------------------------
 
 function ensureClaudeHook(exePath: string): void {
-  const claudeDir = join(homedir(), '.claude');
+  const claudeDir = join(homedir(), ".claude");
   if (!existsSync(claudeDir)) return;
 
-  const settingsPath = join(claudeDir, 'settings.json');
-  let settings: Record<string, any> = {};
+  const settingsPath = join(claudeDir, "settings.json");
+  let settings: HookConfig = {};
 
   if (existsSync(settingsPath)) {
-    const raw = readFileSync(settingsPath, 'utf-8');
-    settings = JSON.parse(raw);
+    const raw = readFileSync(settingsPath, "utf-8");
+    settings = JSON.parse(raw) as HookConfig;
   }
 
-  if (!settings.hooks) {
-    settings.hooks = {};
-  }
-  if (!Array.isArray(settings.hooks.SessionStart)) {
-    settings.hooks.SessionStart = [];
-  }
-
-  const matcherBlocks: any[] = settings.hooks.SessionStart;
+  const matcherBlocks = ensureSessionStartBlocks(
+    ensureHookCollection(settings),
+  );
   const hookCommand = `${exePath} --session-start`;
 
   // Find existing gh-axi matcher block (by looking for gh-axi in any nested hook command)
   const existingIdx = matcherBlocks.findIndex(
-    (block: any) =>
-      Array.isArray(block.hooks) &&
-      block.hooks.some((h: any) => typeof h.command === 'string' && h.command.includes(HOOK_ID)),
+    (block) => Array.isArray(block.hooks) && block.hooks.some(isManagedHook),
   );
 
-  const matcherBlock = {
-    matcher: '',
-    hooks: [
-      {
-        type: 'command' as const,
-        command: hookCommand,
-        timeout: 10,
-      },
-    ],
-  };
+  const matcherBlock = createMatcherBlock(hookCommand);
 
   if (existingIdx >= 0) {
     // Check if command is already correct
-    const existingHook = matcherBlocks[existingIdx].hooks?.find(
-      (h: any) => typeof h.command === 'string' && h.command.includes(HOOK_ID),
-    );
+    const existingHook = matcherBlocks[existingIdx].hooks?.find(isManagedHook);
     if (existingHook?.command === hookCommand) {
       return; // no-op
     }
@@ -73,7 +109,7 @@ function ensureClaudeHook(exePath: string): void {
     matcherBlocks.push(matcherBlock);
   }
 
-  writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2), "utf-8");
 }
 
 // ---------------------------------------------------------------------------
@@ -83,82 +119,67 @@ function ensureClaudeHook(exePath: string): void {
 // ---------------------------------------------------------------------------
 
 function ensureCodexHook(exePath: string): void {
-  const codexDir = join(homedir(), '.codex');
+  const codexDir = join(homedir(), ".codex");
   if (!existsSync(codexDir)) return;
 
-  const hooksPath = join(codexDir, 'hooks.json');
-  let config: Record<string, any> = {};
+  const hooksPath = join(codexDir, "hooks.json");
+  let config: HookConfig = {};
 
   if (existsSync(hooksPath)) {
-    const raw = readFileSync(hooksPath, 'utf-8');
-    config = JSON.parse(raw);
+    const raw = readFileSync(hooksPath, "utf-8");
+    config = JSON.parse(raw) as HookConfig;
   }
 
-  if (!config.hooks) {
-    config.hooks = {};
-  }
+  const hooks = ensureHookCollection(config);
   let changed = false;
   const hookCommand = `${exePath} --session-start`;
 
   // Migrate our legacy lowercase key if present.
-  if (Array.isArray(config.hooks.session_start)) {
-    const filteredLegacyHooks = config.hooks.session_start.filter(
-      (h: any) => !(typeof h.command === 'string' && h.command.includes(HOOK_ID)),
+  if (Array.isArray(hooks.session_start)) {
+    const filteredLegacyHooks = hooks.session_start.filter(
+      (hook) => !isManagedHook(hook),
     );
 
-    if (filteredLegacyHooks.length !== config.hooks.session_start.length) {
+    if (filteredLegacyHooks.length !== hooks.session_start.length) {
       changed = true;
     }
 
     if (filteredLegacyHooks.length > 0) {
-      config.hooks.session_start = filteredLegacyHooks;
+      hooks.session_start = filteredLegacyHooks;
     } else {
-      delete config.hooks.session_start;
+      delete hooks.session_start;
     }
   }
 
-  if (!Array.isArray(config.hooks.SessionStart)) {
-    config.hooks.SessionStart = [];
-  }
-
-  const matcherBlocks: any[] = config.hooks.SessionStart;
+  const matcherBlocks = ensureSessionStartBlocks(hooks);
   const existingIdx = matcherBlocks.findIndex(
-    (block: any) =>
-      Array.isArray(block.hooks) &&
-      block.hooks.some((h: any) => typeof h.command === 'string' && h.command.includes(HOOK_ID)),
+    (block) => Array.isArray(block.hooks) && block.hooks.some(isManagedHook),
   );
 
-  const matcherBlock = {
-    matcher: '',
-    hooks: [
-      {
-        type: 'command' as const,
-        command: hookCommand,
-        timeout: 10,
-      },
-    ],
-  };
+  const matcherBlock = createMatcherBlock(hookCommand);
 
   if (existingIdx >= 0) {
     const existingBlock = matcherBlocks[existingIdx];
-    const existingHook = existingBlock.hooks?.find(
-      (h: any) => typeof h.command === 'string' && h.command.includes(HOOK_ID),
-    );
+    const existingHook = existingBlock.hooks?.find(isManagedHook);
     const matcher = existingBlock?.matcher;
-    const matcherIsMatchAll = matcher === '' || matcher === '*' || matcher == null;
+    const matcherIsMatchAll =
+      matcher === "" || matcher === "*" || matcher == null;
     if (
       existingHook?.command === hookCommand &&
       matcherIsMatchAll &&
-      existingHook?.type === 'command'
+      existingHook?.type === "command"
     ) {
       if (!changed) return; // no-op
     } else if (existingHook) {
       existingHook.command = hookCommand;
-      existingHook.type = 'command';
+      existingHook.type = "command";
       changed = true;
     } else {
+      if (!Array.isArray(existingBlock.hooks)) {
+        existingBlock.hooks = [];
+      }
       existingBlock.hooks.push({
-        type: 'command' as const,
+        type: "command",
         command: hookCommand,
         timeout: 10,
       });
@@ -171,7 +192,7 @@ function ensureCodexHook(exePath: string): void {
 
   if (!changed) return;
 
-  writeFileSync(hooksPath, JSON.stringify(config, null, 2), 'utf-8');
+  writeFileSync(hooksPath, JSON.stringify(config, null, 2), "utf-8");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -95,28 +95,68 @@ function ensureCodexHook(exePath: string): void {
   if (!config.hooks) {
     config.hooks = {};
   }
-  if (!Array.isArray(config.hooks.session_start)) {
-    config.hooks.session_start = [];
+  let changed = false;
+  const hookCommand = `${exePath} --session-start`;
+
+  // Migrate our legacy lowercase key if present.
+  if (Array.isArray(config.hooks.session_start)) {
+    const filteredLegacyHooks = config.hooks.session_start.filter(
+      (h: any) => !(typeof h.command === 'string' && h.command.includes(HOOK_ID)),
+    );
+
+    if (filteredLegacyHooks.length !== config.hooks.session_start.length) {
+      changed = true;
+    }
+
+    if (filteredLegacyHooks.length > 0) {
+      config.hooks.session_start = filteredLegacyHooks;
+    } else {
+      delete config.hooks.session_start;
+    }
   }
 
-  const hooks: any[] = config.hooks.session_start;
+  if (!Array.isArray(config.hooks.SessionStart)) {
+    config.hooks.SessionStart = [];
+  }
 
-  const existingIdx = hooks.findIndex(
-    (h: any) => typeof h.command === 'string' && h.command.includes(HOOK_ID),
+  const matcherBlocks: any[] = config.hooks.SessionStart;
+  const existingIdx = matcherBlocks.findIndex(
+    (block: any) =>
+      Array.isArray(block.hooks) &&
+      block.hooks.some((h: any) => typeof h.command === 'string' && h.command.includes(HOOK_ID)),
   );
 
-  const hookEntry = {
-    command: exePath,
+  const matcherBlock = {
+    matcher: '',
+    hooks: [
+      {
+        type: 'command' as const,
+        command: hookCommand,
+        timeout: 10,
+      },
+    ],
   };
 
   if (existingIdx >= 0) {
-    if (hooks[existingIdx].command === exePath) {
-      return; // no-op
+    const existingHook = matcherBlocks[existingIdx].hooks?.find(
+      (h: any) => typeof h.command === 'string' && h.command.includes(HOOK_ID),
+    );
+    if (
+      existingHook?.command === hookCommand &&
+      matcherBlocks[existingIdx]?.matcher === '' &&
+      existingHook?.type === 'command'
+    ) {
+      if (!changed) return; // no-op
+    } else {
+      matcherBlocks[existingIdx] = matcherBlock;
+      changed = true;
     }
-    hooks[existingIdx] = hookEntry;
   } else {
-    hooks.push(hookEntry);
+    matcherBlocks.push(matcherBlock);
+    changed = true;
   }
+
+  if (!changed) return;
 
   writeFileSync(hooksPath, JSON.stringify(config, null, 2), 'utf-8');
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -78,6 +78,8 @@ function ensureClaudeHook(exePath: string): void {
 
 // ---------------------------------------------------------------------------
 // Codex hooks: ~/.codex/hooks.json
+// Uses `hooks.SessionStart` matcher blocks and migrates legacy
+// `hooks.session_start` entries when present.
 // ---------------------------------------------------------------------------
 
 function ensureCodexHook(exePath: string): void {

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -46,6 +46,13 @@ describe('ensureHooks', () => {
     return call ? JSON.parse(call[1]) : null;
   }
 
+  function getCodexWritten(): any {
+    const call = (mockedFs.writeFileSync as any).mock.calls.find(
+      (c: any[]) => c[0] === path.join(FAKE_HOME, '.codex', 'hooks.json'),
+    );
+    return call ? JSON.parse(call[1]) : null;
+  }
+
   describe('Claude Code hooks (~/.claude/settings.json)', () => {
     it('creates settings.json with SessionStart hook when ~/.claude dir exists but no settings file', () => {
       mockedFs.existsSync.mockImplementation((p) => {
@@ -211,21 +218,26 @@ describe('ensureHooks', () => {
         'utf-8',
       );
 
-      const written = JSON.parse(
-        (mockedFs.writeFileSync as any).mock.calls.find(
-          (c: any[]) => c[0] === path.join(FAKE_HOME, '.codex', 'hooks.json'),
-        )[1],
-      );
-      expect(written.hooks.session_start).toBeInstanceOf(Array);
-      expect(written.hooks.session_start[0].command).toContain(FAKE_EXE);
+      const written = getCodexWritten();
+      expect(written.hooks.SessionStart).toBeInstanceOf(Array);
+      expect(written.hooks.SessionStart.length).toBe(1);
+      expect(written.hooks.SessionStart[0].matcher).toBe('');
+      expect(written.hooks.SessionStart[0].hooks).toBeInstanceOf(Array);
+      expect(written.hooks.SessionStart[0].hooks[0].type).toBe('command');
+      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(`${FAKE_EXE} --session-start`);
     });
 
     it('updates hook when exe path is stale in Codex config', () => {
       const staleExe = '/old/path/gh-axi';
       const existingHooks = {
         hooks: {
-          session_start: [
-            { command: `${staleExe}` },
+          SessionStart: [
+            {
+              matcher: '',
+              hooks: [
+                { type: 'command', command: `${staleExe} --session-start`, timeout: 10 },
+              ],
+            },
           ],
         },
       };
@@ -244,20 +256,21 @@ describe('ensureHooks', () => {
 
       ensureHooks();
 
-      const written = JSON.parse(
-        (mockedFs.writeFileSync as any).mock.calls.find(
-          (c: any[]) => c[0] === path.join(FAKE_HOME, '.codex', 'hooks.json'),
-        )[1],
-      );
-      expect(written.hooks.session_start[0].command).toContain(FAKE_EXE);
-      expect(written.hooks.session_start[0].command).not.toContain(staleExe);
+      const written = getCodexWritten();
+      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(`${FAKE_EXE} --session-start`);
+      expect(written.hooks.SessionStart[0].hooks[0].command).not.toContain(staleExe);
     });
 
     it('is a no-op when Codex hook already has correct exe path', () => {
       const existingHooks = {
         hooks: {
-          session_start: [
-            { command: `${FAKE_EXE}` },
+          SessionStart: [
+            {
+              matcher: '',
+              hooks: [
+                { type: 'command', command: `${FAKE_EXE} --session-start`, timeout: 10 },
+              ],
+            },
           ],
         },
       };
@@ -280,6 +293,69 @@ describe('ensureHooks', () => {
         (c: any[]) => c[0] === path.join(FAKE_HOME, '.codex', 'hooks.json'),
       );
       expect(codexWrites.length).toBe(0);
+    });
+
+    it('preserves other SessionStart matcher blocks when adding gh-axi hook', () => {
+      const existingHooks = {
+        hooks: {
+          SessionStart: [
+            {
+              matcher: '',
+              hooks: [
+                { type: 'command', command: '/some/other/tool' },
+              ],
+            },
+          ],
+        },
+      };
+
+      mockedFs.existsSync.mockImplementation((p) => {
+        if (p === path.join(FAKE_HOME, '.codex')) return true;
+        if (p === path.join(FAKE_HOME, '.codex', 'hooks.json')) return true;
+        return false;
+      });
+      mockedFs.readFileSync.mockImplementation((p) => {
+        if (p === path.join(FAKE_HOME, '.codex', 'hooks.json')) {
+          return JSON.stringify(existingHooks);
+        }
+        throw new Error('ENOENT');
+      });
+
+      ensureHooks();
+
+      const written = getCodexWritten();
+      expect(written.hooks.SessionStart.length).toBe(2);
+      expect(written.hooks.SessionStart[0].hooks[0].command).toBe('/some/other/tool');
+      expect(written.hooks.SessionStart[1].hooks[0].command).toBe(`${FAKE_EXE} --session-start`);
+    });
+
+    it('migrates legacy lowercase session_start entries to SessionStart matcher blocks', () => {
+      const existingHooks = {
+        hooks: {
+          session_start: [
+            { command: `${FAKE_EXE}` },
+          ],
+        },
+      };
+
+      mockedFs.existsSync.mockImplementation((p) => {
+        if (p === path.join(FAKE_HOME, '.codex')) return true;
+        if (p === path.join(FAKE_HOME, '.codex', 'hooks.json')) return true;
+        return false;
+      });
+      mockedFs.readFileSync.mockImplementation((p) => {
+        if (p === path.join(FAKE_HOME, '.codex', 'hooks.json')) {
+          return JSON.stringify(existingHooks);
+        }
+        throw new Error('ENOENT');
+      });
+
+      ensureHooks();
+
+      const written = getCodexWritten();
+      expect(written.hooks.session_start).toBeUndefined();
+      expect(written.hooks.SessionStart).toBeInstanceOf(Array);
+      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(`${FAKE_EXE} --session-start`);
     });
 
     it('skips Codex hooks when ~/.codex directory does not exist', () => {

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -1,20 +1,20 @@
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
-vi.mock('node:fs');
-vi.mock('node:os');
+vi.mock("node:fs");
+vi.mock("node:os");
 
 const mockedFs = vi.mocked(fs);
 const mockedOs = vi.mocked(os);
 
 // Import after mocking
-import { ensureHooks } from '../src/hooks.js';
+import { ensureHooks } from "../src/hooks.js";
 
-describe('ensureHooks', () => {
-  const FAKE_HOME = '/home/testuser';
-  const FAKE_EXE = '/usr/local/bin/gh-axi';
+describe("ensureHooks", () => {
+  const FAKE_HOME = "/home/testuser";
+  const FAKE_EXE = "/usr/local/bin/gh-axi";
   let stderrSpy: ReturnType<typeof vi.spyOn>;
   let originalArgv1: string;
 
@@ -23,15 +23,15 @@ describe('ensureHooks', () => {
     mockedOs.homedir.mockReturnValue(FAKE_HOME);
     originalArgv1 = process.argv[1];
     process.argv[1] = FAKE_EXE;
-    stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
 
     // Default: directories don't exist, files don't exist
     mockedFs.existsSync.mockReturnValue(false);
     mockedFs.readFileSync.mockImplementation(() => {
-      throw new Error('ENOENT');
+      throw new Error("ENOENT");
     });
     mockedFs.writeFileSync.mockImplementation(() => {});
-    mockedFs.mkdirSync.mockImplementation(() => '' as any);
+    mockedFs.mkdirSync.mockImplementation(() => "" as any);
   });
 
   afterEach(() => {
@@ -41,22 +41,22 @@ describe('ensureHooks', () => {
 
   function getClaudeWritten(): any {
     const call = (mockedFs.writeFileSync as any).mock.calls.find(
-      (c: any[]) => c[0] === path.join(FAKE_HOME, '.claude', 'settings.json'),
+      (c: any[]) => c[0] === path.join(FAKE_HOME, ".claude", "settings.json"),
     );
     return call ? JSON.parse(call[1]) : null;
   }
 
   function getCodexWritten(): any {
     const call = (mockedFs.writeFileSync as any).mock.calls.find(
-      (c: any[]) => c[0] === path.join(FAKE_HOME, '.codex', 'hooks.json'),
+      (c: any[]) => c[0] === path.join(FAKE_HOME, ".codex", "hooks.json"),
     );
     return call ? JSON.parse(call[1]) : null;
   }
 
-  describe('Claude Code hooks (~/.claude/settings.json)', () => {
-    it('creates settings.json with SessionStart hook when ~/.claude dir exists but no settings file', () => {
+  describe("Claude Code hooks (~/.claude/settings.json)", () => {
+    it("creates settings.json with SessionStart hook when ~/.claude dir exists but no settings file", () => {
       mockedFs.existsSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.claude')) return true;
+        if (p === path.join(FAKE_HOME, ".claude")) return true;
         return false;
       });
 
@@ -68,42 +68,48 @@ describe('ensureHooks', () => {
       expect(written.hooks.SessionStart.length).toBe(1);
 
       const block = written.hooks.SessionStart[0];
-      expect(block.matcher).toBe('');
+      expect(block.matcher).toBe("");
       expect(block.hooks).toBeInstanceOf(Array);
-      expect(block.hooks[0].type).toBe('command');
+      expect(block.hooks[0].type).toBe("command");
       expect(block.hooks[0].command).toBe(`${FAKE_EXE} --session-start`);
       expect(block.hooks[0].timeout).toBe(10);
     });
 
-    it('adds hook to existing settings.json that has no hooks section', () => {
+    it("adds hook to existing settings.json that has no hooks section", () => {
       mockedFs.existsSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.claude')) return true;
-        if (p === path.join(FAKE_HOME, '.claude', 'settings.json')) return true;
+        if (p === path.join(FAKE_HOME, ".claude")) return true;
+        if (p === path.join(FAKE_HOME, ".claude", "settings.json")) return true;
         return false;
       });
       mockedFs.readFileSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.claude', 'settings.json')) {
+        if (p === path.join(FAKE_HOME, ".claude", "settings.json")) {
           return JSON.stringify({ permissions: {} });
         }
-        throw new Error('ENOENT');
+        throw new Error("ENOENT");
       });
 
       ensureHooks();
 
       const written = getClaudeWritten();
       expect(written.permissions).toEqual({});
-      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(`${FAKE_EXE} --session-start`);
+      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(
+        `${FAKE_EXE} --session-start`,
+      );
     });
 
-    it('updates hook when exe path is stale', () => {
-      const staleExe = '/old/path/gh-axi';
+    it("updates hook when exe path is stale", () => {
+      const staleExe = "/old/path/gh-axi";
       const existingSettings = {
         hooks: {
           SessionStart: [
             {
-              matcher: '',
+              matcher: "",
               hooks: [
-                { type: 'command', command: `${staleExe} --session-start`, timeout: 10 },
+                {
+                  type: "command",
+                  command: `${staleExe} --session-start`,
+                  timeout: 10,
+                },
               ],
             },
           ],
@@ -111,32 +117,40 @@ describe('ensureHooks', () => {
       };
 
       mockedFs.existsSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.claude')) return true;
-        if (p === path.join(FAKE_HOME, '.claude', 'settings.json')) return true;
+        if (p === path.join(FAKE_HOME, ".claude")) return true;
+        if (p === path.join(FAKE_HOME, ".claude", "settings.json")) return true;
         return false;
       });
       mockedFs.readFileSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.claude', 'settings.json')) {
+        if (p === path.join(FAKE_HOME, ".claude", "settings.json")) {
           return JSON.stringify(existingSettings);
         }
-        throw new Error('ENOENT');
+        throw new Error("ENOENT");
       });
 
       ensureHooks();
 
       const written = getClaudeWritten();
-      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(`${FAKE_EXE} --session-start`);
-      expect(written.hooks.SessionStart[0].hooks[0].command).not.toContain(staleExe);
+      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(
+        `${FAKE_EXE} --session-start`,
+      );
+      expect(written.hooks.SessionStart[0].hooks[0].command).not.toContain(
+        staleExe,
+      );
     });
 
-    it('is a no-op when hook already has the correct exe path', () => {
+    it("is a no-op when hook already has the correct exe path", () => {
       const existingSettings = {
         hooks: {
           SessionStart: [
             {
-              matcher: '',
+              matcher: "",
               hooks: [
-                { type: 'command', command: `${FAKE_EXE} --session-start`, timeout: 10 },
+                {
+                  type: "command",
+                  command: `${FAKE_EXE} --session-start`,
+                  timeout: 10,
+                },
               ],
             },
           ],
@@ -144,15 +158,15 @@ describe('ensureHooks', () => {
       };
 
       mockedFs.existsSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.claude')) return true;
-        if (p === path.join(FAKE_HOME, '.claude', 'settings.json')) return true;
+        if (p === path.join(FAKE_HOME, ".claude")) return true;
+        if (p === path.join(FAKE_HOME, ".claude", "settings.json")) return true;
         return false;
       });
       mockedFs.readFileSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.claude', 'settings.json')) {
+        if (p === path.join(FAKE_HOME, ".claude", "settings.json")) {
           return JSON.stringify(existingSettings);
         }
-        throw new Error('ENOENT');
+        throw new Error("ENOENT");
       });
 
       ensureHooks();
@@ -160,7 +174,7 @@ describe('ensureHooks', () => {
       expect(getClaudeWritten()).toBeNull();
     });
 
-    it('skips Claude hooks when ~/.claude directory does not exist', () => {
+    it("skips Claude hooks when ~/.claude directory does not exist", () => {
       mockedFs.existsSync.mockReturnValue(false);
 
       ensureHooks();
@@ -168,74 +182,82 @@ describe('ensureHooks', () => {
       expect(getClaudeWritten()).toBeNull();
     });
 
-    it('preserves other SessionStart matcher blocks when adding gh-axi hook', () => {
+    it("preserves other SessionStart matcher blocks when adding gh-axi hook", () => {
       const existingSettings = {
         hooks: {
           SessionStart: [
             {
-              matcher: '',
-              hooks: [
-                { type: 'command', command: '/some/other/tool' },
-              ],
+              matcher: "",
+              hooks: [{ type: "command", command: "/some/other/tool" }],
             },
           ],
         },
       };
 
       mockedFs.existsSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.claude')) return true;
-        if (p === path.join(FAKE_HOME, '.claude', 'settings.json')) return true;
+        if (p === path.join(FAKE_HOME, ".claude")) return true;
+        if (p === path.join(FAKE_HOME, ".claude", "settings.json")) return true;
         return false;
       });
       mockedFs.readFileSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.claude', 'settings.json')) {
+        if (p === path.join(FAKE_HOME, ".claude", "settings.json")) {
           return JSON.stringify(existingSettings);
         }
-        throw new Error('ENOENT');
+        throw new Error("ENOENT");
       });
 
       ensureHooks();
 
       const written = getClaudeWritten();
       expect(written.hooks.SessionStart.length).toBe(2);
-      expect(written.hooks.SessionStart[0].hooks[0].command).toBe('/some/other/tool');
-      expect(written.hooks.SessionStart[1].hooks[0].command).toBe(`${FAKE_EXE} --session-start`);
+      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(
+        "/some/other/tool",
+      );
+      expect(written.hooks.SessionStart[1].hooks[0].command).toBe(
+        `${FAKE_EXE} --session-start`,
+      );
     });
   });
 
-  describe('Codex hooks (~/.codex/hooks.json)', () => {
-    it('creates hooks.json with hook when ~/.codex dir exists but no hooks file', () => {
+  describe("Codex hooks (~/.codex/hooks.json)", () => {
+    it("creates hooks.json with hook when ~/.codex dir exists but no hooks file", () => {
       mockedFs.existsSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.codex')) return true;
+        if (p === path.join(FAKE_HOME, ".codex")) return true;
         return false;
       });
 
       ensureHooks();
 
       expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
-        path.join(FAKE_HOME, '.codex', 'hooks.json'),
+        path.join(FAKE_HOME, ".codex", "hooks.json"),
         expect.any(String),
-        'utf-8',
+        "utf-8",
       );
 
       const written = getCodexWritten();
       expect(written.hooks.SessionStart).toBeInstanceOf(Array);
       expect(written.hooks.SessionStart.length).toBe(1);
-      expect(written.hooks.SessionStart[0].matcher).toBe('');
+      expect(written.hooks.SessionStart[0].matcher).toBe("");
       expect(written.hooks.SessionStart[0].hooks).toBeInstanceOf(Array);
-      expect(written.hooks.SessionStart[0].hooks[0].type).toBe('command');
-      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(`${FAKE_EXE} --session-start`);
+      expect(written.hooks.SessionStart[0].hooks[0].type).toBe("command");
+      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(
+        `${FAKE_EXE} --session-start`,
+      );
     });
 
-    it('updates hook when exe path is stale in Codex config', () => {
-      const staleExe = '/old/path/gh-axi';
+    it("updates hook when exe path is stale in Codex config", () => {
+      const staleExe = "/old/path/gh-axi";
       const existingHooks = {
         hooks: {
           SessionStart: [
             {
-              matcher: '',
+              matcher: "",
               hooks: [
-                { type: 'command', command: `${staleExe} --session-start`, timeout: 10 },
+                {
+                  type: "command",
+                  command: `${staleExe} --session-start`,
+                  timeout: 10,
+                },
               ],
             },
           ],
@@ -243,32 +265,40 @@ describe('ensureHooks', () => {
       };
 
       mockedFs.existsSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.codex')) return true;
-        if (p === path.join(FAKE_HOME, '.codex', 'hooks.json')) return true;
+        if (p === path.join(FAKE_HOME, ".codex")) return true;
+        if (p === path.join(FAKE_HOME, ".codex", "hooks.json")) return true;
         return false;
       });
       mockedFs.readFileSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.codex', 'hooks.json')) {
+        if (p === path.join(FAKE_HOME, ".codex", "hooks.json")) {
           return JSON.stringify(existingHooks);
         }
-        throw new Error('ENOENT');
+        throw new Error("ENOENT");
       });
 
       ensureHooks();
 
       const written = getCodexWritten();
-      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(`${FAKE_EXE} --session-start`);
-      expect(written.hooks.SessionStart[0].hooks[0].command).not.toContain(staleExe);
+      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(
+        `${FAKE_EXE} --session-start`,
+      );
+      expect(written.hooks.SessionStart[0].hooks[0].command).not.toContain(
+        staleExe,
+      );
     });
 
-    it('is a no-op when Codex hook already has correct exe path', () => {
+    it("is a no-op when Codex hook already has correct exe path", () => {
       const existingHooks = {
         hooks: {
           SessionStart: [
             {
-              matcher: '',
+              matcher: "",
               hooks: [
-                { type: 'command', command: `${FAKE_EXE} --session-start`, timeout: 10 },
+                {
+                  type: "command",
+                  command: `${FAKE_EXE} --session-start`,
+                  timeout: 10,
+                },
               ],
             },
           ],
@@ -276,78 +306,78 @@ describe('ensureHooks', () => {
       };
 
       mockedFs.existsSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.codex')) return true;
-        if (p === path.join(FAKE_HOME, '.codex', 'hooks.json')) return true;
+        if (p === path.join(FAKE_HOME, ".codex")) return true;
+        if (p === path.join(FAKE_HOME, ".codex", "hooks.json")) return true;
         return false;
       });
       mockedFs.readFileSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.codex', 'hooks.json')) {
+        if (p === path.join(FAKE_HOME, ".codex", "hooks.json")) {
           return JSON.stringify(existingHooks);
         }
-        throw new Error('ENOENT');
+        throw new Error("ENOENT");
       });
 
       ensureHooks();
 
       const codexWrites = (mockedFs.writeFileSync as any).mock.calls.filter(
-        (c: any[]) => c[0] === path.join(FAKE_HOME, '.codex', 'hooks.json'),
+        (c: any[]) => c[0] === path.join(FAKE_HOME, ".codex", "hooks.json"),
       );
       expect(codexWrites.length).toBe(0);
     });
 
-    it('preserves other SessionStart matcher blocks when adding gh-axi hook', () => {
+    it("preserves other SessionStart matcher blocks when adding gh-axi hook", () => {
       const existingHooks = {
         hooks: {
           SessionStart: [
             {
-              matcher: '',
-              hooks: [
-                { type: 'command', command: '/some/other/tool' },
-              ],
+              matcher: "",
+              hooks: [{ type: "command", command: "/some/other/tool" }],
             },
           ],
         },
       };
 
       mockedFs.existsSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.codex')) return true;
-        if (p === path.join(FAKE_HOME, '.codex', 'hooks.json')) return true;
+        if (p === path.join(FAKE_HOME, ".codex")) return true;
+        if (p === path.join(FAKE_HOME, ".codex", "hooks.json")) return true;
         return false;
       });
       mockedFs.readFileSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.codex', 'hooks.json')) {
+        if (p === path.join(FAKE_HOME, ".codex", "hooks.json")) {
           return JSON.stringify(existingHooks);
         }
-        throw new Error('ENOENT');
+        throw new Error("ENOENT");
       });
 
       ensureHooks();
 
       const written = getCodexWritten();
       expect(written.hooks.SessionStart.length).toBe(2);
-      expect(written.hooks.SessionStart[0].hooks[0].command).toBe('/some/other/tool');
-      expect(written.hooks.SessionStart[1].hooks[0].command).toBe(`${FAKE_EXE} --session-start`);
+      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(
+        "/some/other/tool",
+      );
+      expect(written.hooks.SessionStart[1].hooks[0].command).toBe(
+        `${FAKE_EXE} --session-start`,
+      );
     });
 
-    it('migrates legacy lowercase session_start entries to SessionStart matcher blocks', () => {
+    it("migrates legacy lowercase session_start entries to SessionStart matcher blocks", () => {
       const existingHooks = {
         hooks: {
-          session_start: [
-            { command: `${FAKE_EXE}` },
-          ],
+          session_start: [{ command: `${FAKE_EXE}` }],
         },
       };
 
       mockedFs.existsSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.codex')) return true;
-        if (p === path.join(FAKE_HOME, '.codex', 'hooks.json')) return true;
+        if (p === path.join(FAKE_HOME, ".codex")) return true;
+        if (p === path.join(FAKE_HOME, ".codex", "hooks.json")) return true;
         return false;
       });
       mockedFs.readFileSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.codex', 'hooks.json')) {
+        if (p === path.join(FAKE_HOME, ".codex", "hooks.json")) {
           return JSON.stringify(existingHooks);
         }
-        throw new Error('ENOENT');
+        throw new Error("ENOENT");
       });
 
       ensureHooks();
@@ -355,33 +385,35 @@ describe('ensureHooks', () => {
       const written = getCodexWritten();
       expect(written.hooks.session_start).toBeUndefined();
       expect(written.hooks.SessionStart).toBeInstanceOf(Array);
-      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(`${FAKE_EXE} --session-start`);
+      expect(written.hooks.SessionStart[0].hooks[0].command).toBe(
+        `${FAKE_EXE} --session-start`,
+      );
     });
 
-    it('skips Codex hooks when ~/.codex directory does not exist', () => {
+    it("skips Codex hooks when ~/.codex directory does not exist", () => {
       mockedFs.existsSync.mockReturnValue(false);
 
       ensureHooks();
 
       const codexWrites = (mockedFs.writeFileSync as any).mock.calls.filter(
-        (c: any[]) => (c[0] as string).includes('.codex'),
+        (c: any[]) => (c[0] as string).includes(".codex"),
       );
       expect(codexWrites.length).toBe(0);
     });
   });
 
-  describe('error handling', () => {
-    it('never throws even when fs operations fail', () => {
+  describe("error handling", () => {
+    it("never throws even when fs operations fail", () => {
       mockedFs.existsSync.mockImplementation(() => {
-        throw new Error('permission denied');
+        throw new Error("permission denied");
       });
 
       expect(() => ensureHooks()).not.toThrow();
     });
 
-    it('logs to stderr when an error occurs', () => {
+    it("logs to stderr when an error occurs", () => {
       mockedFs.existsSync.mockImplementation(() => {
-        throw new Error('permission denied');
+        throw new Error("permission denied");
       });
 
       ensureHooks();
@@ -389,36 +421,36 @@ describe('ensureHooks', () => {
       expect(stderrSpy).toHaveBeenCalled();
     });
 
-    it('handles corrupt JSON in settings file gracefully', () => {
+    it("handles corrupt JSON in settings file gracefully", () => {
       mockedFs.existsSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.claude')) return true;
-        if (p === path.join(FAKE_HOME, '.claude', 'settings.json')) return true;
+        if (p === path.join(FAKE_HOME, ".claude")) return true;
+        if (p === path.join(FAKE_HOME, ".claude", "settings.json")) return true;
         return false;
       });
       mockedFs.readFileSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.claude', 'settings.json')) {
-          return '{ invalid json !!!';
+        if (p === path.join(FAKE_HOME, ".claude", "settings.json")) {
+          return "{ invalid json !!!";
         }
-        throw new Error('ENOENT');
+        throw new Error("ENOENT");
       });
 
       expect(() => ensureHooks()).not.toThrow();
     });
 
-    it('still installs Codex hook when Claude hook fails', () => {
+    it("still installs Codex hook when Claude hook fails", () => {
       let claudeWriteAttempted = false;
       mockedFs.existsSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.claude')) return true;
-        if (p === path.join(FAKE_HOME, '.codex')) return true;
+        if (p === path.join(FAKE_HOME, ".claude")) return true;
+        if (p === path.join(FAKE_HOME, ".codex")) return true;
         return false;
       });
       mockedFs.readFileSync.mockImplementation(() => {
-        throw new Error('ENOENT');
+        throw new Error("ENOENT");
       });
       mockedFs.writeFileSync.mockImplementation((p) => {
-        if ((p as string).includes('.claude')) {
+        if ((p as string).includes(".claude")) {
           claudeWriteAttempted = true;
-          throw new Error('Claude write failed');
+          throw new Error("Claude write failed");
         }
       });
 
@@ -426,25 +458,27 @@ describe('ensureHooks', () => {
 
       expect(claudeWriteAttempted).toBe(true);
       const codexWrites = (mockedFs.writeFileSync as any).mock.calls.filter(
-        (c: any[]) => (c[0] as string).includes('.codex'),
+        (c: any[]) => (c[0] as string).includes(".codex"),
       );
       expect(codexWrites.length).toBe(1);
     });
   });
 
-  describe('executable path resolution', () => {
-    it('uses process.argv[1] as the executable path', () => {
-      process.argv[1] = '/custom/path/to/gh-axi';
+  describe("executable path resolution", () => {
+    it("uses process.argv[1] as the executable path", () => {
+      process.argv[1] = "/custom/path/to/gh-axi";
 
       mockedFs.existsSync.mockImplementation((p) => {
-        if (p === path.join(FAKE_HOME, '.claude')) return true;
+        if (p === path.join(FAKE_HOME, ".claude")) return true;
         return false;
       });
 
       ensureHooks();
 
       const written = getClaudeWritten();
-      expect(written.hooks.SessionStart[0].hooks[0].command).toContain('/custom/path/to/gh-axi');
+      expect(written.hooks.SessionStart[0].hooks[0].command).toContain(
+        "/custom/path/to/gh-axi",
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
This change fixes `gh-axi`'s Codex hook self-installation so it writes the current `SessionStart` matcher-block format with the `--session-start` command, instead of the older lowercase `session_start` array. It also makes the repair path safer by migrating legacy entries and updating existing `gh-axi` hooks without overwriting unrelated hooks, and adds an Airlock workflow to automate critique, testing, documentation, and PR creation on push.

**Risk Assessment:** 🔴 High — A verified functional regression in the hook repair path outweighs the passing tests and makes this unsafe to merge without explicit approval.

## Architecture
```mermaid
flowchart TD
  subgraph hook_flow["Codex Hook Installation"]
    direction TB
    cli_start["gh-axi CLI startup (unchanged)"]
    ensure_hooks["ensureHooks orchestrator (unchanged)"]
    codex_installer["ensureCodexHook matcher-block installer (updated)"]
    codex_config["Codex SessionStart hook config (updated)"]
    legacy_hook["Legacy session_start gh-axi entry (removed)"]
    hook_tests["Codex hook tests (updated)"]

    cli_start -->|"calls on startup"| ensure_hooks
    ensure_hooks -->|"invokes"| codex_installer
    codex_installer -->|"writes and repairs"| codex_config
    legacy_hook -->|"migrated into"| codex_config
    hook_tests -->|"verifies behavior"| codex_installer
  end

  subgraph pipeline_flow["Airlock Automation"]
    direction TB
    workflow["Airlock main workflow (added)"]
    gate_jobs["Critique, test, and gate jobs (added)"]
    publish_jobs["Describe, document, and deploy jobs (added)"]

    workflow -->|"defines"| gate_jobs
    gate_jobs -->|"unblocks"| publish_jobs
  end

  workflow -->|"runs validation around"| hook_tests
```

## Key changes made
- `src/hooks.ts` updates `ensureCodexHook()` to write Codex hooks as `hooks.SessionStart[].hooks[]` entries with `type: "command"`, `matcher: ""`, `timeout: 10`, and the full `<exe> --session-start` command.
- `src/hooks.ts` migrates legacy lowercase `session_start` entries, treats `""`, `"*"`, and missing matchers as match-all, and updates nested `gh-axi` hooks in place so unrelated hooks in the same matcher block are preserved.
- `test/hooks.test.ts` rewrites Codex expectations for the new schema and adds coverage for stale-path repair, no-op installs, legacy migration, and preserving unrelated matcher blocks.
- `.airlock/workflows/main.yml` adds a default Airlock pipeline for rebase, critique, test, review gate, describe, document, lint, push, and PR creation.

## How was this tested
- `npm test -- test/hooks.test.ts`
- `npm test`
- `.airlock/lint.sh`
