### PR TITLE
chore: update axi-sdk-js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0",
-        "axi-sdk-js": "^0.1.4"
+        "axi-sdk-js": "^0.1.5"
       },
       "bin": {
         "gh-axi": "dist/bin/gh-axi.js"
@@ -1460,9 +1460,9 @@
       }
     },
     "node_modules/axi-sdk-js": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.4.tgz",
-      "integrity": "sha512-FCIxUuNSixwuxdxqg5wgsnh8Rb19NVw/+drHb4j3LTXnqJtSIEqZgj/75469FxSd5JBDEpMmwq8eYUc4QrqTxQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/axi-sdk-js/-/axi-sdk-js-0.1.5.tgz",
+      "integrity": "sha512-IOmKj+Wuw1wz4wu1TP5unlnVR0aW/lzp+XIU1NQxvWSqoxsH5J9IgPdC3hOAo5UX/EYk7XQpzq9BJDU1k/Ekrg==",
       "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@toon-format/toon": "^2.1.0",
-    "axi-sdk-js": "^0.1.4"
+    "axi-sdk-js": "^0.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
- Updates the `axi-sdk-js` dependency to `0.1.5` in the npm package manifest.
- Refreshes `package-lock.json` so the lockfile matches the dependency bump.
- Branch pipeline passed for rebase, review, test, document, lint, and push checks.

## Risk Assessment

✅ Low: The branch only updates axi-sdk-js from 0.1.4 to 0.1.5 in package metadata and the lockfile, with a small upstream hook command portability change and no substantiated merge-blocking issues in the changed files.

## Testing

- Summary: Exercised the updated SDK through focused CLI/runtime tests, all existing Vitest tests, and real dev CLI help dispatch; everything passed after using the local nvm Node 22 toolchain.
- `PATH=/Users/kunchen/.nvm/versions/node/v22.14.0/bin:$PATH npm test -- test/cli.test.ts test/cli-entrypoint.test.ts test/errors.test.ts`
- `PATH=/Users/kunchen/.nvm/versions/node/v22.14.0/bin:$PATH npm test`
- `PATH=/Users/kunchen/.nvm/versions/node/v22.14.0/bin:$PATH GH_AXI_DISABLE_HOOKS=1 npm run dev -- --help`
- `PATH=/Users/kunchen/.nvm/versions/node/v22.14.0/bin:$PATH GH_AXI_DISABLE_HOOKS=1 npm run dev -- api --help`
- Outcome: ✅ passed across 1 run (3m23s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `PATH=/Users/kunchen/.nvm/versions/node/v22.14.0/bin:$PATH npm test -- test/cli.test.ts test/cli-entrypoint.test.ts test/errors.test.ts`
- `PATH=/Users/kunchen/.nvm/versions/node/v22.14.0/bin:$PATH npm test`
- `PATH=/Users/kunchen/.nvm/versions/node/v22.14.0/bin:$PATH GH_AXI_DISABLE_HOOKS=1 npm run dev -- --help`
- `PATH=/Users/kunchen/.nvm/versions/node/v22.14.0/bin:$PATH GH_AXI_DISABLE_HOOKS=1 npm run dev -- api --help`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
