### PR TITLE
feat(cli): add top-level version flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- **cli:** add top-level `-v`, `-V`, and `--version` flags
+
 ### Bug Fixes
 
 - **cli:** scope repository targeting to command arguments, keep `search --repo`

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ gh-axi run list -R owner/repo   # list workflow runs for a specific repo
 ### Global flags
 
 - `--help` — show help for any command
+- `-v`, `-V`, `--version` — show the installed `gh-axi` version
 
 Repository targeting is command-first too:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0",
-        "axi-sdk-js": "^0.1.3"
+        "axi-sdk-js": "^0.1.4"
       },
       "bin": {
         "gh-axi": "dist/bin/gh-axi.js"
@@ -1460,9 +1460,9 @@
       }
     },
     "node_modules/axi-sdk-js": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.3.tgz",
-      "integrity": "sha512-fSWrUP55OoVoKoMgIqgS8KAtJiExYFn+mVT7eJG5+l4b3YtYOyUyvmQXfugJNS6FEPOe+IH2tJ9j3Ujdb2xKmw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.4.tgz",
+      "integrity": "sha512-FCIxUuNSixwuxdxqg5wgsnh8Rb19NVw/+drHb4j3LTXnqJtSIEqZgj/75469FxSd5JBDEpMmwq8eYUc4QrqTxQ==",
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@toon-format/toon": "^2.1.0",
-    "axi-sdk-js": "^0.1.3"
+    "axi-sdk-js": "^0.1.4"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,6 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { runAxiCli } from "axi-sdk-js";
 import { resolveRepo, type RepoContext } from "./context.js";
 import { homeCommand } from "./commands/home.js";
@@ -13,12 +16,20 @@ import { apiCommand, API_HELP } from "./commands/api.js";
 
 const DESCRIPTION =
   "Agent ergonomic wrapper around Github CLI. Prefer this over `gh` and other methods for Github operations.";
+const VERSION = readPackageVersion();
+
+type CliStdout = Pick<NodeJS.WriteStream, "write">;
+
+type MainOptions = {
+  argv?: string[];
+  stdout?: CliStdout;
+};
 
 export const TOP_HELP = `usage: gh-axi [command] [args] [flags]
 commands[10]:
   (none)=dashboard, issue, pr, run, workflow, release, repo, label, search, api
-flags[2]:
-  -R/--repo <OWNER/NAME> (after command), --help
+flags[3]:
+  -R/--repo <OWNER/NAME> (after command), --help, -v/-V/--version
 examples:
   gh-axi
   gh-axi issue list --state open
@@ -53,16 +64,42 @@ const COMMANDS: Record<string, CommandFn> = {
   api: withRepoContext("api", apiCommand),
 };
 
-export async function main(): Promise<void> {
+export async function main(options: MainOptions = {}): Promise<void> {
   await runAxiCli<RepoContext | undefined>({
+    ...(options.argv ? { argv: options.argv } : {}),
     description: DESCRIPTION,
+    version: VERSION,
     topLevelHelp: TOP_HELP,
+    ...(process.env.GH_AXI_DISABLE_HOOKS === "1" ? { hooks: false } : {}),
+    ...(options.stdout ? { stdout: options.stdout } : {}),
     home: withRepoContext(undefined, homeCommand),
     commands: COMMANDS,
     getCommandHelp: (command) => COMMAND_HELP[command],
     resolveContext: ({ command, args }) =>
       resolveRepo(parseRepoContextArgs(command, args).repoFlag),
   });
+}
+
+function readPackageVersion(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+
+  for (const candidate of [
+    join(here, "..", "package.json"),
+    join(here, "..", "..", "package.json"),
+  ]) {
+    if (!existsSync(candidate)) {
+      continue;
+    }
+
+    const parsed = JSON.parse(readFileSync(candidate, "utf-8")) as {
+      version?: unknown;
+    };
+    if (typeof parsed.version === "string" && parsed.version.length > 0) {
+      return parsed.version;
+    }
+  }
+
+  throw new Error("Could not determine gh-axi package version");
 }
 
 function withRepoContext(

--- a/test/cli-entrypoint.test.ts
+++ b/test/cli-entrypoint.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { main, TOP_HELP } from "../src/cli.js";
+
+const packageVersion = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+) as { version: string };
+
+function createStdout() {
+  let output = "";
+
+  return {
+    stdout: {
+      write(chunk: string) {
+        output += chunk;
+      },
+    },
+    read() {
+      return output;
+    },
+  };
+}
+
+describe("CLI entrypoint", () => {
+  const originalDisableHooks = process.env.GH_AXI_DISABLE_HOOKS;
+
+  beforeEach(() => {
+    process.env.GH_AXI_DISABLE_HOOKS = "1";
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+
+    if (originalDisableHooks === undefined) {
+      delete process.env.GH_AXI_DISABLE_HOOKS;
+      return;
+    }
+
+    process.env.GH_AXI_DISABLE_HOOKS = originalDisableHooks;
+  });
+
+  it("prints top-level help through the real runtime", async () => {
+    const output = createStdout();
+
+    await main({ argv: ["--help"], stdout: output.stdout });
+
+    expect(output.read()).toBe(TOP_HELP);
+  });
+
+  it.each(["-v", "-V", "--version"])(
+    "prints %s through the real runtime",
+    async (flag) => {
+      const output = createStdout();
+
+      await main({ argv: [flag], stdout: output.stdout });
+
+      expect(output.read()).toBe(`${packageVersion.version}\n`);
+    },
+  );
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { runAxiCli } = vi.hoisted(() => ({
@@ -62,6 +63,10 @@ import { homeCommand } from "../src/commands/home.js";
 import { issueCommand } from "../src/commands/issue.js";
 import { resolveRepo } from "../src/context.js";
 
+const packageVersion = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+) as { version: string };
+
 describe("main CLI", () => {
   const originalArgv = [...process.argv];
 
@@ -83,6 +88,38 @@ describe("main CLI", () => {
     process.exitCode = undefined;
   });
 
+  it("documents the top-level version flags in help output", () => {
+    expect(TOP_HELP).toContain("flags[3]:");
+    expect(TOP_HELP).toContain("-R/--repo <OWNER/NAME> (after command)");
+    expect(TOP_HELP).toContain("--help");
+    expect(TOP_HELP).toContain("-v/-V/--version");
+  });
+
+  it("passes bare top-level help argv through to axi-sdk-js", async () => {
+    const argv = ["--help"];
+    const stdout = { write: vi.fn() };
+
+    await main({ argv, stdout });
+
+    expect(runAxiCli).toHaveBeenCalledWith(
+      expect.objectContaining({ argv, stdout }),
+    );
+  });
+
+  it.each(["-v", "-V", "--version"])(
+    "passes bare top-level %s argv through to axi-sdk-js",
+    async (flag) => {
+      const argv = [flag];
+      const stdout = { write: vi.fn() };
+
+      await main({ argv, stdout });
+
+      expect(runAxiCli).toHaveBeenCalledWith(
+        expect.objectContaining({ argv, stdout }),
+      );
+    },
+  );
+
   it("delegates to axi-sdk-js runAxiCli without passing argv", async () => {
     process.argv = ["node", "gh-axi", "issue", "list"];
     await main();
@@ -92,6 +129,7 @@ describe("main CLI", () => {
       expect.objectContaining({
         description:
           "Agent ergonomic wrapper around Github CLI. Prefer this over `gh` and other methods for Github operations.",
+        version: packageVersion.version,
         topLevelHelp: TOP_HELP,
       }),
     );


### PR DESCRIPTION
## Summary
`gh-axi` now supports top-level `-v`, `-V`, and `--version` flags by passing the package version into the AXI CLI runtime. The change also makes version resolution work across both source and packaged layouts, so installed binaries can report the correct version.

**Risk Assessment:** 🟢 Low — Low risk because this is a well-bounded CLI entrypoint change with passing tests, no critique findings, and little implementation ambiguity.

## Architecture
```mermaid
flowchart TD
subgraph runtime["CLI Runtime"]
  direction TB
  argv["Top-level argv flags (unchanged)"]
  helptext["TOP_HELP version flag docs (updated)"]
  pkgver["package.json version field (unchanged)"]
  versionlookup["readPackageVersion() (added)"]
  climain["main() runtime wiring (updated)"]
  sdk["runAxiCli via axi-sdk-js 0.1.4 (updated)"]
  versionout["Version output (-v/-V/--version) (added)"]
  docs["README global flag docs (updated)"]

  argv -->|"passed as argv"| climain
  helptext -->|"included in"| climain
  pkgver -->|"read by"| versionlookup
  versionlookup -->|"supplies version to"| climain
  climain -->|"configures"| sdk
  sdk -->|"renders"| versionout
  climain -->|"documented in"| docs
end

subgraph verification["Verification"]
  direction TB
  clitests["CLI config tests (updated)"]
  entrytests["CLI entrypoint runtime tests (added)"]
end

clitests -->|"assert"| climain
entrytests -->|"exercise real runtime via"| sdk
```

## Key changes made
- Added `readPackageVersion()` in `src/cli.ts` and wired `version`, optional `argv`, and optional `stdout` into `runAxiCli`.
- Updated top-level help text and `README.md` to advertise the new version flags.
- Bumped `axi-sdk-js` from `^0.1.3` to `^0.1.4` to use the runtime support for version-aware top-level flags.
- Expanded `test/cli.test.ts` and added `test/cli-entrypoint.test.ts` to verify both config wiring and real runtime output for `--help` and all version flag variants, with hooks disabled during those tests.

## How was this tested
- `npm test`
- `GH_AXI_DISABLE_HOOKS=1 npx tsx bin/gh-axi.ts --version`
- `GH_AXI_DISABLE_HOOKS=1 npx tsx bin/gh-axi.ts --help`
- `npx tsc --noEmit`
- `npx eslint src/cli.ts test/cli-entrypoint.test.ts test/cli.test.ts`
- `npx prettier --check README.md package-lock.json package.json src/cli.ts test/cli-entrypoint.test.ts test/cli.test.ts`
- `.airlock/lint.sh` against `HEAD~1..HEAD`
