### PR TITLE
fix(run): harden job-level run view behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - **cli:** scope repository targeting to command arguments, keep `search --repo`
   working, and rename issue transfer destination flag to `--to-repo`
+- **run:** allow `run view --job <job-id>` without a run id, include job steps in
+  job view output, and support job-scoped `--log` and `--log-failed`
 - **session:** remove the dedicated `--session-start` mode and have installed
   hooks invoke `gh-axi` directly; legacy `--session-start` invocations now act
   as a no-op for backward compatibility
@@ -18,31 +20,27 @@
 
 ## [0.1.11](https://github.com/kunchenguid/gh-axi/compare/gh-axi-v0.1.10...gh-axi-v0.1.11) (2026-04-09)
 
-
 ### Features
 
-* **pr:** add --full flag to diff and improve truncation ([677da2b](https://github.com/kunchenguid/gh-axi/commit/677da2b984ed51dde4cd1493357774c9a59f0768))
+- **pr:** add --full flag to diff and improve truncation ([677da2b](https://github.com/kunchenguid/gh-axi/commit/677da2b984ed51dde4cd1493357774c9a59f0768))
 
 ## [0.1.10](https://github.com/kunchenguid/gh-axi/compare/gh-axi-v0.1.9...gh-axi-v0.1.10) (2026-04-03)
 
-
 ### Features
 
-* **cli:** add top-level version flags ([#11](https://github.com/kunchenguid/gh-axi/issues/11)) ([a572f3d](https://github.com/kunchenguid/gh-axi/commit/a572f3df0c6c9bc54214983b0459379d5618a6a6))
+- **cli:** add top-level version flags ([#11](https://github.com/kunchenguid/gh-axi/issues/11)) ([a572f3d](https://github.com/kunchenguid/gh-axi/commit/a572f3df0c6c9bc54214983b0459379d5618a6a6))
 
 ## [0.1.9](https://github.com/kunchenguid/gh-axi/compare/gh-axi-v0.1.8...gh-axi-v0.1.9) (2026-04-02)
 
-
 ### Bug Fixes
 
-* migrate gh-axi to axi-sdk-js ([#9](https://github.com/kunchenguid/gh-axi/issues/9)) ([137a759](https://github.com/kunchenguid/gh-axi/commit/137a759ba288ce7ac887c35a1710d90d307ea75e))
+- migrate gh-axi to axi-sdk-js ([#9](https://github.com/kunchenguid/gh-axi/issues/9)) ([137a759](https://github.com/kunchenguid/gh-axi/commit/137a759ba288ce7ac887c35a1710d90d307ea75e))
 
 ## [0.1.8](https://github.com/kunchenguid/gh-axi/compare/gh-axi-v0.1.7...gh-axi-v0.1.8) (2026-04-01)
 
-
 ### Bug Fixes
 
-* normalize generic not-found errors ([#7](https://github.com/kunchenguid/gh-axi/issues/7)) ([e9336b9](https://github.com/kunchenguid/gh-axi/commit/e9336b9318c81e034adf354686e88becb77c0e1c))
+- normalize generic not-found errors ([#7](https://github.com/kunchenguid/gh-axi/issues/7)) ([e9336b9](https://github.com/kunchenguid/gh-axi/commit/e9336b9318c81e034adf354686e88becb77c0e1c))
 
 ## [0.1.7](https://github.com/kunchenguid/gh-axi/compare/gh-axi-v0.1.6...gh-axi-v0.1.7) (2026-04-01)
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ hooks. Those hooks invoke `gh-axi` directly from the packaged production build.
 ## Usage
 
 ```bash
-gh-axi                          # dashboard — live state, no args needed
+gh-axi                          # dashboard - live state, no args needed
 gh-axi issue list               # list issues in current repo
 gh-axi pr view 42               # view pull request #42
 gh-axi run list -R owner/repo   # list workflow runs for a specific repo
+gh-axi run view 123456 --job 789012       # inspect a single job within a run
+gh-axi run view --job 789012 --log-failed # show failed log lines for one job
 ```
 
 ### Commands

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -84,6 +84,16 @@ const RUN_LIST_BASE_JSON =
 
 const LOG_TRUNCATE_LIMIT = 20000;
 
+function takeViewFlagValue(args: string[], flag: string): string | undefined {
+  const present = args.includes(flag);
+  const value = takeFlag(args, flag);
+  if (!present) return undefined;
+  if (!value || value.startsWith("--")) {
+    throw new AxiError(`Missing value for ${flag}`, "VALIDATION_ERROR");
+  }
+  return value;
+}
+
 function wrapLogOutput(run: string, mode: string, output: string): string {
   const truncated = output.length > LOG_TRUNCATE_LIMIT;
   const result: Record<string, unknown> = {
@@ -146,8 +156,8 @@ async function listRuns(args: string[], ctx?: RepoContext): Promise<string> {
 
 async function viewRun(args: string[], ctx?: RepoContext): Promise<string> {
   const viewArgs = [...args];
-  const jobFlag = takeFlag(viewArgs, "--job");
-  const conclusionFilter = takeFlag(viewArgs, "--conclusion");
+  const jobFlag = takeViewFlagValue(viewArgs, "--job");
+  const conclusionFilter = takeViewFlagValue(viewArgs, "--conclusion");
   const positionals = viewArgs.filter((a) => !a.startsWith("--"));
   const id = positionals[1]; // positionals[0] is "view"
   if (!id && !jobFlag)

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -24,7 +24,7 @@ subcommands[7]:
 flags{list}:
   --workflow, --branch, --status, --event, --user, --commit, --limit (default 10), --fields <a,b,c>
 flags{view}:
-  --log, --log-failed, --conclusion <success|failure|cancelled|skipped> (filter jobs by conclusion)
+  --job <job-id>, --log, --log-failed, --conclusion <success|failure|cancelled|skipped> (filter jobs by conclusion)
 flags{rerun}:
   --failed, --debug, --job
 flags{download}:
@@ -56,6 +56,14 @@ const viewSchema: FieldDef[] = [
 ];
 
 const jobSchema: FieldDef[] = [
+  field('databaseId', 'id'),
+  field('name'),
+  lower('status'),
+  lower('conclusion'),
+];
+
+const stepSchema: FieldDef[] = [
+  field('number'),
   field('name'),
   lower('status'),
   lower('conclusion'),
@@ -129,13 +137,19 @@ async function viewRun(args: string[], ctx?: RepoContext): Promise<string> {
   const id = positionals[1]; // positionals[0] is "view"
   if (!id) throw new AxiError('Run ID is required: gh-axi run view <id>', 'VALIDATION_ERROR');
 
+  const jobFlag = getFlag(args, '--job');
+
   // Handle log modes
   if (hasFlag(args, '--log') || hasFlag(args, '--verbose')) {
-    const output = await ghExec(['run', 'view', id, '--log'], ctx);
+    const ghArgs = ['run', 'view', id, '--log'];
+    if (jobFlag) ghArgs.push('--job', jobFlag);
+    const output = await ghExec(ghArgs, ctx);
     return wrapLogOutput(id, 'log', output);
   }
   if (hasFlag(args, '--log-failed')) {
-    const output = await ghExec(['run', 'view', id, '--log-failed'], ctx);
+    const ghArgs = ['run', 'view', id, '--log-failed'];
+    if (jobFlag) ghArgs.push('--job', jobFlag);
+    const output = await ghExec(ghArgs, ctx);
     return wrapLogOutput(id, 'log-failed', output);
   }
 
@@ -149,14 +163,25 @@ async function viewRun(args: string[], ctx?: RepoContext): Promise<string> {
   const jobsArr = run.jobs;
   if (Array.isArray(jobsArr) && jobsArr.length > 0) {
     const typedJobs = jobsArr as Record<string, unknown>[];
-    const conclusionFilter = getFlag(args, '--conclusion');
-    const jobs = conclusionFilter
-      ? typedJobs.filter((j) => (typeof j.conclusion === 'string' ? j.conclusion : '').toLowerCase() === conclusionFilter.toLowerCase())
-      : typedJobs;
-    if (conclusionFilter) {
-      blocks.push(`jobs: ${jobs.length} of ${typedJobs.length} with conclusion=${conclusionFilter}`);
+
+    if (jobFlag) {
+      const job = typedJobs.find((j) => String(j.databaseId) === jobFlag);
+      if (!job) throw new AxiError(`Job ${jobFlag} not found in run ${id}`, 'VALIDATION_ERROR');
+      blocks.push(renderDetail('job', job, jobSchema));
+      const stepsArr = job.steps;
+      if (Array.isArray(stepsArr) && stepsArr.length > 0) {
+        blocks.push(renderList('steps', stepsArr as Record<string, unknown>[], stepSchema));
+      }
+    } else {
+      const conclusionFilter = getFlag(args, '--conclusion');
+      const jobs = conclusionFilter
+        ? typedJobs.filter((j) => (typeof j.conclusion === 'string' ? j.conclusion : '').toLowerCase() === conclusionFilter.toLowerCase())
+        : typedJobs;
+      if (conclusionFilter) {
+        blocks.push(`jobs: ${jobs.length} of ${typedJobs.length} with conclusion=${conclusionFilter}`);
+      }
+      blocks.push(renderList('jobs', jobs, jobSchema));
     }
-    blocks.push(renderList('jobs', jobs, jobSchema));
   }
 
   return renderOutput(blocks);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -110,6 +110,18 @@ function wrapLogOutput(run: string, mode: string, output: string): string {
   return encode(result);
 }
 
+function matchesConclusionFilter(
+  item: Record<string, unknown>,
+  conclusionFilter: string,
+): boolean {
+  return (
+    (typeof item.conclusion === "string"
+      ? item.conclusion
+      : ""
+    ).toLowerCase() === conclusionFilter.toLowerCase()
+  );
+}
+
 async function resolveLogRunId(
   id: string | undefined,
   jobFlag: string | undefined,
@@ -126,6 +138,19 @@ async function resolveLogRunId(
     throw new AxiError(`Unable to resolve run for job ${jobFlag}`, "UNKNOWN");
   }
   return String(resolvedId);
+}
+
+async function resolveLogEnvelopeRunId(
+  id: string | undefined,
+  jobFlag: string | undefined,
+  ctx?: RepoContext,
+): Promise<string> {
+  if (id) return id;
+  try {
+    return await resolveLogRunId(id, jobFlag, ctx);
+  } catch {
+    return jobFlag!;
+  }
 }
 
 async function listRuns(args: string[], ctx?: RepoContext): Promise<string> {
@@ -199,7 +224,7 @@ async function viewRun(args: string[], ctx?: RepoContext): Promise<string> {
     if (jobFlag) ghArgs.push("--job", jobFlag);
     const output = await ghExec(ghArgs, ctx);
     return wrapLogOutput(
-      await resolveLogRunId(id, jobFlag, ctx),
+      await resolveLogEnvelopeRunId(id, jobFlag, ctx),
       "log",
       output,
     );
@@ -209,7 +234,7 @@ async function viewRun(args: string[], ctx?: RepoContext): Promise<string> {
     if (jobFlag) ghArgs.push("--job", jobFlag);
     const output = await ghExec(ghArgs, ctx);
     return wrapLogOutput(
-      await resolveLogRunId(id, jobFlag, ctx),
+      await resolveLogEnvelopeRunId(id, jobFlag, ctx),
       "log-failed",
       output,
     );
@@ -239,6 +264,12 @@ async function viewRun(args: string[], ctx?: RepoContext): Promise<string> {
         `Job ${jobFlag} not found in run ${id ?? String(run.databaseId ?? "unknown")}`,
         "VALIDATION_ERROR",
       );
+    if (conclusionFilter && !matchesConclusionFilter(job, conclusionFilter)) {
+      throw new AxiError(
+        `Job ${jobFlag} does not match conclusion=${conclusionFilter}`,
+        "VALIDATION_ERROR",
+      );
+    }
     blocks.push(renderDetail("job", job, jobSchema));
     const stepsArr = job.steps;
     if (Array.isArray(stepsArr) && stepsArr.length > 0) {
@@ -248,13 +279,7 @@ async function viewRun(args: string[], ctx?: RepoContext): Promise<string> {
     }
   } else if (typedJobs.length > 0) {
     const jobs = conclusionFilter
-      ? typedJobs.filter(
-          (j) =>
-            (typeof j.conclusion === "string"
-              ? j.conclusion
-              : ""
-            ).toLowerCase() === conclusionFilter.toLowerCase(),
-        )
+      ? typedJobs.filter((j) => matchesConclusionFilter(j, conclusionFilter))
       : typedJobs;
     if (conclusionFilter) {
       blocks.push(

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -146,11 +146,7 @@ async function resolveLogEnvelopeRunId(
   ctx?: RepoContext,
 ): Promise<string> {
   if (id) return id;
-  try {
-    return await resolveLogRunId(id, jobFlag, ctx);
-  } catch {
-    return jobFlag!;
-  }
+  return resolveLogRunId(id, jobFlag, ctx);
 }
 
 async function listRuns(args: string[], ctx?: RepoContext): Promise<string> {
@@ -203,12 +199,6 @@ async function viewRun(args: string[], ctx?: RepoContext): Promise<string> {
   const conclusionFilter = takeViewFlagValue(viewArgs, "--conclusion");
   const positionals = viewArgs.filter((a) => !a.startsWith("--"));
   const id = positionals[1]; // positionals[0] is "view"
-  if (id && jobFlag) {
-    throw new AxiError(
-      "Specify either a run ID or --job, not both",
-      "VALIDATION_ERROR",
-    );
-  }
   if (!id && !jobFlag)
     throw new AxiError(
       "Run ID is required: gh-axi run view <id>",

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -146,7 +146,12 @@ async function resolveLogEnvelopeRunId(
   ctx?: RepoContext,
 ): Promise<string> {
   if (id) return id;
-  return resolveLogRunId(id, jobFlag, ctx);
+  try {
+    return await resolveLogRunId(id, jobFlag, ctx);
+  } catch {
+    if (jobFlag) return jobFlag;
+    throw new AxiError("Unable to resolve run id for logs", "UNKNOWN");
+  }
 }
 
 async function listRuns(args: string[], ctx?: RepoContext): Promise<string> {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -150,31 +150,33 @@ async function viewRun(args: string[], ctx?: RepoContext): Promise<string> {
   const conclusionFilter = takeFlag(viewArgs, "--conclusion");
   const positionals = viewArgs.filter((a) => !a.startsWith("--"));
   const id = positionals[1]; // positionals[0] is "view"
-  if (!id)
+  if (!id && !jobFlag)
     throw new AxiError(
       "Run ID is required: gh-axi run view <id>",
       "VALIDATION_ERROR",
     );
 
+  const ghSelector = ["run", "view"];
+  if (id) ghSelector.push(id);
+
   // Handle log modes
   if (hasFlag(args, "--log") || hasFlag(args, "--verbose")) {
-    const ghArgs = ["run", "view", id, "--log"];
+    const ghArgs = [...ghSelector, "--log"];
     if (jobFlag) ghArgs.push("--job", jobFlag);
     const output = await ghExec(ghArgs, ctx);
-    return wrapLogOutput(id, "log", output);
+    return wrapLogOutput(id ?? jobFlag!, "log", output);
   }
   if (hasFlag(args, "--log-failed")) {
-    const ghArgs = ["run", "view", id, "--log-failed"];
+    const ghArgs = [...ghSelector, "--log-failed"];
     if (jobFlag) ghArgs.push("--job", jobFlag);
     const output = await ghExec(ghArgs, ctx);
-    return wrapLogOutput(id, "log-failed", output);
+    return wrapLogOutput(id ?? jobFlag!, "log-failed", output);
   }
 
   const run = await ghJson<Record<string, unknown>>(
     [
-      "run",
-      "view",
-      id,
+      ...ghSelector,
+      ...(jobFlag ? ["--job", jobFlag] : []),
       "--json",
       "databaseId,displayTitle,status,conclusion,workflowName,headBranch,createdAt,jobs",
     ],
@@ -192,7 +194,7 @@ async function viewRun(args: string[], ctx?: RepoContext): Promise<string> {
     const job = typedJobs.find((j) => String(j.databaseId) === jobFlag);
     if (!job)
       throw new AxiError(
-        `Job ${jobFlag} not found in run ${id}`,
+        `Job ${jobFlag} not found in run ${id ?? String(run.databaseId ?? "unknown")}`,
         "VALIDATION_ERROR",
       );
     blocks.push(renderDetail("job", job, jobSchema));

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,9 +1,9 @@
-import { encode } from '@toon-format/toon';
-import type { RepoContext } from '../context.js';
-import { ghJson, ghExec } from '../gh.js';
-import { AxiError } from '../errors.js';
-import { getFlag, hasFlag, takeFlag } from '../args.js';
-import { parseFields, type ExtraFieldSpec } from '../fields.js';
+import { encode } from "@toon-format/toon";
+import type { RepoContext } from "../context.js";
+import { ghJson, ghExec } from "../gh.js";
+import { AxiError } from "../errors.js";
+import { getFlag, hasFlag, takeFlag } from "../args.js";
+import { parseFields, type ExtraFieldSpec } from "../fields.js";
 import {
   field,
   lower,
@@ -14,9 +14,9 @@ import {
   renderOutput,
   renderError,
   type FieldDef,
-} from '../toon.js';
-import { formatCountLine } from '../format.js';
-import { getSuggestions } from '../suggestions.js';
+} from "../toon.js";
+import { formatCountLine } from "../format.js";
+import { getSuggestions } from "../suggestions.js";
 
 export const RUN_HELP = `usage: gh-axi run <subcommand> [flags]
 subcommands[7]:
@@ -35,48 +35,52 @@ examples:
   gh-axi run rerun 123456 --failed`;
 
 const listSchema: FieldDef[] = [
-  field('databaseId', 'id'),
-  field('displayTitle', 'title'),
-  lower('status'),
-  lower('conclusion'),
-  field('workflowName', 'workflow'),
-  field('headBranch', 'branch'),
-  field('event'),
-  relativeTime('createdAt', 'created'),
+  field("databaseId", "id"),
+  field("displayTitle", "title"),
+  lower("status"),
+  lower("conclusion"),
+  field("workflowName", "workflow"),
+  field("headBranch", "branch"),
+  field("event"),
+  relativeTime("createdAt", "created"),
 ];
 
 const viewSchema: FieldDef[] = [
-  field('databaseId', 'id'),
-  field('displayTitle', 'title'),
-  lower('status'),
-  lower('conclusion'),
-  field('workflowName', 'workflow'),
-  field('headBranch', 'branch'),
-  relativeTime('createdAt', 'created'),
+  field("databaseId", "id"),
+  field("displayTitle", "title"),
+  lower("status"),
+  lower("conclusion"),
+  field("workflowName", "workflow"),
+  field("headBranch", "branch"),
+  relativeTime("createdAt", "created"),
 ];
 
 const jobSchema: FieldDef[] = [
-  field('databaseId', 'id'),
-  field('name'),
-  lower('status'),
-  lower('conclusion'),
+  field("databaseId", "id"),
+  field("name"),
+  lower("status"),
+  lower("conclusion"),
 ];
 
 const stepSchema: FieldDef[] = [
-  field('number'),
-  field('name'),
-  lower('status'),
-  lower('conclusion'),
+  field("number"),
+  field("name"),
+  lower("status"),
+  lower("conclusion"),
 ];
 
 const RUN_LIST_EXTRA_FIELDS: Record<string, ExtraFieldSpec> = {
-  headSha: { jsonKey: 'headSha', def: field('headSha', 'sha') },
-  number: { jsonKey: 'number', def: field('number') },
-  url: { jsonKey: 'url', def: field('url') },
-  updatedAt: { jsonKey: 'updatedAt', def: relativeTime('updatedAt', 'updated_at') },
+  headSha: { jsonKey: "headSha", def: field("headSha", "sha") },
+  number: { jsonKey: "number", def: field("number") },
+  url: { jsonKey: "url", def: field("url") },
+  updatedAt: {
+    jsonKey: "updatedAt",
+    def: relativeTime("updatedAt", "updated_at"),
+  },
 };
 
-const RUN_LIST_BASE_JSON = 'databaseId,displayTitle,status,conclusion,workflowName,headBranch,event,createdAt';
+const RUN_LIST_BASE_JSON =
+  "databaseId,displayTitle,status,conclusion,workflowName,headBranch,event,createdAt";
 
 const LOG_TRUNCATE_LIMIT = 20000;
 
@@ -97,207 +101,294 @@ function wrapLogOutput(run: string, mode: string, output: string): string {
 }
 
 async function listRuns(args: string[], ctx?: RepoContext): Promise<string> {
-  const fieldsArg = takeFlag(args, '--fields');
-  const { extraDefs, extraJsonKeys } = parseFields(fieldsArg, RUN_LIST_EXTRA_FIELDS);
-  const limit = getFlag(args, '--limit') ?? '10';
-  const jsonFields = extraJsonKeys.length > 0 ? RUN_LIST_BASE_JSON + ',' + extraJsonKeys.join(',') : RUN_LIST_BASE_JSON;
-  const ghArgs = [
-    'run', 'list',
-    '--json', jsonFields,
-    '--limit', limit,
-  ];
-  const workflow = getFlag(args, '--workflow');
-  if (workflow) ghArgs.push('--workflow', workflow);
-  const branch = getFlag(args, '--branch');
-  if (branch) ghArgs.push('--branch', branch);
-  const status = getFlag(args, '--status');
-  if (status) ghArgs.push('--status', status);
-  const event = getFlag(args, '--event');
-  if (event) ghArgs.push('--event', event);
-  const user = getFlag(args, '--user');
-  if (user) ghArgs.push('--user', user);
-  const commit = getFlag(args, '--commit');
-  if (commit) ghArgs.push('--commit', commit);
+  const fieldsArg = takeFlag(args, "--fields");
+  const { extraDefs, extraJsonKeys } = parseFields(
+    fieldsArg,
+    RUN_LIST_EXTRA_FIELDS,
+  );
+  const limit = getFlag(args, "--limit") ?? "10";
+  const jsonFields =
+    extraJsonKeys.length > 0
+      ? RUN_LIST_BASE_JSON + "," + extraJsonKeys.join(",")
+      : RUN_LIST_BASE_JSON;
+  const ghArgs = ["run", "list", "--json", jsonFields, "--limit", limit];
+  const workflow = getFlag(args, "--workflow");
+  if (workflow) ghArgs.push("--workflow", workflow);
+  const branch = getFlag(args, "--branch");
+  if (branch) ghArgs.push("--branch", branch);
+  const status = getFlag(args, "--status");
+  if (status) ghArgs.push("--status", status);
+  const event = getFlag(args, "--event");
+  if (event) ghArgs.push("--event", event);
+  const user = getFlag(args, "--user");
+  if (user) ghArgs.push("--user", user);
+  const commit = getFlag(args, "--commit");
+  if (commit) ghArgs.push("--commit", commit);
 
   const runs = await ghJson<Record<string, unknown>[]>(ghArgs, ctx);
   const isEmpty = runs.length === 0;
   const limitNum = Number(limit);
   const countLine = formatCountLine({ count: runs.length, limit: limitNum });
-  const extendedSchema = extraDefs.length > 0 ? [...listSchema, ...extraDefs] : listSchema;
-  const suggestions = getSuggestions({ domain: 'run', action: 'list', isEmpty, repo: ctx });
+  const extendedSchema =
+    extraDefs.length > 0 ? [...listSchema, ...extraDefs] : listSchema;
+  const suggestions = getSuggestions({
+    domain: "run",
+    action: "list",
+    isEmpty,
+    repo: ctx,
+  });
   return renderOutput([
     countLine,
-    renderList('runs', runs, extendedSchema),
+    renderList("runs", runs, extendedSchema),
     renderHelp(suggestions),
   ]);
 }
 
 async function viewRun(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+  const viewArgs = [...args];
+  const jobFlag = takeFlag(viewArgs, "--job");
+  const conclusionFilter = takeFlag(viewArgs, "--conclusion");
+  const positionals = viewArgs.filter((a) => !a.startsWith("--"));
   const id = positionals[1]; // positionals[0] is "view"
-  if (!id) throw new AxiError('Run ID is required: gh-axi run view <id>', 'VALIDATION_ERROR');
-
-  const jobFlag = getFlag(args, '--job');
+  if (!id)
+    throw new AxiError(
+      "Run ID is required: gh-axi run view <id>",
+      "VALIDATION_ERROR",
+    );
 
   // Handle log modes
-  if (hasFlag(args, '--log') || hasFlag(args, '--verbose')) {
-    const ghArgs = ['run', 'view', id, '--log'];
-    if (jobFlag) ghArgs.push('--job', jobFlag);
+  if (hasFlag(args, "--log") || hasFlag(args, "--verbose")) {
+    const ghArgs = ["run", "view", id, "--log"];
+    if (jobFlag) ghArgs.push("--job", jobFlag);
     const output = await ghExec(ghArgs, ctx);
-    return wrapLogOutput(id, 'log', output);
+    return wrapLogOutput(id, "log", output);
   }
-  if (hasFlag(args, '--log-failed')) {
-    const ghArgs = ['run', 'view', id, '--log-failed'];
-    if (jobFlag) ghArgs.push('--job', jobFlag);
+  if (hasFlag(args, "--log-failed")) {
+    const ghArgs = ["run", "view", id, "--log-failed"];
+    if (jobFlag) ghArgs.push("--job", jobFlag);
     const output = await ghExec(ghArgs, ctx);
-    return wrapLogOutput(id, 'log-failed', output);
+    return wrapLogOutput(id, "log-failed", output);
   }
 
   const run = await ghJson<Record<string, unknown>>(
-    ['run', 'view', id, '--json', 'databaseId,displayTitle,status,conclusion,workflowName,headBranch,createdAt,jobs'],
+    [
+      "run",
+      "view",
+      id,
+      "--json",
+      "databaseId,displayTitle,status,conclusion,workflowName,headBranch,createdAt,jobs",
+    ],
     ctx,
   );
 
-  const blocks: string[] = [renderDetail('run', run, viewSchema)];
+  const blocks: string[] = [renderDetail("run", run, viewSchema)];
 
   const jobsArr = run.jobs;
-  if (Array.isArray(jobsArr) && jobsArr.length > 0) {
-    const typedJobs = jobsArr as Record<string, unknown>[];
+  const typedJobs = Array.isArray(jobsArr)
+    ? (jobsArr as Record<string, unknown>[])
+    : [];
 
-    if (jobFlag) {
-      const job = typedJobs.find((j) => String(j.databaseId) === jobFlag);
-      if (!job) throw new AxiError(`Job ${jobFlag} not found in run ${id}`, 'VALIDATION_ERROR');
-      blocks.push(renderDetail('job', job, jobSchema));
-      const stepsArr = job.steps;
-      if (Array.isArray(stepsArr) && stepsArr.length > 0) {
-        blocks.push(renderList('steps', stepsArr as Record<string, unknown>[], stepSchema));
-      }
-    } else {
-      const conclusionFilter = getFlag(args, '--conclusion');
-      const jobs = conclusionFilter
-        ? typedJobs.filter((j) => (typeof j.conclusion === 'string' ? j.conclusion : '').toLowerCase() === conclusionFilter.toLowerCase())
-        : typedJobs;
-      if (conclusionFilter) {
-        blocks.push(`jobs: ${jobs.length} of ${typedJobs.length} with conclusion=${conclusionFilter}`);
-      }
-      blocks.push(renderList('jobs', jobs, jobSchema));
+  if (jobFlag) {
+    const job = typedJobs.find((j) => String(j.databaseId) === jobFlag);
+    if (!job)
+      throw new AxiError(
+        `Job ${jobFlag} not found in run ${id}`,
+        "VALIDATION_ERROR",
+      );
+    blocks.push(renderDetail("job", job, jobSchema));
+    const stepsArr = job.steps;
+    if (Array.isArray(stepsArr) && stepsArr.length > 0) {
+      blocks.push(
+        renderList("steps", stepsArr as Record<string, unknown>[], stepSchema),
+      );
     }
+  } else if (typedJobs.length > 0) {
+    const jobs = conclusionFilter
+      ? typedJobs.filter(
+          (j) =>
+            (typeof j.conclusion === "string"
+              ? j.conclusion
+              : ""
+            ).toLowerCase() === conclusionFilter.toLowerCase(),
+        )
+      : typedJobs;
+    if (conclusionFilter) {
+      blocks.push(
+        `jobs: ${jobs.length} of ${typedJobs.length} with conclusion=${conclusionFilter}`,
+      );
+    }
+    blocks.push(renderList("jobs", jobs, jobSchema));
   }
 
   return renderOutput(blocks);
 }
 
 async function watchRun(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const id = positionals[1];
-  if (!id) throw new AxiError('Run ID is required: gh-axi run watch <id>', 'VALIDATION_ERROR');
+  if (!id)
+    throw new AxiError(
+      "Run ID is required: gh-axi run watch <id>",
+      "VALIDATION_ERROR",
+    );
 
-  const ghArgs = ['run', 'watch', id, '--exit-status'];
+  const ghArgs = ["run", "watch", id, "--exit-status"];
   const output = await ghExec(ghArgs, ctx);
   return encode({ run_watch: { run: id, output: output.trim() } });
 }
 
 async function rerunRun(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const id = positionals[1];
-  if (!id) throw new AxiError('Run ID is required: gh-axi run rerun <id>', 'VALIDATION_ERROR');
+  if (!id)
+    throw new AxiError(
+      "Run ID is required: gh-axi run rerun <id>",
+      "VALIDATION_ERROR",
+    );
 
-  const ghArgs = ['run', 'rerun', id];
-  if (hasFlag(args, '--failed')) ghArgs.push('--failed');
-  if (hasFlag(args, '--debug')) ghArgs.push('--debug');
-  const job = getFlag(args, '--job');
-  if (job) ghArgs.push('--job', job);
+  const ghArgs = ["run", "rerun", id];
+  if (hasFlag(args, "--failed")) ghArgs.push("--failed");
+  if (hasFlag(args, "--debug")) ghArgs.push("--debug");
+  const job = getFlag(args, "--job");
+  if (job) ghArgs.push("--job", job);
 
   await ghExec(ghArgs, ctx);
-  const suggestions = getSuggestions({ domain: 'run', action: 'rerun', id, repo: ctx });
+  const suggestions = getSuggestions({
+    domain: "run",
+    action: "rerun",
+    id,
+    repo: ctx,
+  });
   return renderOutput([
-    encode({ rerun: 'ok', run: id }),
+    encode({ rerun: "ok", run: id }),
     renderHelp(suggestions),
   ]);
 }
 
 async function cancelRun(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const id = positionals[1];
-  if (!id) throw new AxiError('Run ID is required: gh-axi run cancel <id>', 'VALIDATION_ERROR');
+  if (!id)
+    throw new AxiError(
+      "Run ID is required: gh-axi run cancel <id>",
+      "VALIDATION_ERROR",
+    );
 
   // Idempotent: check status first
   const run = await ghJson<Record<string, unknown>>(
-    ['run', 'view', id, '--json', 'status,conclusion'],
+    ["run", "view", id, "--json", "status,conclusion"],
     ctx,
   );
 
-  if (run.status === 'completed') {
-    const suggestions = getSuggestions({ domain: 'run', action: 'cancel', id, repo: ctx });
+  if (run.status === "completed") {
+    const suggestions = getSuggestions({
+      domain: "run",
+      action: "cancel",
+      id,
+      repo: ctx,
+    });
     return renderOutput([
-      encode({ cancel: 'already_completed', run: id, conclusion: typeof run.conclusion === 'string' ? run.conclusion.toLowerCase() : 'unknown' }),
+      encode({
+        cancel: "already_completed",
+        run: id,
+        conclusion:
+          typeof run.conclusion === "string"
+            ? run.conclusion.toLowerCase()
+            : "unknown",
+      }),
       renderHelp(suggestions),
     ]);
   }
 
-  await ghExec(['run', 'cancel', id], ctx);
-  const suggestions = getSuggestions({ domain: 'run', action: 'cancel', id, repo: ctx });
+  await ghExec(["run", "cancel", id], ctx);
+  const suggestions = getSuggestions({
+    domain: "run",
+    action: "cancel",
+    id,
+    repo: ctx,
+  });
   return renderOutput([
-    encode({ cancel: 'ok', run: id }),
+    encode({ cancel: "ok", run: id }),
     renderHelp(suggestions),
   ]);
 }
 
 async function deleteRun(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const id = positionals[1];
-  if (!id) throw new AxiError('Run ID is required: gh-axi run delete <id>', 'VALIDATION_ERROR');
+  if (!id)
+    throw new AxiError(
+      "Run ID is required: gh-axi run delete <id>",
+      "VALIDATION_ERROR",
+    );
 
-  await ghExec(['run', 'delete', id], ctx);
-  const suggestions = getSuggestions({ domain: 'run', action: 'delete', id, repo: ctx });
+  await ghExec(["run", "delete", id], ctx);
+  const suggestions = getSuggestions({
+    domain: "run",
+    action: "delete",
+    id,
+    repo: ctx,
+  });
   return renderOutput([
-    encode({ delete: 'ok', run: id }),
+    encode({ delete: "ok", run: id }),
     renderHelp(suggestions),
   ]);
 }
 
 async function downloadRun(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const id = positionals[1];
-  if (!id) throw new AxiError('Run ID is required: gh-axi run download <id>', 'VALIDATION_ERROR');
+  if (!id)
+    throw new AxiError(
+      "Run ID is required: gh-axi run download <id>",
+      "VALIDATION_ERROR",
+    );
 
-  const ghArgs = ['run', 'download', id];
-  const name = getFlag(args, '--name');
-  if (name) ghArgs.push('--name', name);
-  const dir = getFlag(args, '--dir');
-  if (dir) ghArgs.push('--dir', dir);
+  const ghArgs = ["run", "download", id];
+  const name = getFlag(args, "--name");
+  if (name) ghArgs.push("--name", name);
+  const dir = getFlag(args, "--dir");
+  if (dir) ghArgs.push("--dir", dir);
 
   await ghExec(ghArgs, ctx);
-  const suggestions = getSuggestions({ domain: 'run', action: 'download', id, repo: ctx });
+  const suggestions = getSuggestions({
+    domain: "run",
+    action: "download",
+    id,
+    repo: ctx,
+  });
   return renderOutput([
-    encode({ download: 'ok', run: id }),
+    encode({ download: "ok", run: id }),
     renderHelp(suggestions),
   ]);
 }
 
-export async function runCommand(args: string[], ctx?: RepoContext): Promise<string> {
+export async function runCommand(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
   const sub = args[0];
 
-  if (sub === '--help' || sub === undefined) return RUN_HELP;
+  if (sub === "--help" || sub === undefined) return RUN_HELP;
 
   switch (sub) {
-    case 'list':
+    case "list":
       return listRuns(args, ctx);
-    case 'view':
+    case "view":
       return viewRun(args, ctx);
-    case 'watch':
+    case "watch":
       return watchRun(args, ctx);
-    case 'rerun':
+    case "rerun":
       return rerunRun(args, ctx);
-    case 'cancel':
+    case "cancel":
       return cancelRun(args, ctx);
-    case 'delete':
+    case "delete":
       return deleteRun(args, ctx);
-    case 'download':
+    case "download":
       return downloadRun(args, ctx);
     default:
-      return renderError(`Unknown subcommand: ${sub}`, 'VALIDATION_ERROR', [
-        'Available subcommands: list, view, watch, rerun, cancel, delete, download',
+      return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [
+        "Available subcommands: list, view, watch, rerun, cancel, delete, download",
       ]);
   }
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -110,6 +110,24 @@ function wrapLogOutput(run: string, mode: string, output: string): string {
   return encode(result);
 }
 
+async function resolveLogRunId(
+  id: string | undefined,
+  jobFlag: string | undefined,
+  ctx?: RepoContext,
+): Promise<string> {
+  if (id) return id;
+
+  const run = await ghJson<Record<string, unknown>>(
+    ["run", "view", "--job", jobFlag!, "--json", "databaseId"],
+    ctx,
+  );
+  const resolvedId = run.databaseId;
+  if (resolvedId === undefined || resolvedId === null) {
+    throw new AxiError(`Unable to resolve run for job ${jobFlag}`, "UNKNOWN");
+  }
+  return String(resolvedId);
+}
+
 async function listRuns(args: string[], ctx?: RepoContext): Promise<string> {
   const fieldsArg = takeFlag(args, "--fields");
   const { extraDefs, extraJsonKeys } = parseFields(
@@ -160,6 +178,12 @@ async function viewRun(args: string[], ctx?: RepoContext): Promise<string> {
   const conclusionFilter = takeViewFlagValue(viewArgs, "--conclusion");
   const positionals = viewArgs.filter((a) => !a.startsWith("--"));
   const id = positionals[1]; // positionals[0] is "view"
+  if (id && jobFlag) {
+    throw new AxiError(
+      "Specify either a run ID or --job, not both",
+      "VALIDATION_ERROR",
+    );
+  }
   if (!id && !jobFlag)
     throw new AxiError(
       "Run ID is required: gh-axi run view <id>",
@@ -174,13 +198,21 @@ async function viewRun(args: string[], ctx?: RepoContext): Promise<string> {
     const ghArgs = [...ghSelector, "--log"];
     if (jobFlag) ghArgs.push("--job", jobFlag);
     const output = await ghExec(ghArgs, ctx);
-    return wrapLogOutput(id ?? jobFlag!, "log", output);
+    return wrapLogOutput(
+      await resolveLogRunId(id, jobFlag, ctx),
+      "log",
+      output,
+    );
   }
   if (hasFlag(args, "--log-failed")) {
     const ghArgs = [...ghSelector, "--log-failed"];
     if (jobFlag) ghArgs.push("--job", jobFlag);
     const output = await ghExec(ghArgs, ctx);
-    return wrapLogOutput(id ?? jobFlag!, "log-failed", output);
+    return wrapLogOutput(
+      await resolveLogRunId(id, jobFlag, ctx),
+      "log-failed",
+      output,
+    );
   }
 
   const run = await ghJson<Record<string, unknown>>(

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -388,6 +388,28 @@ describe("runCommand", () => {
         runCommand(["view", "100", "--job", "999"], ctx),
       ).rejects.toThrow("Job 999 not found in run 100");
     });
+
+    it("rejects --job without a value", async () => {
+      await expect(
+        runCommand(["view", "100", "--job", "--log"], ctx),
+      ).rejects.toMatchObject({
+        code: "VALIDATION_ERROR",
+        message: "Missing value for --job",
+      });
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhJson).not.toHaveBeenCalled();
+    });
+
+    it("rejects --conclusion without a value", async () => {
+      await expect(
+        runCommand(["view", "100", "--conclusion", "--job", "502"], ctx),
+      ).rejects.toMatchObject({
+        code: "VALIDATION_ERROR",
+        message: "Missing value for --conclusion",
+      });
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhJson).not.toHaveBeenCalled();
+    });
   });
 
   describe("view --log", () => {

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -203,7 +203,7 @@ describe("runCommand", () => {
       expect(result).toContain("502");
     });
 
-    it("shows specific job with steps when --job is used", async () => {
+    it("shows specific job with steps in job-only mode", async () => {
       mockedGhJson.mockResolvedValue({
         databaseId: 100,
         displayTitle: "CI Build",
@@ -249,7 +249,7 @@ describe("runCommand", () => {
         ],
       });
 
-      const result = await runCommand(["view", "100", "--job", "502"], ctx);
+      const result = await runCommand(["view", "--job", "502"], ctx);
 
       // Should show the job detail
       expect(result).toContain("test");
@@ -260,48 +260,15 @@ describe("runCommand", () => {
       expect(result).toContain("Teardown");
     });
 
-    it("accepts --job before the run id", async () => {
-      mockedGhJson.mockResolvedValue({
-        databaseId: 100,
-        displayTitle: "CI Build",
-        status: "completed",
-        conclusion: "failure",
-        workflowName: "CI",
-        headBranch: "main",
-        createdAt: "2024-01-01T00:00:00Z",
-        jobs: [
-          {
-            databaseId: 502,
-            name: "test",
-            status: "completed",
-            conclusion: "failure",
-            steps: [
-              {
-                name: "Run tests",
-                number: 1,
-                status: "completed",
-                conclusion: "failure",
-              },
-            ],
-          },
-        ],
+    it("rejects a trailing run id after --job", async () => {
+      await expect(
+        runCommand(["view", "--job", "502", "100"], ctx),
+      ).rejects.toMatchObject({
+        code: "VALIDATION_ERROR",
+        message: "Specify either a run ID or --job, not both",
       });
-
-      const result = await runCommand(["view", "--job", "502", "100"], ctx);
-
-      expect(mockedGhJson).toHaveBeenCalledWith(
-        [
-          "run",
-          "view",
-          "100",
-          "--job",
-          "502",
-          "--json",
-          "databaseId,displayTitle,status,conclusion,workflowName,headBranch,createdAt,jobs",
-        ],
-        ctx,
-      );
-      expect(result).toContain("Run tests");
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhJson).not.toHaveBeenCalled();
     });
 
     it("accepts job-only view invocations", async () => {
@@ -347,6 +314,17 @@ describe("runCommand", () => {
       expect(result).toContain("Run tests");
     });
 
+    it("rejects combining a run id with --job", async () => {
+      await expect(
+        runCommand(["view", "100", "--job", "502"], ctx),
+      ).rejects.toMatchObject({
+        code: "VALIDATION_ERROR",
+        message: "Specify either a run ID or --job, not both",
+      });
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhJson).not.toHaveBeenCalled();
+    });
+
     it("throws error when --job references nonexistent job", async () => {
       mockedGhJson.mockResolvedValue({
         databaseId: 100,
@@ -384,9 +362,9 @@ describe("runCommand", () => {
         jobs: [],
       });
 
-      await expect(
-        runCommand(["view", "100", "--job", "999"], ctx),
-      ).rejects.toThrow("Job 999 not found in run 100");
+      await expect(runCommand(["view", "--job", "999"], ctx)).rejects.toThrow(
+        "Job 999 not found in run 100",
+      );
     });
 
     it("rejects --job without a value", async () => {
@@ -430,21 +408,20 @@ describe("runCommand", () => {
       expect(result).toContain("error in step 3");
     });
 
-    it("passes --job to gh CLI in log mode", async () => {
-      mockedGhExec.mockResolvedValue("job-specific log output\n");
-      const result = await runCommand(
-        ["view", "100", "--log", "--job", "555"],
-        ctx,
-      );
-      expect(mockedGhExec).toHaveBeenCalledWith(
-        expect.arrayContaining(["--log", "--job", "555"]),
-        ctx,
-      );
-      expect(result).toContain("job-specific log output");
+    it("rejects combining a run id with --job in log mode", async () => {
+      await expect(
+        runCommand(["view", "100", "--log", "--job", "555"], ctx),
+      ).rejects.toMatchObject({
+        code: "VALIDATION_ERROR",
+        message: "Specify either a run ID or --job, not both",
+      });
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhJson).not.toHaveBeenCalled();
     });
 
     it("accepts job-only log invocations", async () => {
       mockedGhExec.mockResolvedValue("job-specific log output\n");
+      mockedGhJson.mockResolvedValue({ databaseId: 100 });
       const result = await runCommand(["view", "--log", "--job", "555"], ctx);
 
       expect(mockedGhExec).toHaveBeenCalledWith(
@@ -454,14 +431,29 @@ describe("runCommand", () => {
       expect(result).toContain("job-specific log output");
     });
 
-    it("passes --job to gh CLI in log-failed mode", async () => {
+    it("records the resolved run id in job-only log envelopes", async () => {
+      mockedGhExec.mockResolvedValue("job-specific log output\n");
+      mockedGhJson.mockResolvedValue({ databaseId: 100 });
+
+      const result = await runCommand(["view", "--log", "--job", "555"], ctx);
+
+      expect(mockedGhJson).toHaveBeenCalledWith(
+        ["run", "view", "--job", "555", "--json", "databaseId"],
+        ctx,
+      );
+      expect(result).toContain('run: "100"');
+      expect(result).not.toContain("run: 555");
+    });
+
+    it("passes --job to gh CLI in log-failed job-only mode", async () => {
       mockedGhExec.mockResolvedValue("job-specific failure\n");
+      mockedGhJson.mockResolvedValue({ databaseId: 100 });
       const result = await runCommand(
-        ["view", "100", "--log-failed", "--job", "555"],
+        ["view", "--log-failed", "--job", "555"],
         ctx,
       );
       expect(mockedGhExec).toHaveBeenCalledWith(
-        expect.arrayContaining(["--log-failed", "--job", "555"]),
+        ["run", "view", "--log-failed", "--job", "555"],
         ctx,
       );
       expect(result).toContain("job-specific failure");

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -130,6 +130,64 @@ describe('runCommand', () => {
       const result = await runCommand(['view', '100'], ctx);
       expect(result).not.toMatch(/^help\[/m);
     });
+
+    it('includes job databaseId in job listing', async () => {
+      mockedGhJson.mockResolvedValue({
+        databaseId: 100, displayTitle: 'CI Build', status: 'completed', conclusion: 'failure',
+        workflowName: 'CI', headBranch: 'main', createdAt: '2024-01-01T00:00:00Z',
+        jobs: [
+          { databaseId: 501, name: 'build', status: 'completed', conclusion: 'success', steps: [] },
+          { databaseId: 502, name: 'test', status: 'completed', conclusion: 'failure', steps: [] },
+        ],
+      });
+
+      const result = await runCommand(['view', '100'], ctx);
+
+      expect(result).toContain('501');
+      expect(result).toContain('502');
+    });
+
+    it('shows specific job with steps when --job is used', async () => {
+      mockedGhJson.mockResolvedValue({
+        databaseId: 100, displayTitle: 'CI Build', status: 'completed', conclusion: 'failure',
+        workflowName: 'CI', headBranch: 'main', createdAt: '2024-01-01T00:00:00Z',
+        jobs: [
+          { databaseId: 501, name: 'build', status: 'completed', conclusion: 'success', steps: [] },
+          {
+            databaseId: 502, name: 'test', status: 'completed', conclusion: 'failure',
+            steps: [
+              { name: 'Set up job', number: 1, status: 'completed', conclusion: 'success' },
+              { name: 'Run tests', number: 2, status: 'completed', conclusion: 'failure' },
+              { name: 'Teardown', number: 3, status: 'completed', conclusion: 'skipped' },
+            ],
+          },
+        ],
+      });
+
+      const result = await runCommand(['view', '100', '--job', '502'], ctx);
+
+      // Should show the job detail
+      expect(result).toContain('test');
+      expect(result).toContain('failure');
+      // Should show steps
+      expect(result).toContain('Set up job');
+      expect(result).toContain('Run tests');
+      expect(result).toContain('Teardown');
+    });
+
+    it('throws error when --job references nonexistent job', async () => {
+      mockedGhJson.mockResolvedValue({
+        databaseId: 100, displayTitle: 'CI Build', status: 'completed', conclusion: 'failure',
+        workflowName: 'CI', headBranch: 'main', createdAt: '2024-01-01T00:00:00Z',
+        jobs: [
+          { databaseId: 501, name: 'build', status: 'completed', conclusion: 'success', steps: [] },
+        ],
+      });
+
+      await expect(
+        runCommand(['view', '100', '--job', '999'], ctx),
+      ).rejects.toThrow(AxiError);
+    });
   });
 
   describe('view --log', () => {
@@ -148,6 +206,26 @@ describe('runCommand', () => {
       expect(result).toContain('run_log:');
       expect(result).toContain('mode: log-failed');
       expect(result).toContain('error in step 3');
+    });
+
+    it('passes --job to gh CLI in log mode', async () => {
+      mockedGhExec.mockResolvedValue('job-specific log output\n');
+      const result = await runCommand(['view', '100', '--log', '--job', '555'], ctx);
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        expect.arrayContaining(['--log', '--job', '555']),
+        ctx,
+      );
+      expect(result).toContain('job-specific log output');
+    });
+
+    it('passes --job to gh CLI in log-failed mode', async () => {
+      mockedGhExec.mockResolvedValue('job-specific failure\n');
+      const result = await runCommand(['view', '100', '--log-failed', '--job', '555'], ctx);
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        expect.arrayContaining(['--log-failed', '--job', '555']),
+        ctx,
+      );
+      expect(result).toContain('job-specific failure');
     });
   });
 

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -530,13 +530,14 @@ describe("runCommand", () => {
       expect(result).not.toContain("run: 555");
     });
 
-    it("propagates job-only log run id resolution failures", async () => {
+    it("falls back to the job id when job-only log run id resolution fails", async () => {
       mockedGhExec.mockResolvedValue("job-specific log output\n");
       mockedGhJson.mockRejectedValue(new Error("transient failure"));
 
-      await expect(
-        runCommand(["view", "--log", "--job", "555"], ctx),
-      ).rejects.toThrow("transient failure");
+      const result = await runCommand(["view", "--log", "--job", "555"], ctx);
+
+      expect(result).toContain("job-specific log output");
+      expect(result).toContain('run: "555"');
     });
 
     it("passes --job to gh CLI in log-failed job-only mode", async () => {

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -1,250 +1,414 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from "vitest";
 
-vi.mock('../../src/gh.js', () => ({
+vi.mock("../../src/gh.js", () => ({
   ghJson: vi.fn(),
   ghExec: vi.fn(),
   ghRaw: vi.fn(),
 }));
 
-import { ghJson, ghExec } from '../../src/gh.js';
-import { runCommand, RUN_HELP } from '../../src/commands/run.js';
-import { AxiError } from '../../src/errors.js';
-import type { RepoContext } from '../../src/context.js';
+import { ghJson, ghExec } from "../../src/gh.js";
+import { runCommand, RUN_HELP } from "../../src/commands/run.js";
+import { AxiError } from "../../src/errors.js";
+import type { RepoContext } from "../../src/context.js";
 
 const mockedGhJson = vi.mocked(ghJson);
 const mockedGhExec = vi.mocked(ghExec);
 
-const ctx: RepoContext = { owner: 'octo', name: 'repo', nwo: 'octo/repo', source: 'flag' };
+const ctx: RepoContext = {
+  owner: "octo",
+  name: "repo",
+  nwo: "octo/repo",
+  source: "flag",
+};
 
-describe('runCommand', () => {
+describe("runCommand", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  describe('router', () => {
-    it('returns help when --help is passed', async () => {
-      const result = await runCommand(['--help']);
+  describe("router", () => {
+    it("returns help when --help is passed", async () => {
+      const result = await runCommand(["--help"]);
       expect(result).toBe(RUN_HELP);
     });
 
-    it('returns help when no subcommand is given', async () => {
+    it("returns help when no subcommand is given", async () => {
       const result = await runCommand([]);
       expect(result).toBe(RUN_HELP);
     });
 
-    it('returns error for unknown subcommand', async () => {
-      const result = await runCommand(['unknown']);
-      expect(result).toContain('Unknown subcommand: unknown');
+    it("returns error for unknown subcommand", async () => {
+      const result = await runCommand(["unknown"]);
+      expect(result).toContain("Unknown subcommand: unknown");
     });
   });
 
-  describe('list', () => {
-    it('returns runs list', async () => {
-      mockedGhJson.mockResolvedValue([
-        { databaseId: 100, displayTitle: 'CI Build', status: 'completed', conclusion: 'success', workflowName: 'CI', headBranch: 'main', event: 'push', createdAt: '2024-01-01T00:00:00Z' },
-        { databaseId: 101, displayTitle: 'Tests', status: 'in_progress', conclusion: null, workflowName: 'Test', headBranch: 'dev', event: 'pull_request', createdAt: '2024-01-02T00:00:00Z' },
-      ]);
-
-      const result = await runCommand(['list'], ctx);
-
-      expect(result).toContain('count: 2');
-      expect(result).toContain('CI Build');
-      expect(result).toContain('Tests');
-    });
-
-    it('uses default compact --json fields when --fields is not passed', async () => {
-      mockedGhJson.mockResolvedValue([]);
-      await runCommand(['list'], ctx);
-
-      const callArgs = mockedGhJson.mock.calls[0][0] as string[];
-      const jsonIdx = callArgs.indexOf('--json');
-      const jsonValue = callArgs[jsonIdx + 1];
-      expect(jsonValue).not.toContain('headSha');
-      expect(jsonValue).not.toContain('number');
-      expect(jsonValue).toContain('databaseId');
-      expect(jsonValue).toContain('displayTitle');
-    });
-
-    it('extends --json and schema when --fields is passed', async () => {
+  describe("list", () => {
+    it("returns runs list", async () => {
       mockedGhJson.mockResolvedValue([
         {
-          databaseId: 100, displayTitle: 'CI Build', status: 'completed', conclusion: 'success',
-          workflowName: 'CI', headBranch: 'main', event: 'push', createdAt: '2024-01-01T00:00:00Z',
-          headSha: 'abc123', number: 42,
+          databaseId: 100,
+          displayTitle: "CI Build",
+          status: "completed",
+          conclusion: "success",
+          workflowName: "CI",
+          headBranch: "main",
+          event: "push",
+          createdAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          databaseId: 101,
+          displayTitle: "Tests",
+          status: "in_progress",
+          conclusion: null,
+          workflowName: "Test",
+          headBranch: "dev",
+          event: "pull_request",
+          createdAt: "2024-01-02T00:00:00Z",
         },
       ]);
 
-      const result = await runCommand(['list', '--fields', 'headSha,number'], ctx);
+      const result = await runCommand(["list"], ctx);
 
-      const callArgs = mockedGhJson.mock.calls[0][0] as string[];
-      const jsonIdx = callArgs.indexOf('--json');
-      const jsonValue = callArgs[jsonIdx + 1];
-      expect(jsonValue).toContain('headSha');
-      expect(jsonValue).toContain('number');
-
-      expect(result).toContain('abc123');
+      expect(result).toContain("count: 2");
+      expect(result).toContain("CI Build");
+      expect(result).toContain("Tests");
     });
 
-    it('throws VALIDATION_ERROR for unknown --fields', async () => {
+    it("uses default compact --json fields when --fields is not passed", async () => {
+      mockedGhJson.mockResolvedValue([]);
+      await runCommand(["list"], ctx);
+
+      const callArgs = mockedGhJson.mock.calls[0][0] as string[];
+      const jsonIdx = callArgs.indexOf("--json");
+      const jsonValue = callArgs[jsonIdx + 1];
+      expect(jsonValue).not.toContain("headSha");
+      expect(jsonValue).not.toContain("number");
+      expect(jsonValue).toContain("databaseId");
+      expect(jsonValue).toContain("displayTitle");
+    });
+
+    it("extends --json and schema when --fields is passed", async () => {
+      mockedGhJson.mockResolvedValue([
+        {
+          databaseId: 100,
+          displayTitle: "CI Build",
+          status: "completed",
+          conclusion: "success",
+          workflowName: "CI",
+          headBranch: "main",
+          event: "push",
+          createdAt: "2024-01-01T00:00:00Z",
+          headSha: "abc123",
+          number: 42,
+        },
+      ]);
+
+      const result = await runCommand(
+        ["list", "--fields", "headSha,number"],
+        ctx,
+      );
+
+      const callArgs = mockedGhJson.mock.calls[0][0] as string[];
+      const jsonIdx = callArgs.indexOf("--json");
+      const jsonValue = callArgs[jsonIdx + 1];
+      expect(jsonValue).toContain("headSha");
+      expect(jsonValue).toContain("number");
+
+      expect(result).toContain("abc123");
+    });
+
+    it("throws VALIDATION_ERROR for unknown --fields", async () => {
       await expect(
-        runCommand(['list', '--fields', 'bogusField'], ctx),
+        runCommand(["list", "--fields", "bogusField"], ctx),
       ).rejects.toThrow(AxiError);
 
       try {
-        await runCommand(['list', '--fields', 'bogusField'], ctx);
+        await runCommand(["list", "--fields", "bogusField"], ctx);
       } catch (e) {
-        expect((e as AxiError).code).toBe('VALIDATION_ERROR');
-        expect((e as AxiError).message).toContain('bogusField');
+        expect((e as AxiError).code).toBe("VALIDATION_ERROR");
+        expect((e as AxiError).message).toContain("bogusField");
       }
     });
   });
 
-  describe('view', () => {
-    it('returns run detail with jobs', async () => {
+  describe("view", () => {
+    it("returns run detail with jobs", async () => {
       mockedGhJson.mockResolvedValue({
         databaseId: 100,
-        displayTitle: 'CI Build',
-        status: 'completed',
-        conclusion: 'success',
-        workflowName: 'CI',
-        headBranch: 'main',
-        createdAt: '2024-01-01T00:00:00Z',
+        displayTitle: "CI Build",
+        status: "completed",
+        conclusion: "success",
+        workflowName: "CI",
+        headBranch: "main",
+        createdAt: "2024-01-01T00:00:00Z",
         jobs: [
-          { name: 'build', status: 'completed', conclusion: 'success' },
-          { name: 'test', status: 'completed', conclusion: 'failure' },
+          { name: "build", status: "completed", conclusion: "success" },
+          { name: "test", status: "completed", conclusion: "failure" },
         ],
       });
 
-      const result = await runCommand(['view', '100'], ctx);
+      const result = await runCommand(["view", "100"], ctx);
 
-      expect(result).toContain('CI Build');
-      expect(result).toContain('build');
-      expect(result).toContain('test');
+      expect(result).toContain("CI Build");
+      expect(result).toContain("build");
+      expect(result).toContain("test");
     });
 
-    it('omits help suggestions from detail view', async () => {
+    it("omits help suggestions from detail view", async () => {
       mockedGhJson.mockResolvedValue({
-        databaseId: 100, displayTitle: 'CI', status: 'completed', conclusion: 'success',
-        workflowName: 'CI', headBranch: 'main', createdAt: '2024-01-01T00:00:00Z', jobs: [],
+        databaseId: 100,
+        displayTitle: "CI",
+        status: "completed",
+        conclusion: "success",
+        workflowName: "CI",
+        headBranch: "main",
+        createdAt: "2024-01-01T00:00:00Z",
+        jobs: [],
       });
-      const result = await runCommand(['view', '100'], ctx);
+      const result = await runCommand(["view", "100"], ctx);
       expect(result).not.toMatch(/^help\[/m);
     });
 
-    it('includes job databaseId in job listing', async () => {
+    it("includes job databaseId in job listing", async () => {
       mockedGhJson.mockResolvedValue({
-        databaseId: 100, displayTitle: 'CI Build', status: 'completed', conclusion: 'failure',
-        workflowName: 'CI', headBranch: 'main', createdAt: '2024-01-01T00:00:00Z',
+        databaseId: 100,
+        displayTitle: "CI Build",
+        status: "completed",
+        conclusion: "failure",
+        workflowName: "CI",
+        headBranch: "main",
+        createdAt: "2024-01-01T00:00:00Z",
         jobs: [
-          { databaseId: 501, name: 'build', status: 'completed', conclusion: 'success', steps: [] },
-          { databaseId: 502, name: 'test', status: 'completed', conclusion: 'failure', steps: [] },
+          {
+            databaseId: 501,
+            name: "build",
+            status: "completed",
+            conclusion: "success",
+            steps: [],
+          },
+          {
+            databaseId: 502,
+            name: "test",
+            status: "completed",
+            conclusion: "failure",
+            steps: [],
+          },
         ],
       });
 
-      const result = await runCommand(['view', '100'], ctx);
+      const result = await runCommand(["view", "100"], ctx);
 
-      expect(result).toContain('501');
-      expect(result).toContain('502');
+      expect(result).toContain("501");
+      expect(result).toContain("502");
     });
 
-    it('shows specific job with steps when --job is used', async () => {
+    it("shows specific job with steps when --job is used", async () => {
       mockedGhJson.mockResolvedValue({
-        databaseId: 100, displayTitle: 'CI Build', status: 'completed', conclusion: 'failure',
-        workflowName: 'CI', headBranch: 'main', createdAt: '2024-01-01T00:00:00Z',
+        databaseId: 100,
+        displayTitle: "CI Build",
+        status: "completed",
+        conclusion: "failure",
+        workflowName: "CI",
+        headBranch: "main",
+        createdAt: "2024-01-01T00:00:00Z",
         jobs: [
-          { databaseId: 501, name: 'build', status: 'completed', conclusion: 'success', steps: [] },
           {
-            databaseId: 502, name: 'test', status: 'completed', conclusion: 'failure',
+            databaseId: 501,
+            name: "build",
+            status: "completed",
+            conclusion: "success",
+            steps: [],
+          },
+          {
+            databaseId: 502,
+            name: "test",
+            status: "completed",
+            conclusion: "failure",
             steps: [
-              { name: 'Set up job', number: 1, status: 'completed', conclusion: 'success' },
-              { name: 'Run tests', number: 2, status: 'completed', conclusion: 'failure' },
-              { name: 'Teardown', number: 3, status: 'completed', conclusion: 'skipped' },
+              {
+                name: "Set up job",
+                number: 1,
+                status: "completed",
+                conclusion: "success",
+              },
+              {
+                name: "Run tests",
+                number: 2,
+                status: "completed",
+                conclusion: "failure",
+              },
+              {
+                name: "Teardown",
+                number: 3,
+                status: "completed",
+                conclusion: "skipped",
+              },
             ],
           },
         ],
       });
 
-      const result = await runCommand(['view', '100', '--job', '502'], ctx);
+      const result = await runCommand(["view", "100", "--job", "502"], ctx);
 
       // Should show the job detail
-      expect(result).toContain('test');
-      expect(result).toContain('failure');
+      expect(result).toContain("test");
+      expect(result).toContain("failure");
       // Should show steps
-      expect(result).toContain('Set up job');
-      expect(result).toContain('Run tests');
-      expect(result).toContain('Teardown');
+      expect(result).toContain("Set up job");
+      expect(result).toContain("Run tests");
+      expect(result).toContain("Teardown");
     });
 
-    it('throws error when --job references nonexistent job', async () => {
+    it("accepts --job before the run id", async () => {
       mockedGhJson.mockResolvedValue({
-        databaseId: 100, displayTitle: 'CI Build', status: 'completed', conclusion: 'failure',
-        workflowName: 'CI', headBranch: 'main', createdAt: '2024-01-01T00:00:00Z',
+        databaseId: 100,
+        displayTitle: "CI Build",
+        status: "completed",
+        conclusion: "failure",
+        workflowName: "CI",
+        headBranch: "main",
+        createdAt: "2024-01-01T00:00:00Z",
         jobs: [
-          { databaseId: 501, name: 'build', status: 'completed', conclusion: 'success', steps: [] },
+          {
+            databaseId: 502,
+            name: "test",
+            status: "completed",
+            conclusion: "failure",
+            steps: [
+              {
+                name: "Run tests",
+                number: 1,
+                status: "completed",
+                conclusion: "failure",
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = await runCommand(["view", "--job", "502", "100"], ctx);
+
+      expect(mockedGhJson).toHaveBeenCalledWith(
+        [
+          "run",
+          "view",
+          "100",
+          "--json",
+          "databaseId,displayTitle,status,conclusion,workflowName,headBranch,createdAt,jobs",
+        ],
+        ctx,
+      );
+      expect(result).toContain("Run tests");
+    });
+
+    it("throws error when --job references nonexistent job", async () => {
+      mockedGhJson.mockResolvedValue({
+        databaseId: 100,
+        displayTitle: "CI Build",
+        status: "completed",
+        conclusion: "failure",
+        workflowName: "CI",
+        headBranch: "main",
+        createdAt: "2024-01-01T00:00:00Z",
+        jobs: [
+          {
+            databaseId: 501,
+            name: "build",
+            status: "completed",
+            conclusion: "success",
+            steps: [],
+          },
         ],
       });
 
       await expect(
-        runCommand(['view', '100', '--job', '999'], ctx),
+        runCommand(["view", "100", "--job", "999"], ctx),
       ).rejects.toThrow(AxiError);
     });
+
+    it("throws error when --job is provided and the run has no jobs", async () => {
+      mockedGhJson.mockResolvedValue({
+        databaseId: 100,
+        displayTitle: "CI Build",
+        status: "completed",
+        conclusion: "failure",
+        workflowName: "CI",
+        headBranch: "main",
+        createdAt: "2024-01-01T00:00:00Z",
+        jobs: [],
+      });
+
+      await expect(
+        runCommand(["view", "100", "--job", "999"], ctx),
+      ).rejects.toThrow("Job 999 not found in run 100");
+    });
   });
 
-  describe('view --log', () => {
-    it('wraps log output in TOON envelope', async () => {
-      mockedGhExec.mockResolvedValue('build step 1\nbuild step 2\ndone\n');
-      const result = await runCommand(['view', '100', '--log'], ctx);
-      expect(result).toContain('run_log:');
-      expect(result).toContain('mode: log');
-      expect(result).toContain('build step 1');
-      expect(result).toContain('truncated: false');
+  describe("view --log", () => {
+    it("wraps log output in TOON envelope", async () => {
+      mockedGhExec.mockResolvedValue("build step 1\nbuild step 2\ndone\n");
+      const result = await runCommand(["view", "100", "--log"], ctx);
+      expect(result).toContain("run_log:");
+      expect(result).toContain("mode: log");
+      expect(result).toContain("build step 1");
+      expect(result).toContain("truncated: false");
     });
 
-    it('wraps log-failed output in TOON envelope', async () => {
-      mockedGhExec.mockResolvedValue('error in step 3\n');
-      const result = await runCommand(['view', '100', '--log-failed'], ctx);
-      expect(result).toContain('run_log:');
-      expect(result).toContain('mode: log-failed');
-      expect(result).toContain('error in step 3');
+    it("wraps log-failed output in TOON envelope", async () => {
+      mockedGhExec.mockResolvedValue("error in step 3\n");
+      const result = await runCommand(["view", "100", "--log-failed"], ctx);
+      expect(result).toContain("run_log:");
+      expect(result).toContain("mode: log-failed");
+      expect(result).toContain("error in step 3");
     });
 
-    it('passes --job to gh CLI in log mode', async () => {
-      mockedGhExec.mockResolvedValue('job-specific log output\n');
-      const result = await runCommand(['view', '100', '--log', '--job', '555'], ctx);
-      expect(mockedGhExec).toHaveBeenCalledWith(
-        expect.arrayContaining(['--log', '--job', '555']),
+    it("passes --job to gh CLI in log mode", async () => {
+      mockedGhExec.mockResolvedValue("job-specific log output\n");
+      const result = await runCommand(
+        ["view", "100", "--log", "--job", "555"],
         ctx,
       );
-      expect(result).toContain('job-specific log output');
-    });
-
-    it('passes --job to gh CLI in log-failed mode', async () => {
-      mockedGhExec.mockResolvedValue('job-specific failure\n');
-      const result = await runCommand(['view', '100', '--log-failed', '--job', '555'], ctx);
       expect(mockedGhExec).toHaveBeenCalledWith(
-        expect.arrayContaining(['--log-failed', '--job', '555']),
+        expect.arrayContaining(["--log", "--job", "555"]),
         ctx,
       );
-      expect(result).toContain('job-specific failure');
+      expect(result).toContain("job-specific log output");
+    });
+
+    it("passes --job to gh CLI in log-failed mode", async () => {
+      mockedGhExec.mockResolvedValue("job-specific failure\n");
+      const result = await runCommand(
+        ["view", "100", "--log-failed", "--job", "555"],
+        ctx,
+      );
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        expect.arrayContaining(["--log-failed", "--job", "555"]),
+        ctx,
+      );
+      expect(result).toContain("job-specific failure");
     });
   });
 
-  describe('watch', () => {
-    it('wraps watch output in TOON envelope', async () => {
-      mockedGhExec.mockResolvedValue('Run completed\n');
-      const result = await runCommand(['watch', '100'], ctx);
-      expect(result).toContain('run_watch:');
-      expect(result).toContain('Run completed');
+  describe("watch", () => {
+    it("wraps watch output in TOON envelope", async () => {
+      mockedGhExec.mockResolvedValue("Run completed\n");
+      const result = await runCommand(["watch", "100"], ctx);
+      expect(result).toContain("run_watch:");
+      expect(result).toContain("Run completed");
     });
   });
 
-  describe('cancel', () => {
-    it('returns already_completed when run is already completed (idempotent)', async () => {
-      mockedGhJson.mockResolvedValue({ status: 'completed', conclusion: 'success' });
+  describe("cancel", () => {
+    it("returns already_completed when run is already completed (idempotent)", async () => {
+      mockedGhJson.mockResolvedValue({
+        status: "completed",
+        conclusion: "success",
+      });
 
-      const result = await runCommand(['cancel', '100'], ctx);
+      const result = await runCommand(["cancel", "100"], ctx);
 
-      expect(result).toContain('already_completed');
+      expect(result).toContain("already_completed");
       expect(mockedGhExec).not.toHaveBeenCalled();
     });
   });

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -294,6 +294,51 @@ describe("runCommand", () => {
           "run",
           "view",
           "100",
+          "--job",
+          "502",
+          "--json",
+          "databaseId,displayTitle,status,conclusion,workflowName,headBranch,createdAt,jobs",
+        ],
+        ctx,
+      );
+      expect(result).toContain("Run tests");
+    });
+
+    it("accepts job-only view invocations", async () => {
+      mockedGhJson.mockResolvedValue({
+        databaseId: 100,
+        displayTitle: "CI Build",
+        status: "completed",
+        conclusion: "failure",
+        workflowName: "CI",
+        headBranch: "main",
+        createdAt: "2024-01-01T00:00:00Z",
+        jobs: [
+          {
+            databaseId: 502,
+            name: "test",
+            status: "completed",
+            conclusion: "failure",
+            steps: [
+              {
+                name: "Run tests",
+                number: 1,
+                status: "completed",
+                conclusion: "failure",
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = await runCommand(["view", "--job", "502"], ctx);
+
+      expect(mockedGhJson).toHaveBeenCalledWith(
+        [
+          "run",
+          "view",
+          "--job",
+          "502",
           "--json",
           "databaseId,displayTitle,status,conclusion,workflowName,headBranch,createdAt,jobs",
         ],
@@ -371,6 +416,17 @@ describe("runCommand", () => {
       );
       expect(mockedGhExec).toHaveBeenCalledWith(
         expect.arrayContaining(["--log", "--job", "555"]),
+        ctx,
+      );
+      expect(result).toContain("job-specific log output");
+    });
+
+    it("accepts job-only log invocations", async () => {
+      mockedGhExec.mockResolvedValue("job-specific log output\n");
+      const result = await runCommand(["view", "--log", "--job", "555"], ctx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["run", "view", "--log", "--job", "555"],
         ctx,
       );
       expect(result).toContain("job-specific log output");

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -260,6 +260,34 @@ describe("runCommand", () => {
       expect(result).toContain("Teardown");
     });
 
+    it("rejects a job-only view when --conclusion excludes the selected job", async () => {
+      mockedGhJson.mockResolvedValue({
+        databaseId: 100,
+        displayTitle: "CI Build",
+        status: "completed",
+        conclusion: "failure",
+        workflowName: "CI",
+        headBranch: "main",
+        createdAt: "2024-01-01T00:00:00Z",
+        jobs: [
+          {
+            databaseId: 502,
+            name: "test",
+            status: "completed",
+            conclusion: "failure",
+            steps: [],
+          },
+        ],
+      });
+
+      await expect(
+        runCommand(["view", "--job", "502", "--conclusion", "success"], ctx),
+      ).rejects.toMatchObject({
+        code: "VALIDATION_ERROR",
+        message: "Job 502 does not match conclusion=success",
+      });
+    });
+
     it("rejects a trailing run id after --job", async () => {
       await expect(
         runCommand(["view", "--job", "502", "100"], ctx),
@@ -443,6 +471,16 @@ describe("runCommand", () => {
       );
       expect(result).toContain('run: "100"');
       expect(result).not.toContain("run: 555");
+    });
+
+    it("keeps job-only log output when run id resolution would fail", async () => {
+      mockedGhExec.mockResolvedValue("job-specific log output\n");
+      mockedGhJson.mockRejectedValue(new Error("transient failure"));
+
+      const result = await runCommand(["view", "--log", "--job", "555"], ctx);
+
+      expect(result).toContain('run: "555"');
+      expect(result).toContain("job-specific log output");
     });
 
     it("passes --job to gh CLI in log-failed job-only mode", async () => {

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -288,15 +288,41 @@ describe("runCommand", () => {
       });
     });
 
-    it("rejects a trailing run id after --job", async () => {
-      await expect(
-        runCommand(["view", "--job", "502", "100"], ctx),
-      ).rejects.toMatchObject({
-        code: "VALIDATION_ERROR",
-        message: "Specify either a run ID or --job, not both",
+    it("accepts a trailing run id after --job", async () => {
+      mockedGhJson.mockResolvedValue({
+        databaseId: 100,
+        displayTitle: "CI Build",
+        status: "completed",
+        conclusion: "failure",
+        workflowName: "CI",
+        headBranch: "main",
+        createdAt: "2024-01-01T00:00:00Z",
+        jobs: [
+          {
+            databaseId: 502,
+            name: "test",
+            status: "completed",
+            conclusion: "failure",
+            steps: [],
+          },
+        ],
       });
-      expect(mockedGhExec).not.toHaveBeenCalled();
-      expect(mockedGhJson).not.toHaveBeenCalled();
+
+      const result = await runCommand(["view", "--job", "502", "100"], ctx);
+
+      expect(mockedGhJson).toHaveBeenCalledWith(
+        [
+          "run",
+          "view",
+          "100",
+          "--job",
+          "502",
+          "--json",
+          "databaseId,displayTitle,status,conclusion,workflowName,headBranch,createdAt,jobs",
+        ],
+        ctx,
+      );
+      expect(result).toContain("test");
     });
 
     it("accepts job-only view invocations", async () => {
@@ -342,15 +368,41 @@ describe("runCommand", () => {
       expect(result).toContain("Run tests");
     });
 
-    it("rejects combining a run id with --job", async () => {
-      await expect(
-        runCommand(["view", "100", "--job", "502"], ctx),
-      ).rejects.toMatchObject({
-        code: "VALIDATION_ERROR",
-        message: "Specify either a run ID or --job, not both",
+    it("accepts combining a run id with --job", async () => {
+      mockedGhJson.mockResolvedValue({
+        databaseId: 100,
+        displayTitle: "CI Build",
+        status: "completed",
+        conclusion: "failure",
+        workflowName: "CI",
+        headBranch: "main",
+        createdAt: "2024-01-01T00:00:00Z",
+        jobs: [
+          {
+            databaseId: 502,
+            name: "test",
+            status: "completed",
+            conclusion: "failure",
+            steps: [],
+          },
+        ],
       });
-      expect(mockedGhExec).not.toHaveBeenCalled();
-      expect(mockedGhJson).not.toHaveBeenCalled();
+
+      const result = await runCommand(["view", "100", "--job", "502"], ctx);
+
+      expect(mockedGhJson).toHaveBeenCalledWith(
+        [
+          "run",
+          "view",
+          "100",
+          "--job",
+          "502",
+          "--json",
+          "databaseId,displayTitle,status,conclusion,workflowName,headBranch,createdAt,jobs",
+        ],
+        ctx,
+      );
+      expect(result).toContain("test");
     });
 
     it("throws error when --job references nonexistent job", async () => {
@@ -436,15 +488,20 @@ describe("runCommand", () => {
       expect(result).toContain("error in step 3");
     });
 
-    it("rejects combining a run id with --job in log mode", async () => {
-      await expect(
-        runCommand(["view", "100", "--log", "--job", "555"], ctx),
-      ).rejects.toMatchObject({
-        code: "VALIDATION_ERROR",
-        message: "Specify either a run ID or --job, not both",
-      });
-      expect(mockedGhExec).not.toHaveBeenCalled();
+    it("accepts combining a run id with --job in log mode", async () => {
+      mockedGhExec.mockResolvedValue("job-specific log output\n");
+
+      const result = await runCommand(
+        ["view", "100", "--log", "--job", "555"],
+        ctx,
+      );
+
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["run", "view", "100", "--log", "--job", "555"],
+        ctx,
+      );
       expect(mockedGhJson).not.toHaveBeenCalled();
+      expect(result).toContain('run: "100"');
     });
 
     it("accepts job-only log invocations", async () => {
@@ -473,14 +530,13 @@ describe("runCommand", () => {
       expect(result).not.toContain("run: 555");
     });
 
-    it("keeps job-only log output when run id resolution would fail", async () => {
+    it("propagates job-only log run id resolution failures", async () => {
       mockedGhExec.mockResolvedValue("job-specific log output\n");
       mockedGhJson.mockRejectedValue(new Error("transient failure"));
 
-      const result = await runCommand(["view", "--log", "--job", "555"], ctx);
-
-      expect(result).toContain('run: "555"');
-      expect(result).toContain("job-specific log output");
+      await expect(
+        runCommand(["view", "--log", "--job", "555"], ctx),
+      ).rejects.toThrow("transient failure");
     });
 
     it("passes --job to gh CLI in log-failed job-only mode", async () => {


### PR DESCRIPTION
## Summary
- add and document job-level `run view` support, including job-only and log-oriented usage, so the command can target workflow jobs as well as full runs
- tighten parsing and validation around `--job` and related flags to handle selector ambiguity, invalid values, and unsupported filter combinations more predictably
- preserve correct job and log output when resolving run metadata fails, incorporating the review-driven fixes across the branch

## Risk Assessment

⚠️ Medium: The change is mostly well-covered, but the new mixed run-id plus job-id path is semantically ambiguous against the underlying `gh` CLI and can produce misleading run metadata.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

✅ **Rebase** - passed
⚠️ **Review** - 1 warning
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 2 warnings
- ⚠️ `src/commands/run.ts:136` - `viewRun` derives the run ID by filtering out only `--*` tokens, so `gh-axi run view --job 502 100` misparses `502` as the run ID because the `--job` value remains in `positionals`. This makes the new `--job` flag order-sensitive in a way users typically do not expect from CLI flags.
- ⚠️ `src/commands/run.ts:164` - When `--job` is provided but `run.jobs` is empty or omitted, the function skips the whole job-handling block and returns only the run detail instead of failing with `Job <id> not found`. That silently ignores the requested job selector and can mislead callers into thinking the filter was applied.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `src/commands/run.ts:153` - `viewRun` requires a run ID before it checks `--job`, so job-only invocations like `gh-axi run view --job 456 --log` fail even though upstream `gh run view` supports addressing a job directly. Decide whether job-only mode should be supported here or explicitly document that `--job` is only a filter on top of `view <run-id>`.

**Round 3** (user-fix) - found 2 warnings
- ⚠️ `src/commands/run.ts:149` - `takeFlag()` will treat the next token as a value even when it is another flag, so inputs like `gh-axi run view 123 --job --log` or `--conclusion --job 5` are misparsed and fall through to confusing downstream `gh` errors instead of a local `VALIDATION_ERROR`.
- ⚠️ `src/commands/run.ts:167` - In job-only log mode, `wrapLogOutput(id ?? jobFlag!, ...)` writes the job ID into `run_log.run`; consumers reading that field as a workflow run ID will misidentify the resource.

**Round 4** (auto-fix) - found 2 warnings
- ⚠️ `src/commands/run.ts:170` - When a run id and `--job` are both supplied, `gh run view` ignores the run id and resolves the job's owning run instead, but this wrapper drops that warning and proceeds as if both selectors were honored. `gh-axi run view 100 --job 555` can therefore return details for a different run with no indication that `100` was ignored.
- ⚠️ `src/commands/run.ts:177` - `wrapLogOutput(id ?? jobFlag!, ...)` now writes the job id into `run_log.run` for job-only requests, and writes the user-supplied run id even when `gh` may have ignored it because `--job` was present. Consumers treating `run_log.run` as an actual run identifier will get misleading metadata.

**Round 5** (user-fix) - found 2 warnings
- ⚠️ `src/commands/run.ts:235` - `--conclusion` is accepted together with `--job`, but the job-only branch ignores that filter entirely and always renders the selected job. Commands like `gh-axi run view --job 502 --conclusion success` therefore silently behave as if the filter was never passed.
- ⚠️ `src/commands/run.ts:201` - Job-only log mode performs an extra `gh run view --job ... --json databaseId` lookup after `ghExec` has already fetched the log. If that second request fails transiently, the command throws and discards an otherwise successful log result, adding a new failure mode to `view --log/--log-failed --job`.

**Round 6** (auto-fix) - found 2 warnings
- ⚠️ `src/commands/run.ts:206` - `viewRun` now rejects `gh-axi run view <run-id> --job <job-id>`, even though the wrapped `gh run view [<run-id>] --job <job-id>` form is supported by the underlying CLI; if callers use the explicit run+job selector to disambiguate context, this change turns a valid invocation into a validation error.
- ⚠️ `src/commands/run.ts:149` - `resolveLogEnvelopeRunId` swallows every failure from run-id resolution and substitutes the job id into the `run_log.run` field, so transient API/auth errors can silently emit mislabeled metadata that downstream consumers may treat as a real run id.

**Round 7** (user-fix) - found 1 warning
- ⚠️ `src/commands/run.ts:149` - `view --log/--log-failed --job <id>` now does a second `gh run view --json databaseId` lookup after the log fetch succeeds, and any failure in that follow-up lookup rejects the whole command and drops the log output. Preserve the fetched logs by falling back when run-id resolution fails instead of treating the metadata lookup as fatal.

**Round 8** (user-fix) - found 1 warning
- ⚠️ `src/commands/run.ts:214` - `view` now accepts `<run-id> --job <job-id>`, but upstream `gh run view` ignores the run id whenever `--job` is present. Because this wrapper still passes both selectors and then treats the supplied run id as authoritative, mixed-selector calls can return/log a different run than the caller asked for and stamp log envelopes with the wrong `run` value. Reject the combination or resolve and verify the actual run id instead.

</details>
