### PR TITLE
fix: normalize generic not-found errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - **session:** remove the dedicated `--session-start` mode and have installed
   hooks invoke `gh-axi` directly; legacy `--session-start` invocations now act
   as a no-op for backward compatibility
+- **errors:** classify mixed-case generic `not found` gh errors as `NOT_FOUND`
+  instead of falling back to `UNKNOWN`
 
 ## [0.1.7](https://github.com/kunchenguid/gh-axi/compare/gh-axi-v0.1.6...gh-axi-v0.1.7) (2026-04-01)
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -83,6 +83,10 @@ const patterns: ErrorPattern[] = [
   },
 ];
 
+function firstErrorLine(stderr: string): string {
+  return stderr.trim().split('\n')[0] ?? '';
+}
+
 export function mapGhError(stderr: string, exitCode: number): AxiError {
   for (const { pattern, code, message, suggestions } of patterns) {
     const match = stderr.match(pattern);
@@ -92,11 +96,11 @@ export function mapGhError(stderr: string, exitCode: number): AxiError {
   }
 
   // Generic not-found for any 404-like message
-  if (stderr.includes('not found') || stderr.includes('Not Found')) {
-    return new AxiError(stderr.trim().split('\n')[0], 'NOT_FOUND');
+  if (/not found/i.test(stderr)) {
+    return new AxiError(firstErrorLine(stderr), 'NOT_FOUND');
   }
 
-  return new AxiError(stderr.trim().split('\n')[0] || `gh exited with code ${exitCode}`, 'UNKNOWN');
+  return new AxiError(firstErrorLine(stderr) || `gh exited with code ${exitCode}`, 'UNKNOWN');
 }
 
 /** Map an error to the appropriate process exit code: 2 for usage errors, 1 for everything else. */

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,11 +1,11 @@
 export type ErrorCode =
-  | 'REPO_NOT_FOUND'
-  | 'NOT_FOUND'
-  | 'AUTH_REQUIRED'
-  | 'FORBIDDEN'
-  | 'VALIDATION_ERROR'
-  | 'GH_NOT_INSTALLED'
-  | 'UNKNOWN';
+  | "REPO_NOT_FOUND"
+  | "NOT_FOUND"
+  | "AUTH_REQUIRED"
+  | "FORBIDDEN"
+  | "VALIDATION_ERROR"
+  | "GH_NOT_INSTALLED"
+  | "UNKNOWN";
 
 export class AxiError extends Error {
   constructor(
@@ -14,7 +14,7 @@ export class AxiError extends Error {
     public readonly suggestions: string[] = [],
   ) {
     super(message);
-    this.name = 'AxiError';
+    this.name = "AxiError";
   }
 }
 
@@ -28,84 +28,93 @@ interface ErrorPattern {
 const patterns: ErrorPattern[] = [
   {
     pattern: /Could not resolve to a Repository with the name '([^']+)'/,
-    code: 'REPO_NOT_FOUND',
+    code: "REPO_NOT_FOUND",
     message: (m) => `Repository "${m[1]}" not found`,
-    suggestions: () => ['Run `gh-axi repo list` to see your repositories'],
+    suggestions: () => ["Run `gh-axi repo list` to see your repositories"],
   },
   {
     pattern: /Could not resolve to an? .+? with the number of (\d+)/,
-    code: 'NOT_FOUND',
+    code: "NOT_FOUND",
     message: (m) => `Item #${m[1]} does not exist in this repository`,
     suggestions: () => [],
   },
   {
     pattern: /issue (\d+) not found/i,
-    code: 'NOT_FOUND',
+    code: "NOT_FOUND",
     message: (m) => `Issue #${m[1]} does not exist`,
     suggestions: () => [],
   },
   {
     pattern: /pull request (\d+) not found/i,
-    code: 'NOT_FOUND',
+    code: "NOT_FOUND",
     message: (m) => `Pull request #${m[1]} does not exist`,
     suggestions: () => [],
   },
   {
     pattern: /release with tag "([^"]+)" not found/i,
-    code: 'NOT_FOUND',
+    code: "NOT_FOUND",
     message: (m) => `Release "${m[1]}" not found`,
-    suggestions: () => [`Run \`gh-axi release list\` to see available releases`],
+    suggestions: () => [
+      `Run \`gh-axi release list\` to see available releases`,
+    ],
   },
   {
     pattern: /run (\d+) not found/i,
-    code: 'NOT_FOUND',
+    code: "NOT_FOUND",
     message: (m) => `Run ${m[1]} not found`,
     suggestions: () => [`Run \`gh-axi run list\` to see recent runs`],
   },
   {
     pattern: /gh auth login/,
-    code: 'AUTH_REQUIRED',
-    message: () => 'GitHub auth required — run `gh auth login` first',
+    code: "AUTH_REQUIRED",
+    message: () => "GitHub auth required — run `gh auth login` first",
   },
   {
     pattern: /HTTP 403/,
-    code: 'FORBIDDEN',
-    message: () => 'Insufficient permissions for this action',
+    code: "FORBIDDEN",
+    message: () => "Insufficient permissions for this action",
   },
   {
     pattern: /HTTP 422/,
-    code: 'VALIDATION_ERROR',
+    code: "VALIDATION_ERROR",
     message: (_m, stderr) => {
       // Try to extract a meaningful message from the 422 body
       const msgMatch = stderr.match(/"message"\s*:\s*"([^"]+)"/);
-      return msgMatch ? msgMatch[1] : 'Validation error';
+      return msgMatch ? msgMatch[1] : "Validation error";
     },
   },
 ];
 
 function firstErrorLine(stderr: string): string {
-  return stderr.trim().split('\n')[0] ?? '';
+  return stderr.trim().split("\n")[0] ?? "";
 }
 
 export function mapGhError(stderr: string, exitCode: number): AxiError {
   for (const { pattern, code, message, suggestions } of patterns) {
     const match = stderr.match(pattern);
     if (match) {
-      return new AxiError(message(match, stderr), code, suggestions?.(match) ?? []);
+      return new AxiError(
+        message(match, stderr),
+        code,
+        suggestions?.(match) ?? [],
+      );
     }
   }
 
   // Generic not-found for any 404-like message
   if (/not found/i.test(stderr)) {
-    return new AxiError(firstErrorLine(stderr), 'NOT_FOUND');
+    return new AxiError(firstErrorLine(stderr), "NOT_FOUND");
   }
 
-  return new AxiError(firstErrorLine(stderr) || `gh exited with code ${exitCode}`, 'UNKNOWN');
+  return new AxiError(
+    firstErrorLine(stderr) || `gh exited with code ${exitCode}`,
+    "UNKNOWN",
+  );
 }
 
 /** Map an error to the appropriate process exit code: 2 for usage errors, 1 for everything else. */
 export function exitCodeForError(err: unknown): number {
-  if (err instanceof AxiError && err.code === 'VALIDATION_ERROR') {
+  if (err instanceof AxiError && err.code === "VALIDATION_ERROR") {
     return 2;
   }
   return 1;
@@ -113,7 +122,7 @@ export function exitCodeForError(err: unknown): number {
 
 export function ghNotInstalledError(): AxiError {
   return new AxiError(
-    'gh CLI is not installed — see https://cli.github.com',
-    'GH_NOT_INSTALLED',
+    "gh CLI is not installed — see https://cli.github.com",
+    "GH_NOT_INSTALLED",
   );
 }

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,170 +1,181 @@
-import { describe, it, expect } from 'vitest';
-import { AxiError, mapGhError, ghNotInstalledError, exitCodeForError } from '../src/errors.js';
+import { describe, it, expect } from "vitest";
+import {
+  AxiError,
+  mapGhError,
+  ghNotInstalledError,
+  exitCodeForError,
+} from "../src/errors.js";
 
-describe('AxiError', () => {
-  it('has correct code and message', () => {
-    const err = new AxiError('not found', 'NOT_FOUND');
-    expect(err.message).toBe('not found');
-    expect(err.code).toBe('NOT_FOUND');
-    expect(err.name).toBe('AxiError');
+describe("AxiError", () => {
+  it("has correct code and message", () => {
+    const err = new AxiError("not found", "NOT_FOUND");
+    expect(err.message).toBe("not found");
+    expect(err.code).toBe("NOT_FOUND");
+    expect(err.name).toBe("AxiError");
     expect(err).toBeInstanceOf(Error);
   });
 
-  it('has default empty suggestions', () => {
-    const err = new AxiError('msg', 'UNKNOWN');
+  it("has default empty suggestions", () => {
+    const err = new AxiError("msg", "UNKNOWN");
     expect(err.suggestions).toEqual([]);
   });
 
-  it('stores custom suggestions', () => {
-    const err = new AxiError('msg', 'NOT_FOUND', ['Try this', 'Try that']);
-    expect(err.suggestions).toEqual(['Try this', 'Try that']);
+  it("stores custom suggestions", () => {
+    const err = new AxiError("msg", "NOT_FOUND", ["Try this", "Try that"]);
+    expect(err.suggestions).toEqual(["Try this", "Try that"]);
   });
 });
 
-describe('mapGhError', () => {
-  it('matches repo not found pattern', () => {
-    const err = mapGhError("Could not resolve to a Repository with the name 'cli/cli'", 1);
-    expect(err.code).toBe('REPO_NOT_FOUND');
-    expect(err.message).toContain('cli/cli');
+describe("mapGhError", () => {
+  it("matches repo not found pattern", () => {
+    const err = mapGhError(
+      "Could not resolve to a Repository with the name 'cli/cli'",
+      1,
+    );
+    expect(err.code).toBe("REPO_NOT_FOUND");
+    expect(err.message).toContain("cli/cli");
     expect(err.suggestions.length).toBeGreaterThan(0);
   });
 
-  it('matches issue not found pattern (GraphQL)', () => {
-    const err = mapGhError('Could not resolve to an Issue with the number of 999', 1);
-    expect(err.code).toBe('NOT_FOUND');
-    expect(err.message).toContain('999');
+  it("matches issue not found pattern (GraphQL)", () => {
+    const err = mapGhError(
+      "Could not resolve to an Issue with the number of 999",
+      1,
+    );
+    expect(err.code).toBe("NOT_FOUND");
+    expect(err.message).toContain("999");
   });
 
-  it('matches issue not found pattern (REST)', () => {
-    const err = mapGhError('issue 42 not found', 1);
-    expect(err.code).toBe('NOT_FOUND');
-    expect(err.message).toContain('42');
+  it("matches issue not found pattern (REST)", () => {
+    const err = mapGhError("issue 42 not found", 1);
+    expect(err.code).toBe("NOT_FOUND");
+    expect(err.message).toContain("42");
   });
 
-  it('matches pull request not found pattern', () => {
-    const err = mapGhError('pull request 10 not found', 1);
-    expect(err.code).toBe('NOT_FOUND');
-    expect(err.message).toContain('10');
+  it("matches pull request not found pattern", () => {
+    const err = mapGhError("pull request 10 not found", 1);
+    expect(err.code).toBe("NOT_FOUND");
+    expect(err.message).toContain("10");
   });
 
-  it('matches release not found pattern', () => {
+  it("matches release not found pattern", () => {
     const err = mapGhError('release with tag "v1.0" not found', 1);
-    expect(err.code).toBe('NOT_FOUND');
-    expect(err.message).toContain('v1.0');
-    expect(err.suggestions.some((s) => s.includes('release list'))).toBe(true);
+    expect(err.code).toBe("NOT_FOUND");
+    expect(err.message).toContain("v1.0");
+    expect(err.suggestions.some((s) => s.includes("release list"))).toBe(true);
   });
 
-  it('matches run not found pattern', () => {
-    const err = mapGhError('run 12345 not found', 1);
-    expect(err.code).toBe('NOT_FOUND');
-    expect(err.message).toContain('12345');
-    expect(err.suggestions.some((s) => s.includes('run list'))).toBe(true);
+  it("matches run not found pattern", () => {
+    const err = mapGhError("run 12345 not found", 1);
+    expect(err.code).toBe("NOT_FOUND");
+    expect(err.message).toContain("12345");
+    expect(err.suggestions.some((s) => s.includes("run list"))).toBe(true);
   });
 
-  it('matches auth required pattern', () => {
-    const err = mapGhError('To get started, please run: gh auth login', 1);
-    expect(err.code).toBe('AUTH_REQUIRED');
+  it("matches auth required pattern", () => {
+    const err = mapGhError("To get started, please run: gh auth login", 1);
+    expect(err.code).toBe("AUTH_REQUIRED");
   });
 
-  it('matches forbidden pattern', () => {
-    const err = mapGhError('HTTP 403: Forbidden', 1);
-    expect(err.code).toBe('FORBIDDEN');
+  it("matches forbidden pattern", () => {
+    const err = mapGhError("HTTP 403: Forbidden", 1);
+    expect(err.code).toBe("FORBIDDEN");
   });
 
-  it('matches validation error pattern with message extraction', () => {
+  it("matches validation error pattern with message extraction", () => {
     const stderr = 'HTTP 422: {"message": "Validation Failed", "errors": []}';
     const err = mapGhError(stderr, 1);
-    expect(err.code).toBe('VALIDATION_ERROR');
-    expect(err.message).toBe('Validation Failed');
+    expect(err.code).toBe("VALIDATION_ERROR");
+    expect(err.message).toBe("Validation Failed");
   });
 
-  it('matches validation error pattern without extractable message', () => {
-    const err = mapGhError('HTTP 422', 1);
-    expect(err.code).toBe('VALIDATION_ERROR');
-    expect(err.message).toBe('Validation error');
+  it("matches validation error pattern without extractable message", () => {
+    const err = mapGhError("HTTP 422", 1);
+    expect(err.code).toBe("VALIDATION_ERROR");
+    expect(err.message).toBe("Validation error");
   });
 
-  it('returns NOT_FOUND for generic not found messages', () => {
-    const err = mapGhError('something not found', 1);
-    expect(err.code).toBe('NOT_FOUND');
+  it("returns NOT_FOUND for generic not found messages", () => {
+    const err = mapGhError("something not found", 1);
+    expect(err.code).toBe("NOT_FOUND");
   });
 
   it('returns NOT_FOUND for "Not Found" (capitalized)', () => {
-    const err = mapGhError('Not Found', 1);
-    expect(err.code).toBe('NOT_FOUND');
+    const err = mapGhError("Not Found", 1);
+    expect(err.code).toBe("NOT_FOUND");
   });
 
-  it('returns NOT_FOUND for mixed-case not found messages', () => {
-    const err = mapGhError('resource NOT found', 1);
-    expect(err.code).toBe('NOT_FOUND');
+  it("returns NOT_FOUND for mixed-case not found messages", () => {
+    const err = mapGhError("resource NOT found", 1);
+    expect(err.code).toBe("NOT_FOUND");
   });
 
-  it('returns UNKNOWN for unrecognized errors', () => {
-    const err = mapGhError('some random error', 1);
-    expect(err.code).toBe('UNKNOWN');
-    expect(err.message).toBe('some random error');
+  it("returns UNKNOWN for unrecognized errors", () => {
+    const err = mapGhError("some random error", 1);
+    expect(err.code).toBe("UNKNOWN");
+    expect(err.message).toBe("some random error");
   });
 
-  it('returns UNKNOWN with exit code message for empty stderr', () => {
-    const err = mapGhError('', 2);
-    expect(err.code).toBe('UNKNOWN');
-    expect(err.message).toContain('exited with code 2');
+  it("returns UNKNOWN with exit code message for empty stderr", () => {
+    const err = mapGhError("", 2);
+    expect(err.code).toBe("UNKNOWN");
+    expect(err.message).toContain("exited with code 2");
   });
 
-  it('uses first line of multi-line stderr for UNKNOWN errors', () => {
-    const err = mapGhError('first line\nsecond line\nthird line', 1);
-    expect(err.code).toBe('UNKNOWN');
-    expect(err.message).toBe('first line');
+  it("uses first line of multi-line stderr for UNKNOWN errors", () => {
+    const err = mapGhError("first line\nsecond line\nthird line", 1);
+    expect(err.code).toBe("UNKNOWN");
+    expect(err.message).toBe("first line");
   });
 });
 
-describe('ghNotInstalledError', () => {
-  it('returns AxiError with GH_NOT_INSTALLED code', () => {
+describe("ghNotInstalledError", () => {
+  it("returns AxiError with GH_NOT_INSTALLED code", () => {
     const err = ghNotInstalledError();
     expect(err).toBeInstanceOf(AxiError);
-    expect(err.code).toBe('GH_NOT_INSTALLED');
-    expect(err.message).toContain('gh CLI');
+    expect(err.code).toBe("GH_NOT_INSTALLED");
+    expect(err.message).toContain("gh CLI");
   });
 });
 
-describe('exitCodeForError', () => {
-  it('returns 2 for VALIDATION_ERROR', () => {
-    const err = new AxiError('missing flag', 'VALIDATION_ERROR');
+describe("exitCodeForError", () => {
+  it("returns 2 for VALIDATION_ERROR", () => {
+    const err = new AxiError("missing flag", "VALIDATION_ERROR");
     expect(exitCodeForError(err)).toBe(2);
   });
 
-  it('returns 1 for NOT_FOUND', () => {
-    const err = new AxiError('not found', 'NOT_FOUND');
+  it("returns 1 for NOT_FOUND", () => {
+    const err = new AxiError("not found", "NOT_FOUND");
     expect(exitCodeForError(err)).toBe(1);
   });
 
-  it('returns 1 for REPO_NOT_FOUND', () => {
-    const err = new AxiError('repo not found', 'REPO_NOT_FOUND');
+  it("returns 1 for REPO_NOT_FOUND", () => {
+    const err = new AxiError("repo not found", "REPO_NOT_FOUND");
     expect(exitCodeForError(err)).toBe(1);
   });
 
-  it('returns 1 for AUTH_REQUIRED', () => {
-    const err = new AxiError('auth required', 'AUTH_REQUIRED');
+  it("returns 1 for AUTH_REQUIRED", () => {
+    const err = new AxiError("auth required", "AUTH_REQUIRED");
     expect(exitCodeForError(err)).toBe(1);
   });
 
-  it('returns 1 for FORBIDDEN', () => {
-    const err = new AxiError('forbidden', 'FORBIDDEN');
+  it("returns 1 for FORBIDDEN", () => {
+    const err = new AxiError("forbidden", "FORBIDDEN");
     expect(exitCodeForError(err)).toBe(1);
   });
 
-  it('returns 1 for GH_NOT_INSTALLED', () => {
-    const err = new AxiError('gh missing', 'GH_NOT_INSTALLED');
+  it("returns 1 for GH_NOT_INSTALLED", () => {
+    const err = new AxiError("gh missing", "GH_NOT_INSTALLED");
     expect(exitCodeForError(err)).toBe(1);
   });
 
-  it('returns 1 for UNKNOWN', () => {
-    const err = new AxiError('unknown', 'UNKNOWN');
+  it("returns 1 for UNKNOWN", () => {
+    const err = new AxiError("unknown", "UNKNOWN");
     expect(exitCodeForError(err)).toBe(1);
   });
 
-  it('returns 1 for non-AxiError', () => {
-    const err = new Error('generic error');
+  it("returns 1 for non-AxiError", () => {
+    const err = new Error("generic error");
     expect(exitCodeForError(err)).toBe(1);
   });
 });

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -94,6 +94,11 @@ describe('mapGhError', () => {
     expect(err.code).toBe('NOT_FOUND');
   });
 
+  it('returns NOT_FOUND for mixed-case not found messages', () => {
+    const err = mapGhError('resource NOT found', 1);
+    expect(err.code).toBe('NOT_FOUND');
+  });
+
   it('returns UNKNOWN for unrecognized errors', () => {
     const err = mapGhError('some random error', 1);
     expect(err.code).toBe('UNKNOWN');


### PR DESCRIPTION
## Summary
This change tightens the generic GitHub CLI error fallback so mixed-case `not found` messages consistently map to `NOT_FOUND`, and it reuses a single helper for extracting the leading fallback error line.

**Risk Assessment:** 🟢 Low — Low-risk, well-bounded error-mapping tweak with passing targeted/full tests and no review findings.

## Architecture
```mermaid
flowchart TD
  subgraph runtime_flow["Runtime Error Mapping"]
    direction TB
    gh_stderr["gh stderr output (unchanged)"]
    map_error["mapGhError fallback logic (updated)"]
    first_line["firstErrorLine helper (added)"]
    axi_error["AxiError result (unchanged)"]

    gh_stderr -->|"provides stderr text"| map_error
    first_line -->|"extracts leading message line"| map_error
    map_error -->|"returns NOT_FOUND or UNKNOWN"| axi_error
  end

  subgraph test_flow["Regression Coverage"]
    direction TB
    errors_test["errors.test mixed-case case (updated)"]
  end

  errors_test -->|"verifies mixed-case not found mapping"| map_error
```

## Key changes made
- Added `firstErrorLine()` so fallback error messages trim stderr consistently and keep only the first line.
- Replaced the previous case-sensitive generic `not found` checks with a single case-insensitive `/not found/i` match.
- Extended the error tests to cover mixed-case `not found` output and preserve the fallback behavior.

## How was this tested
- `npm test -- --run test/errors.test.ts`
- `npm test`
- `.airlock/lint.sh` after installing local dev dependencies

All reported checks passed.