### PR TITLE
fix(commands): render PR reviews with inline comments

### DIFF
--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -1,12 +1,12 @@
-import { encode } from '@toon-format/toon';
-import type { RepoContext } from '../context.js';
-import { ghJson, ghExec, ghRaw } from '../gh.js';
-import { AxiError } from '../errors.js';
-import { truncateBody } from '../body.js';
-import { formatCountLine } from '../format.js';
-import { getSuggestions } from '../suggestions.js';
-import { takeFlag, takeBoolFlag, takeNumber } from '../args.js';
-import { parseFields, type ExtraFieldSpec } from '../fields.js';
+import { encode } from "@toon-format/toon";
+import type { RepoContext } from "../context.js";
+import { ghJson, ghExec, ghRaw } from "../gh.js";
+import { AxiError } from "../errors.js";
+import { truncateBody } from "../body.js";
+import { formatCountLine } from "../format.js";
+import { getSuggestions } from "../suggestions.js";
+import { takeFlag, takeBoolFlag, takeNumber } from "../args.js";
+import { parseFields, type ExtraFieldSpec } from "../fields.js";
 import {
   field,
   pluck,
@@ -22,7 +22,7 @@ import {
   renderError,
   renderOutput,
   type FieldDef,
-} from '../toon.js';
+} from "../toon.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -85,27 +85,46 @@ interface RevertResult {
 // ---------------------------------------------------------------------------
 
 /** Classify a CI check run into a simple status category. */
-function classifyCheck(c: CheckRun): 'pass' | 'fail' | 'skip' | 'pending' {
-  const conc = (c.conclusion ?? '').toUpperCase();
-  const st = (c.state ?? c.status ?? '').toUpperCase();
-  if (conc === 'SUCCESS' || conc === 'NEUTRAL') return 'pass';
-  if (conc === 'FAILURE' || conc === 'TIMED_OUT' || conc === 'ACTION_REQUIRED') return 'fail';
-  if (conc === 'SKIPPED' || conc === 'CANCELLED' || st === 'EXPECTED' || st === 'NEUTRAL') return 'skip';
-  return 'pending';
+function classifyCheck(c: CheckRun): "pass" | "fail" | "skip" | "pending" {
+  const conc = (c.conclusion ?? "").toUpperCase();
+  const st = (c.state ?? c.status ?? "").toUpperCase();
+  if (conc === "SUCCESS" || conc === "NEUTRAL") return "pass";
+  if (conc === "FAILURE" || conc === "TIMED_OUT" || conc === "ACTION_REQUIRED")
+    return "fail";
+  if (
+    conc === "SKIPPED" ||
+    conc === "CANCELLED" ||
+    st === "EXPECTED" ||
+    st === "NEUTRAL"
+  )
+    return "skip";
+  return "pending";
 }
 
-function prRestPath(ctx: RepoContext | undefined, num: number, suffix: string): string {
-  const repoPath = ctx ? `repos/${ctx.owner}/${ctx.name}` : 'repos/{owner}/{repo}';
+function prRestPath(
+  ctx: RepoContext | undefined,
+  num: number,
+  suffix: string,
+): string {
+  const repoPath = ctx
+    ? `repos/${ctx.owner}/${ctx.name}`
+    : "repos/{owner}/{repo}";
   return `${repoPath}/pulls/${num}/${suffix}`;
 }
 
 function flattenPaginated<T>(items: T[] | T[][]): T[] {
-  if (items.length > 0 && Array.isArray(items[0])) return (items as T[][]).flat();
+  if (items.length > 0 && Array.isArray(items[0]))
+    return (items as T[][]).flat();
   return items as T[];
 }
 
 async function ghApiPaginatedArray<T>(path: string): Promise<T[]> {
-  const pages = await ghJson<T[] | T[][]>(['api', path, '--paginate', '--slurp']);
+  const pages = await ghJson<T[] | T[][]>([
+    "api",
+    path,
+    "--paginate",
+    "--slurp",
+  ]);
   return flattenPaginated(pages);
 }
 
@@ -114,71 +133,87 @@ async function ghApiPaginatedArray<T>(path: string): Promise<T[]> {
 // ---------------------------------------------------------------------------
 
 const REVIEW_MAP: Record<string, string> = {
-  APPROVED: 'approved',
-  CHANGES_REQUESTED: 'changes_requested',
-  REVIEW_REQUIRED: 'required',
+  APPROVED: "approved",
+  CHANGES_REQUESTED: "changes_requested",
+  REVIEW_REQUIRED: "required",
 };
 
 const REVIEW_STATE_MAP: Record<string, string> = {
-  APPROVED: 'approved',
-  CHANGES_REQUESTED: 'changes_requested',
-  COMMENTED: 'commented',
-  DISMISSED: 'dismissed',
-  PENDING: 'pending',
+  APPROVED: "approved",
+  CHANGES_REQUESTED: "changes_requested",
+  COMMENTED: "commented",
+  DISMISSED: "dismissed",
+  PENDING: "pending",
 };
 
 const listSchema: FieldDef[] = [
-  field('number'),
-  field('title'),
-  lower('state'),
-  pluck('author', 'login', 'author'),
-  boolYesNo('isDraft', 'draft'),
-  mapEnum('reviewDecision', REVIEW_MAP, 'none', 'review'),
+  field("number"),
+  field("title"),
+  lower("state"),
+  pluck("author", "login", "author"),
+  boolYesNo("isDraft", "draft"),
+  mapEnum("reviewDecision", REVIEW_MAP, "none", "review"),
 ];
 
-const LIST_JSON_FIELDS = 'number,title,state,author,isDraft,reviewDecision';
+const LIST_JSON_FIELDS = "number,title,state,author,isDraft,reviewDecision";
 
 const PR_LIST_EXTRA_FIELDS: Record<string, ExtraFieldSpec> = {
-  body: { jsonKey: 'body', def: field('body') },
-  createdAt: { jsonKey: 'createdAt', def: relativeTime('createdAt', 'created') },
-  labels: { jsonKey: 'labels', def: joinArray('labels', 'name', 'labels') },
-  milestone: { jsonKey: 'milestone', def: pluck('milestone', 'title', 'milestone') },
-  mergedAt: { jsonKey: 'mergedAt', def: relativeTime('mergedAt', 'merged_at') },
-  url: { jsonKey: 'url', def: field('url') },
+  body: { jsonKey: "body", def: field("body") },
+  createdAt: {
+    jsonKey: "createdAt",
+    def: relativeTime("createdAt", "created"),
+  },
+  labels: { jsonKey: "labels", def: joinArray("labels", "name", "labels") },
+  milestone: {
+    jsonKey: "milestone",
+    def: pluck("milestone", "title", "milestone"),
+  },
+  mergedAt: { jsonKey: "mergedAt", def: relativeTime("mergedAt", "merged_at") },
+  url: { jsonKey: "url", def: field("url") },
 };
 
 const viewSchema: FieldDef[] = [
-  field('number'),
-  field('title'),
-  lower('state'),
-  pluck('author', 'login', 'author'),
-  boolYesNo('isDraft', 'draft'),
-  custom('merged', (item: PrItem) => {
-    if ((item.state ?? '').toUpperCase() === 'MERGED') return item.mergedAt ?? 'yes';
-    return 'no';
+  field("number"),
+  field("title"),
+  lower("state"),
+  pluck("author", "login", "author"),
+  boolYesNo("isDraft", "draft"),
+  custom("merged", (item: PrItem) => {
+    if ((item.state ?? "").toUpperCase() === "MERGED")
+      return item.mergedAt ?? "yes";
+    return "no";
   }),
-  custom('checks', (item: PrItem) => {
+  custom("checks", (item: PrItem) => {
     const checks = item.statusCheckRollup;
-    if (!Array.isArray(checks) || checks.length === 0) return '0 passed, 0 failed — this PR has no CI checks configured';
-    const passed = checks.filter((c: CheckRun) => classifyCheck(c) === 'pass').length;
-    const failed = checks.filter((c: CheckRun) => classifyCheck(c) === 'fail').length;
-    const skipped = checks.filter((c: CheckRun) => classifyCheck(c) === 'skip').length;
+    if (!Array.isArray(checks) || checks.length === 0)
+      return "0 passed, 0 failed — this PR has no CI checks configured";
+    const passed = checks.filter(
+      (c: CheckRun) => classifyCheck(c) === "pass",
+    ).length;
+    const failed = checks.filter(
+      (c: CheckRun) => classifyCheck(c) === "fail",
+    ).length;
+    const skipped = checks.filter(
+      (c: CheckRun) => classifyCheck(c) === "skip",
+    ).length;
     const parts = [`${passed} passed`, `${failed} failed`];
     if (skipped > 0) parts.push(`${skipped} skipped`);
     parts.push(`${checks.length} total`);
-    return parts.join(', ');
+    return parts.join(", ");
   }),
-  custom('body', (item: PrItem) => truncateBody(item.body, 500)),
+  custom("body", (item: PrItem) => truncateBody(item.body, 500)),
 ];
 
-const viewSchemaFull: FieldDef[] = viewSchema.map(f =>
-  'as' in f && f.as === 'body'
-    ? custom('body', (item: PrItem) => typeof item.body === 'string' ? item.body : '')
+const viewSchemaFull: FieldDef[] = viewSchema.map((f) =>
+  "as" in f && f.as === "body"
+    ? custom("body", (item: PrItem) =>
+        typeof item.body === "string" ? item.body : "",
+      )
     : f,
 );
 
 const VIEW_JSON_FIELDS =
-  'number,title,state,author,isDraft,mergedAt,statusCheckRollup,body,comments,reviews';
+  "number,title,state,author,isDraft,mergedAt,statusCheckRollup,body,comments,reviews";
 
 // ---------------------------------------------------------------------------
 // Help
@@ -212,28 +247,46 @@ examples:
 // ---------------------------------------------------------------------------
 
 async function prList(args: string[], ctx?: RepoContext): Promise<string> {
-  if (args.includes('--search')) {
-    throw new AxiError('pr list does not support --search. Use `gh-axi search prs "<query>"` instead for full-text search with total counts.', 'VALIDATION_ERROR');
+  if (args.includes("--search")) {
+    throw new AxiError(
+      'pr list does not support --search. Use `gh-axi search prs "<query>"` instead for full-text search with total counts.',
+      "VALIDATION_ERROR",
+    );
   }
-  const fieldsArg = takeFlag(args, '--fields');
-  const { extraDefs, extraJsonKeys } = parseFields(fieldsArg, PR_LIST_EXTRA_FIELDS);
-  const state = takeFlag(args, '--state') ?? 'open';
-  const label = takeFlag(args, '--label');
-  const assignee = takeFlag(args, '--assignee');
-  const author = takeFlag(args, '--author');
-  const base = takeFlag(args, '--base');
-  const head = takeFlag(args, '--head');
-  const draft = takeBoolFlag(args, '--draft');
-  const limit = takeFlag(args, '--limit') ?? '30';
+  const fieldsArg = takeFlag(args, "--fields");
+  const { extraDefs, extraJsonKeys } = parseFields(
+    fieldsArg,
+    PR_LIST_EXTRA_FIELDS,
+  );
+  const state = takeFlag(args, "--state") ?? "open";
+  const label = takeFlag(args, "--label");
+  const assignee = takeFlag(args, "--assignee");
+  const author = takeFlag(args, "--author");
+  const base = takeFlag(args, "--base");
+  const head = takeFlag(args, "--head");
+  const draft = takeBoolFlag(args, "--draft");
+  const limit = takeFlag(args, "--limit") ?? "30";
 
-  const jsonFields = extraJsonKeys.length > 0 ? LIST_JSON_FIELDS + ',' + extraJsonKeys.join(',') : LIST_JSON_FIELDS;
-  const ghArgs = ['pr', 'list', '--json', jsonFields, '--state', state, '--limit', limit];
-  if (label) ghArgs.push('--label', label);
-  if (assignee) ghArgs.push('--assignee', assignee);
-  if (author) ghArgs.push('--author', author);
-  if (base) ghArgs.push('--base', base);
-  if (head) ghArgs.push('--head', head);
-  if (draft) ghArgs.push('--draft');
+  const jsonFields =
+    extraJsonKeys.length > 0
+      ? LIST_JSON_FIELDS + "," + extraJsonKeys.join(",")
+      : LIST_JSON_FIELDS;
+  const ghArgs = [
+    "pr",
+    "list",
+    "--json",
+    jsonFields,
+    "--state",
+    state,
+    "--limit",
+    limit,
+  ];
+  if (label) ghArgs.push("--label", label);
+  if (assignee) ghArgs.push("--assignee", assignee);
+  if (author) ghArgs.push("--author", author);
+  if (base) ghArgs.push("--base", base);
+  if (head) ghArgs.push("--head", head);
+  if (draft) ghArgs.push("--draft");
 
   const items = await ghJson<PrItem[]>(ghArgs, ctx);
   const isEmpty = items.length === 0;
@@ -244,52 +297,66 @@ async function prList(args: string[], ctx?: RepoContext): Promise<string> {
   if (items.length === limitNum && ctx) {
     try {
       const ghState = state.toUpperCase();
-      const statesFilter = ghState === 'ALL' ? '' : `states:[${ghState === 'CLOSED' ? 'CLOSED,MERGED' : ghState}]`;
+      const statesFilter =
+        ghState === "ALL"
+          ? ""
+          : `states:[${ghState === "CLOSED" ? "CLOSED,MERGED" : ghState}]`;
       const query = `{ repository(owner:"${ctx.owner}", name:"${ctx.name}") { pullRequests(${statesFilter}) { totalCount } } }`;
-      const gqlResult = await ghRaw(['api', 'graphql', '-f', `query=${query}`]);
+      const gqlResult = await ghRaw(["api", "graphql", "-f", `query=${query}`]);
       if (gqlResult.exitCode === 0) {
         const parsed = JSON.parse(gqlResult.stdout);
-        totalCount = parsed?.data?.repository?.pullRequests?.totalCount ?? undefined;
+        totalCount =
+          parsed?.data?.repository?.pullRequests?.totalCount ?? undefined;
       }
     } catch {
       // fall back to limit-based message
     }
   }
-  const countLine = formatCountLine({ count: items.length, limit: limitNum, totalCount });
-  const extendedSchema = extraDefs.length > 0 ? [...listSchema, ...extraDefs] : listSchema;
+  const countLine = formatCountLine({
+    count: items.length,
+    limit: limitNum,
+    totalCount,
+  });
+  const extendedSchema =
+    extraDefs.length > 0 ? [...listSchema, ...extraDefs] : listSchema;
 
   return renderOutput([
     countLine,
-    renderList('pull_requests', items, extendedSchema),
-    renderHelp(getSuggestions({ domain: 'pr', action: 'list', isEmpty, repo: ctx })),
+    renderList("pull_requests", items, extendedSchema),
+    renderHelp(
+      getSuggestions({ domain: "pr", action: "list", isEmpty, repo: ctx }),
+    ),
   ]);
 }
 
 async function prView(args: string[], ctx?: RepoContext): Promise<string> {
-  const includeComments = takeBoolFlag(args, '--comments');
-  const includeReviews = takeBoolFlag(args, '--reviews');
-  const full = takeBoolFlag(args, '--full');
-  const num = takeNumber(args, 'PR');
+  const includeComments = takeBoolFlag(args, "--comments");
+  const includeReviews = takeBoolFlag(args, "--reviews");
+  const full = takeBoolFlag(args, "--full");
+  const num = takeNumber(args, "PR");
 
   // Always fetch comments + review summaries (for count or full rendering)
-  const ghArgs = ['pr', 'view', String(num), '--json', VIEW_JSON_FIELDS];
+  const ghArgs = ["pr", "view", String(num), "--json", VIEW_JSON_FIELDS];
   const pr = await ghJson<PrItem>(ghArgs, ctx);
 
   const schema = [...(full ? viewSchemaFull : viewSchema)];
   if (includeComments && Array.isArray(pr.comments)) {
     schema.push(
-      custom('comments', (item: PrItem) =>
+      custom("comments", (item: PrItem) =>
         (item.comments ?? []).map((c: PrComment) => ({
-          author: c.author?.login ?? 'unknown',
-          body: c.body ?? '',
-          created: c.createdAt ?? '',
+          author: c.author?.login ?? "unknown",
+          body: c.body ?? "",
+          created: c.createdAt ?? "",
         })),
       ),
     );
   } else {
     const commentCount = Array.isArray(pr.comments) ? pr.comments.length : 0;
     schema.push(
-      custom('comment_count', () => `${commentCount} — use --comments to see full comments`),
+      custom(
+        "comment_count",
+        () => `${commentCount} — use --comments to see full comments`,
+      ),
     );
   }
 
@@ -298,38 +365,41 @@ async function prView(args: string[], ctx?: RepoContext): Promise<string> {
     // the numeric review IDs on inline review comments. Fetch both via REST
     // so we can correlate inline comments back to their parent review.
     const reviews = await ghApiPaginatedArray<PrReview>(
-      prRestPath(ctx, num, 'reviews'),
+      prRestPath(ctx, num, "reviews"),
     );
     let inlineComments: PrReviewComment[] = [];
     if (reviews.length > 0) {
       inlineComments = await ghApiPaginatedArray<PrReviewComment>(
-        prRestPath(ctx, num, 'comments'),
+        prRestPath(ctx, num, "comments"),
       );
     }
     const commentsByReview = new Map<number, PrReviewComment[]>();
     for (const c of inlineComments) {
-      if (typeof c.pull_request_review_id === 'number') {
+      if (typeof c.pull_request_review_id === "number") {
         const list = commentsByReview.get(c.pull_request_review_id) ?? [];
         list.push(c);
         commentsByReview.set(c.pull_request_review_id, list);
       }
     }
     schema.push(
-      custom('reviews', () =>
+      custom("reviews", () =>
         reviews.map((r) => {
-          const stateUpper = (r.state ?? '').toUpperCase();
+          const stateUpper = (r.state ?? "").toUpperCase();
           const inline = commentsByReview.get(r.id) ?? [];
           return {
-            author: r.user?.login ?? 'unknown',
-            state: REVIEW_STATE_MAP[stateUpper] ?? stateUpper.toLowerCase() ?? 'unknown',
-            submitted: r.submitted_at ?? '',
-            body: r.body ?? '',
+            author: r.user?.login ?? "unknown",
+            state:
+              REVIEW_STATE_MAP[stateUpper] ??
+              stateUpper.toLowerCase() ??
+              "unknown",
+            submitted: r.submitted_at ?? "",
+            body: r.body ?? "",
             inline_comments: inline.map((c) => ({
-              author: c.user?.login ?? 'unknown',
-              path: c.path ?? '',
+              author: c.user?.login ?? "unknown",
+              path: c.path ?? "",
               line: c.line ?? c.original_line ?? null,
-              body: c.body ?? '',
-              created: c.created_at ?? '',
+              body: c.body ?? "",
+              created: c.created_at ?? "",
             })),
           };
         }),
@@ -338,198 +408,251 @@ async function prView(args: string[], ctx?: RepoContext): Promise<string> {
   } else {
     const reviewCount = Array.isArray(pr.reviews) ? pr.reviews.length : 0;
     schema.push(
-      custom('review_count', () => `${reviewCount} — use --reviews to see full reviews`),
+      custom(
+        "review_count",
+        () => `${reviewCount} — use --reviews to see full reviews`,
+      ),
     );
   }
 
-  return renderOutput([
-    renderDetail('pull_request', pr, schema),
-  ]);
+  return renderOutput([renderDetail("pull_request", pr, schema)]);
 }
 
 async function prCreate(args: string[], ctx?: RepoContext): Promise<string> {
-  const title = takeFlag(args, '--title');
-  if (!title) throw new AxiError('--title is required', 'VALIDATION_ERROR');
-  const body = takeFlag(args, '--body');
-  const base = takeFlag(args, '--base');
-  const head = takeFlag(args, '--head');
-  const draft = takeBoolFlag(args, '--draft');
-  const assignee = takeFlag(args, '--assignee');
-  const reviewer = takeFlag(args, '--reviewer');
-  const label = takeFlag(args, '--label');
-  const milestone = takeFlag(args, '--milestone');
-  const project = takeFlag(args, '--project');
+  const title = takeFlag(args, "--title");
+  if (!title) throw new AxiError("--title is required", "VALIDATION_ERROR");
+  const body = takeFlag(args, "--body");
+  const base = takeFlag(args, "--base");
+  const head = takeFlag(args, "--head");
+  const draft = takeBoolFlag(args, "--draft");
+  const assignee = takeFlag(args, "--assignee");
+  const reviewer = takeFlag(args, "--reviewer");
+  const label = takeFlag(args, "--label");
+  const milestone = takeFlag(args, "--milestone");
+  const project = takeFlag(args, "--project");
 
-  const ghArgs = ['pr', 'create', '--title', title];
-  if (body) ghArgs.push('--body', body);
-  if (base) ghArgs.push('--base', base);
-  if (head) ghArgs.push('--head', head);
-  if (draft) ghArgs.push('--draft');
-  if (assignee) ghArgs.push('--assignee', assignee);
-  if (reviewer) ghArgs.push('--reviewer', reviewer);
-  if (label) ghArgs.push('--label', label);
-  if (milestone) ghArgs.push('--milestone', milestone);
-  if (project) ghArgs.push('--project', project);
+  const ghArgs = ["pr", "create", "--title", title];
+  if (body) ghArgs.push("--body", body);
+  if (base) ghArgs.push("--base", base);
+  if (head) ghArgs.push("--head", head);
+  if (draft) ghArgs.push("--draft");
+  if (assignee) ghArgs.push("--assignee", assignee);
+  if (reviewer) ghArgs.push("--reviewer", reviewer);
+  if (label) ghArgs.push("--label", label);
+  if (milestone) ghArgs.push("--milestone", milestone);
+  if (project) ghArgs.push("--project", project);
 
   const stdout = await ghExec(ghArgs, ctx);
   // Parse PR number from URL: https://github.com/OWNER/REPO/pull/123
   const urlMatch = stdout.match(/\/pull\/(\d+)/);
   const num = urlMatch ? Number(urlMatch[1]) : undefined;
-  const url = stdout.trim().split('\n').pop()?.trim() ?? '';
+  const url = stdout.trim().split("\n").pop()?.trim() ?? "";
 
   return renderOutput([
-    renderDetail('created', { number: num ?? url, url }, [field('number'), field('url')]),
-    renderHelp(getSuggestions({ domain: 'pr', action: 'create', id: num, repo: ctx })),
+    renderDetail("created", { number: num ?? url, url }, [
+      field("number"),
+      field("url"),
+    ]),
+    renderHelp(
+      getSuggestions({ domain: "pr", action: "create", id: num, repo: ctx }),
+    ),
   ]);
 }
 
 async function prEdit(args: string[], ctx?: RepoContext): Promise<string> {
-  const num = takeNumber(args, 'PR');
-  const title = takeFlag(args, '--title');
-  const body = takeFlag(args, '--body');
-  const addLabel = takeFlag(args, '--add-label');
-  const removeLabel = takeFlag(args, '--remove-label');
-  const addAssignee = takeFlag(args, '--add-assignee');
-  const removeAssignee = takeFlag(args, '--remove-assignee');
-  const addReviewer = takeFlag(args, '--add-reviewer');
-  const removeReviewer = takeFlag(args, '--remove-reviewer');
-  const milestone = takeFlag(args, '--milestone');
-  const base = takeFlag(args, '--base');
+  const num = takeNumber(args, "PR");
+  const title = takeFlag(args, "--title");
+  const body = takeFlag(args, "--body");
+  const addLabel = takeFlag(args, "--add-label");
+  const removeLabel = takeFlag(args, "--remove-label");
+  const addAssignee = takeFlag(args, "--add-assignee");
+  const removeAssignee = takeFlag(args, "--remove-assignee");
+  const addReviewer = takeFlag(args, "--add-reviewer");
+  const removeReviewer = takeFlag(args, "--remove-reviewer");
+  const milestone = takeFlag(args, "--milestone");
+  const base = takeFlag(args, "--base");
 
-  const ghArgs = ['pr', 'edit', String(num)];
-  if (title) ghArgs.push('--title', title);
-  if (body) ghArgs.push('--body', body);
-  if (addLabel) ghArgs.push('--add-label', addLabel);
-  if (removeLabel) ghArgs.push('--remove-label', removeLabel);
-  if (addAssignee) ghArgs.push('--add-assignee', addAssignee);
-  if (removeAssignee) ghArgs.push('--remove-assignee', removeAssignee);
-  if (addReviewer) ghArgs.push('--add-reviewer', addReviewer);
-  if (removeReviewer) ghArgs.push('--remove-reviewer', removeReviewer);
-  if (milestone) ghArgs.push('--milestone', milestone);
-  if (base) ghArgs.push('--base', base);
+  const ghArgs = ["pr", "edit", String(num)];
+  if (title) ghArgs.push("--title", title);
+  if (body) ghArgs.push("--body", body);
+  if (addLabel) ghArgs.push("--add-label", addLabel);
+  if (removeLabel) ghArgs.push("--remove-label", removeLabel);
+  if (addAssignee) ghArgs.push("--add-assignee", addAssignee);
+  if (removeAssignee) ghArgs.push("--remove-assignee", removeAssignee);
+  if (addReviewer) ghArgs.push("--add-reviewer", addReviewer);
+  if (removeReviewer) ghArgs.push("--remove-reviewer", removeReviewer);
+  if (milestone) ghArgs.push("--milestone", milestone);
+  if (base) ghArgs.push("--base", base);
 
   await ghExec(ghArgs, ctx);
   return renderOutput([
-    renderDetail('edited', { number: num, status: 'ok' }, [field('number'), field('status')]),
-    renderHelp(getSuggestions({ domain: 'pr', action: 'edit', id: num, repo: ctx })),
+    renderDetail("edited", { number: num, status: "ok" }, [
+      field("number"),
+      field("status"),
+    ]),
+    renderHelp(
+      getSuggestions({ domain: "pr", action: "edit", id: num, repo: ctx }),
+    ),
   ]);
 }
 
 async function prClose(args: string[], ctx?: RepoContext): Promise<string> {
-  const comment = takeFlag(args, '--comment');
-  const num = takeNumber(args, 'PR');
+  const comment = takeFlag(args, "--comment");
+  const num = takeNumber(args, "PR");
 
   // Idempotent: check current state
-  const pr = await ghJson<Pick<PrItem, 'state'>>(['pr', 'view', String(num), '--json', 'state'], ctx);
-  const state = (pr.state ?? '').toUpperCase();
-  if (state === 'CLOSED' || state === 'MERGED') {
+  const pr = await ghJson<Pick<PrItem, "state">>(
+    ["pr", "view", String(num), "--json", "state"],
+    ctx,
+  );
+  const state = (pr.state ?? "").toUpperCase();
+  if (state === "CLOSED" || state === "MERGED") {
     return renderOutput([
-      renderDetail('pull_request', { number: num, state: state.toLowerCase(), already: true }, [
-        field('number'),
-        field('state'),
-        field('already'),
-      ]),
-      renderHelp(getSuggestions({ domain: 'pr', action: 'close', id: num, repo: ctx })),
+      renderDetail(
+        "pull_request",
+        { number: num, state: state.toLowerCase(), already: true },
+        [field("number"), field("state"), field("already")],
+      ),
+      renderHelp(
+        getSuggestions({ domain: "pr", action: "close", id: num, repo: ctx }),
+      ),
     ]);
   }
 
-  const ghArgs = ['pr', 'close', String(num)];
-  if (comment) ghArgs.push('--comment', comment);
+  const ghArgs = ["pr", "close", String(num)];
+  if (comment) ghArgs.push("--comment", comment);
   await ghExec(ghArgs, ctx);
 
   return renderOutput([
-    renderDetail('closed', { number: num, status: 'ok' }, [field('number'), field('status')]),
-    renderHelp(getSuggestions({ domain: 'pr', action: 'close', id: num, repo: ctx })),
+    renderDetail("closed", { number: num, status: "ok" }, [
+      field("number"),
+      field("status"),
+    ]),
+    renderHelp(
+      getSuggestions({ domain: "pr", action: "close", id: num, repo: ctx }),
+    ),
   ]);
 }
 
 async function prMerge(args: string[], ctx?: RepoContext): Promise<string> {
-  const num = takeNumber(args, 'PR');
-  const method = takeFlag(args, '--method');
-  const auto = takeBoolFlag(args, '--auto');
-  const deleteBranch = takeBoolFlag(args, '--delete-branch');
-  const body = takeFlag(args, '--body');
-  const subject = takeFlag(args, '--subject');
+  const num = takeNumber(args, "PR");
+  const method = takeFlag(args, "--method");
+  const auto = takeBoolFlag(args, "--auto");
+  const deleteBranch = takeBoolFlag(args, "--delete-branch");
+  const body = takeFlag(args, "--body");
+  const subject = takeFlag(args, "--subject");
 
   // Idempotent: check if already merged
-  const pr = await ghJson<Pick<PrItem, 'state' | 'mergedBy' | 'mergedAt'>>(
-    ['pr', 'view', String(num), '--json', 'state,mergedBy,mergedAt'],
+  const pr = await ghJson<Pick<PrItem, "state" | "mergedBy" | "mergedAt">>(
+    ["pr", "view", String(num), "--json", "state,mergedBy,mergedAt"],
     ctx,
   );
-  if ((pr.state ?? '').toUpperCase() === 'MERGED') {
+  if ((pr.state ?? "").toUpperCase() === "MERGED") {
     return renderOutput([
-      renderDetail('pull_request', {
-        number: num,
-        state: 'merged',
-        merged_by: pr.mergedBy?.login ?? null,
-        merged_at: pr.mergedAt ?? null,
-      }, [field('number'), field('state'), field('merged_by'), field('merged_at')]),
-      renderHelp(getSuggestions({ domain: 'pr', action: 'merge', id: num, repo: ctx })),
+      renderDetail(
+        "pull_request",
+        {
+          number: num,
+          state: "merged",
+          merged_by: pr.mergedBy?.login ?? null,
+          merged_at: pr.mergedAt ?? null,
+        },
+        [
+          field("number"),
+          field("state"),
+          field("merged_by"),
+          field("merged_at"),
+        ],
+      ),
+      renderHelp(
+        getSuggestions({ domain: "pr", action: "merge", id: num, repo: ctx }),
+      ),
     ]);
   }
 
-  const ghArgs = ['pr', 'merge', String(num)];
-  if (method) ghArgs.push('--' + method);
-  if (auto) ghArgs.push('--auto');
-  if (deleteBranch) ghArgs.push('--delete-branch');
-  if (body) ghArgs.push('--body', body);
-  if (subject) ghArgs.push('--subject', subject);
+  const ghArgs = ["pr", "merge", String(num)];
+  if (method) ghArgs.push("--" + method);
+  if (auto) ghArgs.push("--auto");
+  if (deleteBranch) ghArgs.push("--delete-branch");
+  if (body) ghArgs.push("--body", body);
+  if (subject) ghArgs.push("--subject", subject);
 
   await ghExec(ghArgs, ctx);
 
   return renderOutput([
-    renderDetail('merged', { number: num, status: 'ok', method: method ?? 'default' }, [
-      field('number'),
-      field('status'),
-      field('method'),
-    ]),
-    renderHelp(getSuggestions({ domain: 'pr', action: 'merge', id: num, repo: ctx })),
+    renderDetail(
+      "merged",
+      { number: num, status: "ok", method: method ?? "default" },
+      [field("number"), field("status"), field("method")],
+    ),
+    renderHelp(
+      getSuggestions({ domain: "pr", action: "merge", id: num, repo: ctx }),
+    ),
   ]);
 }
 
 async function prReview(args: string[], ctx?: RepoContext): Promise<string> {
-  const num = takeNumber(args, 'PR');
-  const approve = takeBoolFlag(args, '--approve');
-  const requestChanges = takeBoolFlag(args, '--request-changes');
-  const commentFlag = takeBoolFlag(args, '--comment');
-  const body = takeFlag(args, '--body');
+  const num = takeNumber(args, "PR");
+  const approve = takeBoolFlag(args, "--approve");
+  const requestChanges = takeBoolFlag(args, "--request-changes");
+  const commentFlag = takeBoolFlag(args, "--comment");
+  const body = takeFlag(args, "--body");
 
-  const ghArgs = ['pr', 'review', String(num)];
-  if (approve) ghArgs.push('--approve');
-  else if (requestChanges) ghArgs.push('--request-changes');
-  else if (commentFlag) ghArgs.push('--comment');
-  if (body) ghArgs.push('--body', body);
+  const ghArgs = ["pr", "review", String(num)];
+  if (approve) ghArgs.push("--approve");
+  else if (requestChanges) ghArgs.push("--request-changes");
+  else if (commentFlag) ghArgs.push("--comment");
+  if (body) ghArgs.push("--body", body);
 
   await ghExec(ghArgs, ctx);
 
-  const action = approve ? 'approved' : requestChanges ? 'changes_requested' : 'commented';
+  const action = approve
+    ? "approved"
+    : requestChanges
+      ? "changes_requested"
+      : "commented";
   return renderOutput([
-    renderDetail('review', { number: num, action }, [field('number'), field('action')]),
-    renderHelp(getSuggestions({ domain: 'pr', action: 'review', id: num, repo: ctx })),
+    renderDetail("review", { number: num, action }, [
+      field("number"),
+      field("action"),
+    ]),
+    renderHelp(
+      getSuggestions({ domain: "pr", action: "review", id: num, repo: ctx }),
+    ),
   ]);
 }
 
 async function prChecks(args: string[], ctx?: RepoContext): Promise<string> {
-  const num = takeNumber(args, 'PR');
+  const num = takeNumber(args, "PR");
 
   // Use pr view --json statusCheckRollup instead of pr checks --json which
   // can error on PRs with unusual check data
-  const pr = await ghJson<Pick<PrItem, 'statusCheckRollup'>>(
-    ['pr', 'view', String(num), '--json', 'statusCheckRollup'],
+  const pr = await ghJson<Pick<PrItem, "statusCheckRollup">>(
+    ["pr", "view", String(num), "--json", "statusCheckRollup"],
     ctx,
   );
-  const checks: CheckRun[] = Array.isArray(pr.statusCheckRollup) ? pr.statusCheckRollup : [];
+  const checks: CheckRun[] = Array.isArray(pr.statusCheckRollup)
+    ? pr.statusCheckRollup
+    : [];
 
   if (checks.length === 0) {
     return renderOutput([
-      encode({ checks: '0 passed, 0 failed — this PR has no CI checks configured' }),
+      encode({
+        checks: "0 passed, 0 failed — this PR has no CI checks configured",
+      }),
     ]);
   }
 
   // Pre-compute summary counts so agents don't have to count rows
-  const passed = checks.filter((c: CheckRun) => classifyCheck(c) === 'pass').length;
-  const failed = checks.filter((c: CheckRun) => classifyCheck(c) === 'fail').length;
-  const skipped = checks.filter((c: CheckRun) => classifyCheck(c) === 'skip').length;
+  const passed = checks.filter(
+    (c: CheckRun) => classifyCheck(c) === "pass",
+  ).length;
+  const failed = checks.filter(
+    (c: CheckRun) => classifyCheck(c) === "fail",
+  ).length;
+  const skipped = checks.filter(
+    (c: CheckRun) => classifyCheck(c) === "skip",
+  ).length;
   const pending = checks.length - passed - failed - skipped;
 
   const summaryParts = [`${passed} passed`, `${failed} failed`];
@@ -538,23 +661,25 @@ async function prChecks(args: string[], ctx?: RepoContext): Promise<string> {
   summaryParts.push(`${checks.length} total`);
 
   const checksSchema: FieldDef[] = [
-    custom('name', (c: CheckRun) => c.name ?? c.context ?? 'check'),
-    custom('conclusion', (c: CheckRun) => classifyCheck(c)),
+    custom("name", (c: CheckRun) => c.name ?? c.context ?? "check"),
+    custom("conclusion", (c: CheckRun) => classifyCheck(c)),
   ];
 
   return renderOutput([
-    encode({ summary: summaryParts.join(', ') }),
-    renderList('checks', checks, checksSchema),
-    renderHelp(getSuggestions({ domain: 'pr', action: 'checks', id: num, repo: ctx })),
+    encode({ summary: summaryParts.join(", ") }),
+    renderList("checks", checks, checksSchema),
+    renderHelp(
+      getSuggestions({ domain: "pr", action: "checks", id: num, repo: ctx }),
+    ),
   ]);
 }
 
 const DIFF_TRUNCATE_LIMIT = 4000;
 
 async function prDiff(args: string[], ctx?: RepoContext): Promise<string> {
-  const full = takeBoolFlag(args, '--full');
-  const num = takeNumber(args, 'PR');
-  const diff = await ghExec(['pr', 'diff', String(num)], ctx);
+  const full = takeBoolFlag(args, "--full");
+  const num = takeNumber(args, "PR");
+  const diff = await ghExec(["pr", "diff", String(num)], ctx);
 
   const shouldTruncate = !full && diff.length > DIFF_TRUNCATE_LIMIT;
   const prDiffBlock: Record<string, unknown> = {
@@ -566,9 +691,14 @@ async function prDiff(args: string[], ctx?: RepoContext): Promise<string> {
     prDiffBlock.original_length = diff.length;
   }
 
-  const suggestions = getSuggestions({ domain: 'pr', action: 'diff', id: num, repo: ctx });
+  const suggestions = getSuggestions({
+    domain: "pr",
+    action: "diff",
+    id: num,
+    repo: ctx,
+  });
   if (shouldTruncate) {
-    const repoArg = ctx && ctx.source !== 'git' ? ` -R ${ctx.nwo}` : '';
+    const repoArg = ctx && ctx.source !== "git" ? ` -R ${ctx.nwo}` : "";
     suggestions.unshift(
       `Run \`gh-axi${repoArg} pr diff ${num} --full\` to see the complete diff`,
     );
@@ -581,118 +711,165 @@ async function prDiff(args: string[], ctx?: RepoContext): Promise<string> {
 }
 
 async function prCheckout(args: string[], ctx?: RepoContext): Promise<string> {
-  const num = takeNumber(args, 'PR');
-  const stdout = await ghExec(['pr', 'checkout', String(num)], ctx);
+  const num = takeNumber(args, "PR");
+  const stdout = await ghExec(["pr", "checkout", String(num)], ctx);
   // Extract branch name from output
   const branchMatch = stdout.match(/Switched to branch '([^']+)'/);
   const branch = branchMatch ? branchMatch[1] : stdout.trim();
 
   return renderOutput([
-    renderDetail('checkout', { number: num, branch, status: 'ok' }, [
-      field('number'),
-      field('branch'),
-      field('status'),
+    renderDetail("checkout", { number: num, branch, status: "ok" }, [
+      field("number"),
+      field("branch"),
+      field("status"),
     ]),
-    renderHelp(getSuggestions({ domain: 'pr', action: 'checkout', id: num, repo: ctx })),
+    renderHelp(
+      getSuggestions({ domain: "pr", action: "checkout", id: num, repo: ctx }),
+    ),
   ]);
 }
 
 async function prReady(args: string[], ctx?: RepoContext): Promise<string> {
-  const num = takeNumber(args, 'PR');
+  const num = takeNumber(args, "PR");
 
   // Idempotent: check if already not a draft
-  const pr = await ghJson<Pick<PrItem, 'isDraft'>>(['pr', 'view', String(num), '--json', 'isDraft'], ctx);
+  const pr = await ghJson<Pick<PrItem, "isDraft">>(
+    ["pr", "view", String(num), "--json", "isDraft"],
+    ctx,
+  );
   if (!pr.isDraft) {
     return renderOutput([
-      renderDetail('pull_request', { number: num, draft: 'no', already: true }, [
-        field('number'),
-        field('draft'),
-        field('already'),
-      ]),
-      renderHelp(getSuggestions({ domain: 'pr', action: 'ready', id: num, repo: ctx })),
+      renderDetail(
+        "pull_request",
+        { number: num, draft: "no", already: true },
+        [field("number"), field("draft"), field("already")],
+      ),
+      renderHelp(
+        getSuggestions({ domain: "pr", action: "ready", id: num, repo: ctx }),
+      ),
     ]);
   }
 
-  await ghExec(['pr', 'ready', String(num)], ctx);
+  await ghExec(["pr", "ready", String(num)], ctx);
   return renderOutput([
-    renderDetail('ready', { number: num, status: 'ok' }, [field('number'), field('status')]),
-    renderHelp(getSuggestions({ domain: 'pr', action: 'ready', id: num, repo: ctx })),
+    renderDetail("ready", { number: num, status: "ok" }, [
+      field("number"),
+      field("status"),
+    ]),
+    renderHelp(
+      getSuggestions({ domain: "pr", action: "ready", id: num, repo: ctx }),
+    ),
   ]);
 }
 
 async function prReopen(args: string[], ctx?: RepoContext): Promise<string> {
-  const num = takeNumber(args, 'PR');
+  const num = takeNumber(args, "PR");
 
   // Idempotent: check current state
-  const pr = await ghJson<Pick<PrItem, 'state'>>(['pr', 'view', String(num), '--json', 'state'], ctx);
-  const state = (pr.state ?? '').toUpperCase();
-  if (state === 'OPEN') {
+  const pr = await ghJson<Pick<PrItem, "state">>(
+    ["pr", "view", String(num), "--json", "state"],
+    ctx,
+  );
+  const state = (pr.state ?? "").toUpperCase();
+  if (state === "OPEN") {
     return renderOutput([
-      renderDetail('pull_request', { number: num, state: 'open', already: true }, [
-        field('number'),
-        field('state'),
-        field('already'),
-      ]),
-      renderHelp(getSuggestions({ domain: 'pr', action: 'reopen', id: num, repo: ctx })),
+      renderDetail(
+        "pull_request",
+        { number: num, state: "open", already: true },
+        [field("number"), field("state"), field("already")],
+      ),
+      renderHelp(
+        getSuggestions({ domain: "pr", action: "reopen", id: num, repo: ctx }),
+      ),
     ]);
   }
 
-  await ghExec(['pr', 'reopen', String(num)], ctx);
+  await ghExec(["pr", "reopen", String(num)], ctx);
   return renderOutput([
-    renderDetail('reopened', { number: num, status: 'ok' }, [field('number'), field('status')]),
-    renderHelp(getSuggestions({ domain: 'pr', action: 'reopen', id: num, repo: ctx })),
+    renderDetail("reopened", { number: num, status: "ok" }, [
+      field("number"),
+      field("status"),
+    ]),
+    renderHelp(
+      getSuggestions({ domain: "pr", action: "reopen", id: num, repo: ctx }),
+    ),
   ]);
 }
 
 async function prComment(args: string[], ctx?: RepoContext): Promise<string> {
-  const num = takeNumber(args, 'PR');
-  const body = takeFlag(args, '--body');
-  if (!body) throw new AxiError('--body is required', 'VALIDATION_ERROR');
+  const num = takeNumber(args, "PR");
+  const body = takeFlag(args, "--body");
+  if (!body) throw new AxiError("--body is required", "VALIDATION_ERROR");
 
-  await ghExec(['pr', 'comment', String(num), '--body', body], ctx);
+  await ghExec(["pr", "comment", String(num), "--body", body], ctx);
   return renderOutput([
-    renderDetail('commented', { number: num, status: 'ok' }, [field('number'), field('status')]),
-    renderHelp(getSuggestions({ domain: 'pr', action: 'comment', id: num, repo: ctx })),
+    renderDetail("commented", { number: num, status: "ok" }, [
+      field("number"),
+      field("status"),
+    ]),
+    renderHelp(
+      getSuggestions({ domain: "pr", action: "comment", id: num, repo: ctx }),
+    ),
   ]);
 }
 
-async function prUpdateBranch(args: string[], ctx?: RepoContext): Promise<string> {
-  const num = takeNumber(args, 'PR');
-  await ghExec(['pr', 'update-branch', String(num)], ctx);
+async function prUpdateBranch(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
+  const num = takeNumber(args, "PR");
+  await ghExec(["pr", "update-branch", String(num)], ctx);
   return renderOutput([
-    renderDetail('updated', { number: num, status: 'ok' }, [field('number'), field('status')]),
-    renderHelp(getSuggestions({ domain: 'pr', action: 'update-branch', id: num, repo: ctx })),
+    renderDetail("updated", { number: num, status: "ok" }, [
+      field("number"),
+      field("status"),
+    ]),
+    renderHelp(
+      getSuggestions({
+        domain: "pr",
+        action: "update-branch",
+        id: num,
+        repo: ctx,
+      }),
+    ),
   ]);
 }
 
 async function prRevert(args: string[], ctx?: RepoContext): Promise<string> {
-  const num = takeNumber(args, 'PR');
+  const num = takeNumber(args, "PR");
 
   // gh pr revert may not exist in all gh versions; fall back to API
-  const result = await ghRaw(['pr', 'revert', String(num)], ctx);
+  const result = await ghRaw(["pr", "revert", String(num)], ctx);
   if (result.exitCode === 0) {
     // Try to extract the new PR number/URL from stdout
     const urlMatch = result.stdout.match(/\/pull\/(\d+)/);
     const newNum = urlMatch ? Number(urlMatch[1]) : null;
     return renderOutput([
-      renderDetail('reverted', { number: num, revert_pr: newNum, status: 'ok' }, [
-        field('number'),
-        field('revert_pr'),
-        field('status'),
-      ]),
-      renderHelp(getSuggestions({ domain: 'pr', action: 'revert', id: newNum ?? num, repo: ctx })),
+      renderDetail(
+        "reverted",
+        { number: num, revert_pr: newNum, status: "ok" },
+        [field("number"), field("revert_pr"), field("status")],
+      ),
+      renderHelp(
+        getSuggestions({
+          domain: "pr",
+          action: "revert",
+          id: newNum ?? num,
+          repo: ctx,
+        }),
+      ),
     ]);
   }
 
   // Fallback: use gh api to create a revert via the REST API
   const apiResult = await ghRaw(
-    ['api', `repos/{owner}/{repo}/pulls/${num}/revert`, '--method', 'POST'],
+    ["api", `repos/{owner}/{repo}/pulls/${num}/revert`, "--method", "POST"],
     ctx,
   );
   if (apiResult.exitCode !== 0) {
     throw new AxiError(
-      apiResult.stderr.trim().split('\n')[0] || `Failed to revert PR #${num}`,
-      'UNKNOWN',
+      apiResult.stderr.trim().split("\n")[0] || `Failed to revert PR #${num}`,
+      "UNKNOWN",
     );
   }
   let revertData: RevertResult;
@@ -703,13 +880,24 @@ async function prRevert(args: string[], ctx?: RepoContext): Promise<string> {
   }
 
   return renderOutput([
-    renderDetail('reverted', {
-      number: num,
-      revert_pr: revertData.number ?? null,
-      url: revertData.html_url ?? null,
-      status: 'ok',
-    }, [field('number'), field('revert_pr'), field('url'), field('status')]),
-    renderHelp(getSuggestions({ domain: 'pr', action: 'revert', id: revertData.number ?? num, repo: ctx })),
+    renderDetail(
+      "reverted",
+      {
+        number: num,
+        revert_pr: revertData.number ?? null,
+        url: revertData.html_url ?? null,
+        status: "ok",
+      },
+      [field("number"), field("revert_pr"), field("url"), field("status")],
+    ),
+    renderHelp(
+      getSuggestions({
+        domain: "pr",
+        action: "revert",
+        id: revertData.number ?? num,
+        repo: ctx,
+      }),
+    ),
   ]);
 }
 
@@ -717,49 +905,52 @@ async function prRevert(args: string[], ctx?: RepoContext): Promise<string> {
 // Router
 // ---------------------------------------------------------------------------
 
-export async function prCommand(args: string[], ctx?: RepoContext): Promise<string> {
+export async function prCommand(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
   const sub = args[0];
   const rest = args.slice(1);
 
   switch (sub) {
-    case 'list':
+    case "list":
       return prList(rest, ctx);
-    case 'view':
+    case "view":
       return prView(rest, ctx);
-    case 'create':
+    case "create":
       return prCreate(rest, ctx);
-    case 'edit':
+    case "edit":
       return prEdit(rest, ctx);
-    case 'close':
+    case "close":
       return prClose(rest, ctx);
-    case 'merge':
+    case "merge":
       return prMerge(rest, ctx);
-    case 'review':
+    case "review":
       return prReview(rest, ctx);
-    case 'checks':
+    case "checks":
       return prChecks(rest, ctx);
-    case 'diff':
+    case "diff":
       return prDiff(rest, ctx);
-    case 'checkout':
+    case "checkout":
       return prCheckout(rest, ctx);
-    case 'ready':
+    case "ready":
       return prReady(rest, ctx);
-    case 'reopen':
+    case "reopen":
       return prReopen(rest, ctx);
-    case 'comment':
+    case "comment":
       return prComment(rest, ctx);
-    case 'update-branch':
+    case "update-branch":
       return prUpdateBranch(rest, ctx);
-    case 'revert':
+    case "revert":
       return prRevert(rest, ctx);
-    case '--help':
-    case '-h':
-    case 'help':
+    case "--help":
+    case "-h":
+    case "help":
     case undefined:
       return PR_HELP;
     default:
-      return renderError(`Unknown pr subcommand: ${sub}`, 'VALIDATION_ERROR', [
-        'Run `gh-axi pr --help` to see available subcommands',
+      return renderError(`Unknown pr subcommand: ${sub}`, "VALIDATION_ERROR", [
+        "Run `gh-axi pr --help` to see available subcommands",
       ]);
   }
 }

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -53,7 +53,26 @@ interface PrItem {
   statusCheckRollup?: CheckRun[];
   body?: string;
   comments?: PrComment[];
+  reviews?: unknown[];
   mergedBy?: { login: string };
+}
+
+interface PrReview {
+  id: number;
+  user?: { login: string };
+  body?: string;
+  state?: string;
+  submitted_at?: string;
+}
+
+interface PrReviewComment {
+  pull_request_review_id?: number;
+  user?: { login: string };
+  path?: string;
+  line?: number | null;
+  original_line?: number | null;
+  body?: string;
+  created_at?: string;
 }
 
 interface RevertResult {
@@ -83,6 +102,14 @@ const REVIEW_MAP: Record<string, string> = {
   APPROVED: 'approved',
   CHANGES_REQUESTED: 'changes_requested',
   REVIEW_REQUIRED: 'required',
+};
+
+const REVIEW_STATE_MAP: Record<string, string> = {
+  APPROVED: 'approved',
+  CHANGES_REQUESTED: 'changes_requested',
+  COMMENTED: 'commented',
+  DISMISSED: 'dismissed',
+  PENDING: 'pending',
 };
 
 const listSchema: FieldDef[] = [
@@ -136,7 +163,7 @@ const viewSchemaFull: FieldDef[] = viewSchema.map(f =>
 );
 
 const VIEW_JSON_FIELDS =
-  'number,title,state,author,isDraft,mergedAt,statusCheckRollup,body,comments';
+  'number,title,state,author,isDraft,mergedAt,statusCheckRollup,body,comments,reviews';
 
 // ---------------------------------------------------------------------------
 // Help
@@ -148,7 +175,7 @@ subcommands[15]:
 flags{list}:
   --state <open|closed|all>, --label, --assignee, --author, --base, --head, --draft, --limit <n> (default 30), --fields <a,b,c>
 flags{view}:
-  --comments, --full (show complete body without truncation)
+  --comments, --reviews (show review submissions and inline review comments), --full (show complete body without truncation)
 flags{create}:
   --title <text> (required), --body, --base, --head, --draft, --assignee, --reviewer, --label, --milestone
 flags{merge}:
@@ -162,6 +189,7 @@ flags{diff}:
 examples:
   gh-axi pr list --state open --label bug
   gh-axi pr view 42 --comments
+  gh-axi pr view 42 --reviews
   gh-axi pr merge 42 --squash --delete-branch`;
 
 // ---------------------------------------------------------------------------
@@ -224,10 +252,11 @@ async function prList(args: string[], ctx?: RepoContext): Promise<string> {
 
 async function prView(args: string[], ctx?: RepoContext): Promise<string> {
   const includeComments = takeBoolFlag(args, '--comments');
+  const includeReviews = takeBoolFlag(args, '--reviews');
   const full = takeBoolFlag(args, '--full');
   const num = takeNumber(args, 'PR');
 
-  // Always fetch comments (for count or full rendering)
+  // Always fetch comments + review summaries (for count or full rendering)
   const ghArgs = ['pr', 'view', String(num), '--json', VIEW_JSON_FIELDS];
   const pr = await ghJson<PrItem>(ghArgs, ctx);
 
@@ -246,6 +275,57 @@ async function prView(args: string[], ctx?: RepoContext): Promise<string> {
     const commentCount = Array.isArray(pr.comments) ? pr.comments.length : 0;
     schema.push(
       custom('comment_count', () => `${commentCount} — use --comments to see full comments`),
+    );
+  }
+
+  if (includeReviews) {
+    // gh pr view --json reviews returns GraphQL node IDs, which don't match
+    // the numeric review IDs on inline review comments. Fetch both via REST
+    // so we can correlate inline comments back to their parent review.
+    const reviews = await ghJson<PrReview[]>(
+      ['api', `repos/{owner}/{repo}/pulls/${num}/reviews`, '--paginate'],
+      ctx,
+    );
+    let inlineComments: PrReviewComment[] = [];
+    if (reviews.length > 0) {
+      inlineComments = await ghJson<PrReviewComment[]>(
+        ['api', `repos/{owner}/{repo}/pulls/${num}/comments`, '--paginate'],
+        ctx,
+      );
+    }
+    const commentsByReview = new Map<number, PrReviewComment[]>();
+    for (const c of inlineComments) {
+      if (typeof c.pull_request_review_id === 'number') {
+        const list = commentsByReview.get(c.pull_request_review_id) ?? [];
+        list.push(c);
+        commentsByReview.set(c.pull_request_review_id, list);
+      }
+    }
+    schema.push(
+      custom('reviews', () =>
+        reviews.map((r) => {
+          const stateUpper = (r.state ?? '').toUpperCase();
+          const inline = commentsByReview.get(r.id) ?? [];
+          return {
+            author: r.user?.login ?? 'unknown',
+            state: REVIEW_STATE_MAP[stateUpper] ?? stateUpper.toLowerCase() ?? 'unknown',
+            submitted: r.submitted_at ?? '',
+            body: r.body ?? '',
+            inline_comments: inline.map((c) => ({
+              author: c.user?.login ?? 'unknown',
+              path: c.path ?? '',
+              line: c.line ?? c.original_line ?? null,
+              body: c.body ?? '',
+              created: c.created_at ?? '',
+            })),
+          };
+        }),
+      ),
+    );
+  } else {
+    const reviewCount = Array.isArray(pr.reviews) ? pr.reviews.length : 0;
+    schema.push(
+      custom('review_count', () => `${reviewCount} — use --reviews to see full reviews`),
     );
   }
 

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -94,6 +94,21 @@ function classifyCheck(c: CheckRun): 'pass' | 'fail' | 'skip' | 'pending' {
   return 'pending';
 }
 
+function prRestPath(ctx: RepoContext | undefined, num: number, suffix: string): string {
+  const repoPath = ctx ? `repos/${ctx.owner}/${ctx.name}` : 'repos/{owner}/{repo}';
+  return `${repoPath}/pulls/${num}/${suffix}`;
+}
+
+function flattenPaginated<T>(items: T[] | T[][]): T[] {
+  if (items.length > 0 && Array.isArray(items[0])) return (items as T[][]).flat();
+  return items as T[];
+}
+
+async function ghApiPaginatedArray<T>(path: string): Promise<T[]> {
+  const pages = await ghJson<T[] | T[][]>(['api', path, '--paginate', '--slurp']);
+  return flattenPaginated(pages);
+}
+
 // ---------------------------------------------------------------------------
 // Schemas
 // ---------------------------------------------------------------------------
@@ -282,15 +297,13 @@ async function prView(args: string[], ctx?: RepoContext): Promise<string> {
     // gh pr view --json reviews returns GraphQL node IDs, which don't match
     // the numeric review IDs on inline review comments. Fetch both via REST
     // so we can correlate inline comments back to their parent review.
-    const reviews = await ghJson<PrReview[]>(
-      ['api', `repos/{owner}/{repo}/pulls/${num}/reviews`, '--paginate'],
-      ctx,
+    const reviews = await ghApiPaginatedArray<PrReview>(
+      prRestPath(ctx, num, 'reviews'),
     );
     let inlineComments: PrReviewComment[] = [];
     if (reviews.length > 0) {
-      inlineComments = await ghJson<PrReviewComment[]>(
-        ['api', `repos/{owner}/{repo}/pulls/${num}/comments`, '--paginate'],
-        ctx,
+      inlineComments = await ghApiPaginatedArray<PrReviewComment>(
+        prRestPath(ctx, num, 'comments'),
       );
     }
     const commentsByReview = new Map<number, PrReviewComment[]>();

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -134,6 +134,143 @@ describe('prCommand', () => {
       const result = await prCommand(['view', '42'], ctx);
       expect(result).not.toMatch(/^help\[/m);
     });
+
+    it('shows review_count summary when --reviews is not passed', async () => {
+      mockedGhJson.mockResolvedValue({
+        number: 42, title: 'My PR', state: 'OPEN', author: { login: 'alice' },
+        isDraft: false, mergedAt: null, statusCheckRollup: [], body: 'desc',
+        comments: [],
+        reviews: [{ id: 'PRR_1' }, { id: 'PRR_2' }],
+      });
+
+      const result = await prCommand(['view', '42'], ctx);
+
+      expect(result).toContain('review_count: 2');
+      expect(result).toContain('use --reviews to see full reviews');
+    });
+
+    it('lists review submissions and inline comments with --reviews', async () => {
+      mockedGhJson
+        .mockResolvedValueOnce({
+          number: 42, title: 'My PR', state: 'OPEN', author: { login: 'alice' },
+          isDraft: false, mergedAt: null, statusCheckRollup: [], body: 'desc',
+          comments: [],
+          reviews: [{ id: 'PRR_1' }],
+        })
+        .mockResolvedValueOnce([
+          {
+            id: 1001,
+            user: { login: 'cursor[bot]' },
+            body: 'Found 2 issues',
+            state: 'COMMENTED',
+            submitted_at: '2026-04-01T00:00:00Z',
+          },
+          {
+            id: 1002,
+            user: { login: 'reviewer' },
+            body: '',
+            state: 'APPROVED',
+            submitted_at: '2026-04-02T00:00:00Z',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            pull_request_review_id: 1001,
+            user: { login: 'cursor[bot]' },
+            path: 'src/foo.ts',
+            line: 42,
+            body: 'This could be null',
+            created_at: '2026-04-01T00:00:00Z',
+          },
+          {
+            pull_request_review_id: 1001,
+            user: { login: 'cursor[bot]' },
+            path: 'src/bar.ts',
+            line: null,
+            original_line: 7,
+            body: 'Off-by-one bug',
+            created_at: '2026-04-01T00:00:00Z',
+          },
+        ]);
+
+      const result = await prCommand(['view', '42', '--reviews'], ctx);
+
+      // Review submissions surfaced
+      expect(result).toContain('cursor[bot]');
+      expect(result).toContain('commented');
+      expect(result).toContain('Found 2 issues');
+      expect(result).toContain('approved');
+      // Inline comments surfaced under the right review
+      expect(result).toContain('src/foo.ts');
+      expect(result).toContain('This could be null');
+      expect(result).toContain('src/bar.ts');
+      expect(result).toContain('Off-by-one bug');
+      // review_count is replaced by full reviews block
+      expect(result).not.toContain('use --reviews to see full reviews');
+
+      // Verify REST endpoints were used
+      const apiCalls = mockedGhJson.mock.calls.map((c) => c[0]);
+      expect(apiCalls.some((a) => Array.isArray(a) && a.includes('api') && (a as string[]).some((s) => s.includes('/pulls/42/reviews')))).toBe(true);
+      expect(apiCalls.some((a) => Array.isArray(a) && a.includes('api') && (a as string[]).some((s) => s.includes('/pulls/42/comments')))).toBe(true);
+    });
+
+    it('skips inline-comment fetch when there are no reviews', async () => {
+      mockedGhJson
+        .mockResolvedValueOnce({
+          number: 42, title: 'My PR', state: 'OPEN', author: { login: 'alice' },
+          isDraft: false, mergedAt: null, statusCheckRollup: [], body: 'desc',
+          comments: [],
+          reviews: [],
+        })
+        .mockResolvedValueOnce([]); // empty reviews from REST
+
+      const result = await prCommand(['view', '42', '--reviews'], ctx);
+
+      // Two calls only: pr view --json and pulls/42/reviews. No comments call.
+      expect(mockedGhJson).toHaveBeenCalledTimes(2);
+      expect(result).toContain('reviews');
+    });
+
+    it('renders both comments and reviews when --comments --reviews are combined', async () => {
+      mockedGhJson
+        .mockResolvedValueOnce({
+          number: 42, title: 'My PR', state: 'OPEN', author: { login: 'alice' },
+          isDraft: false, mergedAt: null, statusCheckRollup: [], body: 'desc',
+          comments: [
+            { author: { login: 'carol' }, body: 'top-level chat', createdAt: '2026-04-01T00:00:00Z' },
+          ],
+          reviews: [{ id: 'PRR_1' }],
+        })
+        .mockResolvedValueOnce([
+          {
+            id: 2001,
+            user: { login: 'dave' },
+            body: 'lgtm with nits',
+            state: 'CHANGES_REQUESTED',
+            submitted_at: '2026-04-03T00:00:00Z',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            pull_request_review_id: 2001,
+            user: { login: 'dave' },
+            path: 'README.md',
+            line: 1,
+            body: 'fix typo',
+            created_at: '2026-04-03T00:00:00Z',
+          },
+        ]);
+
+      const result = await prCommand(['view', '42', '--comments', '--reviews'], ctx);
+
+      expect(result).toContain('top-level chat');
+      expect(result).toContain('carol');
+      expect(result).toContain('lgtm with nits');
+      expect(result).toContain('changes_requested');
+      expect(result).toContain('fix typo');
+      expect(result).not.toContain('use --comments to see full comments');
+      expect(result).not.toContain('use --reviews to see full reviews');
+    });
   });
 
   describe('close', () => {

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -214,6 +214,83 @@ describe('prCommand', () => {
       expect(apiCalls.some((a) => Array.isArray(a) && a.includes('api') && (a as string[]).some((s) => s.includes('/pulls/42/comments')))).toBe(true);
     });
 
+    it('uses explicit REST paths without repo context for review fetches', async () => {
+      mockedGhJson
+        .mockResolvedValueOnce({
+          number: 42, title: 'My PR', state: 'OPEN', author: { login: 'alice' },
+          isDraft: false, mergedAt: null, statusCheckRollup: [], body: 'desc',
+          comments: [],
+          reviews: [],
+        })
+        .mockResolvedValueOnce([]);
+
+      await prCommand(['view', '42', '--reviews'], ctx);
+
+      expect(mockedGhJson).toHaveBeenNthCalledWith(
+        2,
+        ['api', 'repos/octo/repo/pulls/42/reviews', '--paginate', '--slurp'],
+      );
+    });
+
+    it('flattens paginated review and inline comment pages', async () => {
+      mockedGhJson
+        .mockResolvedValueOnce({
+          number: 42, title: 'My PR', state: 'OPEN', author: { login: 'alice' },
+          isDraft: false, mergedAt: null, statusCheckRollup: [], body: 'desc',
+          comments: [],
+          reviews: [{ id: 'PRR_1' }],
+        })
+        .mockResolvedValueOnce([
+          [
+            {
+              id: 3001,
+              user: { login: 'erin' },
+              body: 'page one review',
+              state: 'COMMENTED',
+              submitted_at: '2026-04-04T00:00:00Z',
+            },
+          ],
+          [
+            {
+              id: 3002,
+              user: { login: 'frank' },
+              body: 'page two review',
+              state: 'APPROVED',
+              submitted_at: '2026-04-05T00:00:00Z',
+            },
+          ],
+        ])
+        .mockResolvedValueOnce([
+          [
+            {
+              pull_request_review_id: 3001,
+              user: { login: 'erin' },
+              path: 'src/a.ts',
+              line: 10,
+              body: 'page one comment',
+              created_at: '2026-04-04T00:00:00Z',
+            },
+          ],
+          [
+            {
+              pull_request_review_id: 3002,
+              user: { login: 'frank' },
+              path: 'src/b.ts',
+              line: 20,
+              body: 'page two comment',
+              created_at: '2026-04-05T00:00:00Z',
+            },
+          ],
+        ]);
+
+      const result = await prCommand(['view', '42', '--reviews'], ctx);
+
+      expect(result).toContain('page one review');
+      expect(result).toContain('page two review');
+      expect(result).toContain('page one comment');
+      expect(result).toContain('page two comment');
+    });
+
     it('skips inline-comment fetch when there are no reviews', async () => {
       mockedGhJson
         .mockResolvedValueOnce({

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -1,262 +1,335 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from "vitest";
 
-vi.mock('../../src/gh.js', () => ({
+vi.mock("../../src/gh.js", () => ({
   ghJson: vi.fn(),
   ghExec: vi.fn(),
   ghRaw: vi.fn(),
 }));
 
-import { ghJson, ghExec, ghRaw } from '../../src/gh.js';
-import { prCommand, PR_HELP } from '../../src/commands/pr.js';
-import { AxiError } from '../../src/errors.js';
-import type { RepoContext } from '../../src/context.js';
+import { ghJson, ghExec } from "../../src/gh.js";
+import { prCommand, PR_HELP } from "../../src/commands/pr.js";
+import { AxiError } from "../../src/errors.js";
+import type { RepoContext } from "../../src/context.js";
 
 const mockedGhJson = vi.mocked(ghJson);
 const mockedGhExec = vi.mocked(ghExec);
-const mockedGhRaw = vi.mocked(ghRaw);
 
-const ctx: RepoContext = { owner: 'octo', name: 'repo', nwo: 'octo/repo', source: 'flag' };
+const ctx: RepoContext = {
+  owner: "octo",
+  name: "repo",
+  nwo: "octo/repo",
+  source: "flag",
+};
 
-describe('prCommand', () => {
+describe("prCommand", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  describe('router', () => {
-    it('returns help when --help is passed', async () => {
-      const result = await prCommand(['--help']);
+  describe("router", () => {
+    it("returns help when --help is passed", async () => {
+      const result = await prCommand(["--help"]);
       expect(result).toBe(PR_HELP);
     });
 
-    it('returns help when no subcommand is given', async () => {
+    it("returns help when no subcommand is given", async () => {
       const result = await prCommand([]);
       expect(result).toBe(PR_HELP);
     });
 
-    it('returns error for unknown subcommand', async () => {
-      const result = await prCommand(['unknown']);
-      expect(result).toContain('Unknown pr subcommand: unknown');
+    it("returns error for unknown subcommand", async () => {
+      const result = await prCommand(["unknown"]);
+      expect(result).toContain("Unknown pr subcommand: unknown");
     });
   });
 
-  describe('list', () => {
-    it('returns list with count line', async () => {
+  describe("list", () => {
+    it("returns list with count line", async () => {
       mockedGhJson.mockResolvedValue([
-        { number: 1, title: 'Fix bug', state: 'OPEN', author: { login: 'alice' }, isDraft: false, reviewDecision: 'APPROVED' },
-        { number: 2, title: 'Add feature', state: 'OPEN', author: { login: 'bob' }, isDraft: true, reviewDecision: '' },
+        {
+          number: 1,
+          title: "Fix bug",
+          state: "OPEN",
+          author: { login: "alice" },
+          isDraft: false,
+          reviewDecision: "APPROVED",
+        },
+        {
+          number: 2,
+          title: "Add feature",
+          state: "OPEN",
+          author: { login: "bob" },
+          isDraft: true,
+          reviewDecision: "",
+        },
       ]);
 
-      const result = await prCommand(['list'], ctx);
+      const result = await prCommand(["list"], ctx);
 
-      expect(result).toContain('count: 2');
-      expect(result).toContain('Fix bug');
-      expect(result).toContain('Add feature');
+      expect(result).toContain("count: 2");
+      expect(result).toContain("Fix bug");
+      expect(result).toContain("Add feature");
       expect(mockedGhJson).toHaveBeenCalledWith(
-        expect.arrayContaining(['pr', 'list', '--json']),
+        expect.arrayContaining(["pr", "list", "--json"]),
         ctx,
       );
     });
 
-    it('uses default compact --json fields when --fields is not passed', async () => {
+    it("uses default compact --json fields when --fields is not passed", async () => {
       mockedGhJson.mockResolvedValue([]);
-      await prCommand(['list'], ctx);
+      await prCommand(["list"], ctx);
 
       const callArgs = mockedGhJson.mock.calls[0][0] as string[];
-      const jsonIdx = callArgs.indexOf('--json');
+      const jsonIdx = callArgs.indexOf("--json");
       const jsonValue = callArgs[jsonIdx + 1];
-      expect(jsonValue).not.toContain('body');
-      expect(jsonValue).not.toContain('createdAt');
-      expect(jsonValue).toContain('number');
-      expect(jsonValue).toContain('title');
+      expect(jsonValue).not.toContain("body");
+      expect(jsonValue).not.toContain("createdAt");
+      expect(jsonValue).toContain("number");
+      expect(jsonValue).toContain("title");
     });
 
-    it('extends --json and schema when --fields is passed', async () => {
+    it("extends --json and schema when --fields is passed", async () => {
       mockedGhJson.mockResolvedValue([
         {
-          number: 1, title: 'Fix', state: 'OPEN', author: { login: 'alice' },
-          isDraft: false, reviewDecision: 'APPROVED',
-          body: 'PR body text', createdAt: '2024-01-01T00:00:00Z',
+          number: 1,
+          title: "Fix",
+          state: "OPEN",
+          author: { login: "alice" },
+          isDraft: false,
+          reviewDecision: "APPROVED",
+          body: "PR body text",
+          createdAt: "2024-01-01T00:00:00Z",
         },
       ]);
 
-      const result = await prCommand(['list', '--fields', 'body,createdAt'], ctx);
+      const result = await prCommand(
+        ["list", "--fields", "body,createdAt"],
+        ctx,
+      );
 
       const callArgs = mockedGhJson.mock.calls[0][0] as string[];
-      const jsonIdx = callArgs.indexOf('--json');
+      const jsonIdx = callArgs.indexOf("--json");
       const jsonValue = callArgs[jsonIdx + 1];
-      expect(jsonValue).toContain('body');
-      expect(jsonValue).toContain('createdAt');
+      expect(jsonValue).toContain("body");
+      expect(jsonValue).toContain("createdAt");
 
-      expect(result).toContain('PR body text');
+      expect(result).toContain("PR body text");
     });
 
-    it('throws VALIDATION_ERROR for unknown --fields', async () => {
+    it("throws VALIDATION_ERROR for unknown --fields", async () => {
       await expect(
-        prCommand(['list', '--fields', 'fakeField'], ctx),
+        prCommand(["list", "--fields", "fakeField"], ctx),
       ).rejects.toThrow(AxiError);
 
       try {
-        await prCommand(['list', '--fields', 'fakeField'], ctx);
+        await prCommand(["list", "--fields", "fakeField"], ctx);
       } catch (e) {
-        expect((e as AxiError).code).toBe('VALIDATION_ERROR');
-        expect((e as AxiError).message).toContain('fakeField');
+        expect((e as AxiError).code).toBe("VALIDATION_ERROR");
+        expect((e as AxiError).message).toContain("fakeField");
       }
     });
   });
 
-  describe('view', () => {
-    it('returns detail with schema fields', async () => {
+  describe("view", () => {
+    it("returns detail with schema fields", async () => {
       mockedGhJson.mockResolvedValue({
         number: 42,
-        title: 'My PR',
-        state: 'OPEN',
-        author: { login: 'alice' },
+        title: "My PR",
+        state: "OPEN",
+        author: { login: "alice" },
         isDraft: false,
         mergedAt: null,
         statusCheckRollup: [],
-        body: 'PR description here',
+        body: "PR description here",
         comments: [],
       });
 
-      const result = await prCommand(['view', '42'], ctx);
+      const result = await prCommand(["view", "42"], ctx);
 
-      expect(result).toContain('42');
-      expect(result).toContain('My PR');
-      expect(result).toContain('open');
-      expect(result).toContain('alice');
+      expect(result).toContain("42");
+      expect(result).toContain("My PR");
+      expect(result).toContain("open");
+      expect(result).toContain("alice");
     });
 
-    it('omits help suggestions from detail view', async () => {
+    it("omits help suggestions from detail view", async () => {
       mockedGhJson.mockResolvedValue({
-        number: 42, title: 'My PR', state: 'OPEN', author: { login: 'alice' },
-        isDraft: false, mergedAt: null, statusCheckRollup: [], body: 'desc', comments: [],
+        number: 42,
+        title: "My PR",
+        state: "OPEN",
+        author: { login: "alice" },
+        isDraft: false,
+        mergedAt: null,
+        statusCheckRollup: [],
+        body: "desc",
+        comments: [],
       });
-      const result = await prCommand(['view', '42'], ctx);
+      const result = await prCommand(["view", "42"], ctx);
       expect(result).not.toMatch(/^help\[/m);
     });
 
-    it('shows review_count summary when --reviews is not passed', async () => {
+    it("shows review_count summary when --reviews is not passed", async () => {
       mockedGhJson.mockResolvedValue({
-        number: 42, title: 'My PR', state: 'OPEN', author: { login: 'alice' },
-        isDraft: false, mergedAt: null, statusCheckRollup: [], body: 'desc',
+        number: 42,
+        title: "My PR",
+        state: "OPEN",
+        author: { login: "alice" },
+        isDraft: false,
+        mergedAt: null,
+        statusCheckRollup: [],
+        body: "desc",
         comments: [],
-        reviews: [{ id: 'PRR_1' }, { id: 'PRR_2' }],
+        reviews: [{ id: "PRR_1" }, { id: "PRR_2" }],
       });
 
-      const result = await prCommand(['view', '42'], ctx);
+      const result = await prCommand(["view", "42"], ctx);
 
-      expect(result).toContain('review_count: 2');
-      expect(result).toContain('use --reviews to see full reviews');
+      expect(result).toContain("review_count: 2");
+      expect(result).toContain("use --reviews to see full reviews");
     });
 
-    it('lists review submissions and inline comments with --reviews', async () => {
+    it("lists review submissions and inline comments with --reviews", async () => {
       mockedGhJson
         .mockResolvedValueOnce({
-          number: 42, title: 'My PR', state: 'OPEN', author: { login: 'alice' },
-          isDraft: false, mergedAt: null, statusCheckRollup: [], body: 'desc',
+          number: 42,
+          title: "My PR",
+          state: "OPEN",
+          author: { login: "alice" },
+          isDraft: false,
+          mergedAt: null,
+          statusCheckRollup: [],
+          body: "desc",
           comments: [],
-          reviews: [{ id: 'PRR_1' }],
+          reviews: [{ id: "PRR_1" }],
         })
         .mockResolvedValueOnce([
           {
             id: 1001,
-            user: { login: 'cursor[bot]' },
-            body: 'Found 2 issues',
-            state: 'COMMENTED',
-            submitted_at: '2026-04-01T00:00:00Z',
+            user: { login: "cursor[bot]" },
+            body: "Found 2 issues",
+            state: "COMMENTED",
+            submitted_at: "2026-04-01T00:00:00Z",
           },
           {
             id: 1002,
-            user: { login: 'reviewer' },
-            body: '',
-            state: 'APPROVED',
-            submitted_at: '2026-04-02T00:00:00Z',
+            user: { login: "reviewer" },
+            body: "",
+            state: "APPROVED",
+            submitted_at: "2026-04-02T00:00:00Z",
           },
         ])
         .mockResolvedValueOnce([
           {
             pull_request_review_id: 1001,
-            user: { login: 'cursor[bot]' },
-            path: 'src/foo.ts',
+            user: { login: "cursor[bot]" },
+            path: "src/foo.ts",
             line: 42,
-            body: 'This could be null',
-            created_at: '2026-04-01T00:00:00Z',
+            body: "This could be null",
+            created_at: "2026-04-01T00:00:00Z",
           },
           {
             pull_request_review_id: 1001,
-            user: { login: 'cursor[bot]' },
-            path: 'src/bar.ts',
+            user: { login: "cursor[bot]" },
+            path: "src/bar.ts",
             line: null,
             original_line: 7,
-            body: 'Off-by-one bug',
-            created_at: '2026-04-01T00:00:00Z',
+            body: "Off-by-one bug",
+            created_at: "2026-04-01T00:00:00Z",
           },
         ]);
 
-      const result = await prCommand(['view', '42', '--reviews'], ctx);
+      const result = await prCommand(["view", "42", "--reviews"], ctx);
 
       // Review submissions surfaced
-      expect(result).toContain('cursor[bot]');
-      expect(result).toContain('commented');
-      expect(result).toContain('Found 2 issues');
-      expect(result).toContain('approved');
+      expect(result).toContain("cursor[bot]");
+      expect(result).toContain("commented");
+      expect(result).toContain("Found 2 issues");
+      expect(result).toContain("approved");
       // Inline comments surfaced under the right review
-      expect(result).toContain('src/foo.ts');
-      expect(result).toContain('This could be null');
-      expect(result).toContain('src/bar.ts');
-      expect(result).toContain('Off-by-one bug');
+      expect(result).toContain("src/foo.ts");
+      expect(result).toContain("This could be null");
+      expect(result).toContain("src/bar.ts");
+      expect(result).toContain("Off-by-one bug");
       // review_count is replaced by full reviews block
-      expect(result).not.toContain('use --reviews to see full reviews');
+      expect(result).not.toContain("use --reviews to see full reviews");
 
       // Verify REST endpoints were used
       const apiCalls = mockedGhJson.mock.calls.map((c) => c[0]);
-      expect(apiCalls.some((a) => Array.isArray(a) && a.includes('api') && (a as string[]).some((s) => s.includes('/pulls/42/reviews')))).toBe(true);
-      expect(apiCalls.some((a) => Array.isArray(a) && a.includes('api') && (a as string[]).some((s) => s.includes('/pulls/42/comments')))).toBe(true);
+      expect(
+        apiCalls.some(
+          (a) =>
+            Array.isArray(a) &&
+            a.includes("api") &&
+            (a as string[]).some((s) => s.includes("/pulls/42/reviews")),
+        ),
+      ).toBe(true);
+      expect(
+        apiCalls.some(
+          (a) =>
+            Array.isArray(a) &&
+            a.includes("api") &&
+            (a as string[]).some((s) => s.includes("/pulls/42/comments")),
+        ),
+      ).toBe(true);
     });
 
-    it('uses explicit REST paths without repo context for review fetches', async () => {
+    it("uses explicit REST paths without repo context for review fetches", async () => {
       mockedGhJson
         .mockResolvedValueOnce({
-          number: 42, title: 'My PR', state: 'OPEN', author: { login: 'alice' },
-          isDraft: false, mergedAt: null, statusCheckRollup: [], body: 'desc',
+          number: 42,
+          title: "My PR",
+          state: "OPEN",
+          author: { login: "alice" },
+          isDraft: false,
+          mergedAt: null,
+          statusCheckRollup: [],
+          body: "desc",
           comments: [],
           reviews: [],
         })
         .mockResolvedValueOnce([]);
 
-      await prCommand(['view', '42', '--reviews'], ctx);
+      await prCommand(["view", "42", "--reviews"], ctx);
 
-      expect(mockedGhJson).toHaveBeenNthCalledWith(
-        2,
-        ['api', 'repos/octo/repo/pulls/42/reviews', '--paginate', '--slurp'],
-      );
+      expect(mockedGhJson).toHaveBeenNthCalledWith(2, [
+        "api",
+        "repos/octo/repo/pulls/42/reviews",
+        "--paginate",
+        "--slurp",
+      ]);
     });
 
-    it('flattens paginated review and inline comment pages', async () => {
+    it("flattens paginated review and inline comment pages", async () => {
       mockedGhJson
         .mockResolvedValueOnce({
-          number: 42, title: 'My PR', state: 'OPEN', author: { login: 'alice' },
-          isDraft: false, mergedAt: null, statusCheckRollup: [], body: 'desc',
+          number: 42,
+          title: "My PR",
+          state: "OPEN",
+          author: { login: "alice" },
+          isDraft: false,
+          mergedAt: null,
+          statusCheckRollup: [],
+          body: "desc",
           comments: [],
-          reviews: [{ id: 'PRR_1' }],
+          reviews: [{ id: "PRR_1" }],
         })
         .mockResolvedValueOnce([
           [
             {
               id: 3001,
-              user: { login: 'erin' },
-              body: 'page one review',
-              state: 'COMMENTED',
-              submitted_at: '2026-04-04T00:00:00Z',
+              user: { login: "erin" },
+              body: "page one review",
+              state: "COMMENTED",
+              submitted_at: "2026-04-04T00:00:00Z",
             },
           ],
           [
             {
               id: 3002,
-              user: { login: 'frank' },
-              body: 'page two review',
-              state: 'APPROVED',
-              submitted_at: '2026-04-05T00:00:00Z',
+              user: { login: "frank" },
+              body: "page two review",
+              state: "APPROVED",
+              submitted_at: "2026-04-05T00:00:00Z",
             },
           ],
         ])
@@ -264,180 +337,201 @@ describe('prCommand', () => {
           [
             {
               pull_request_review_id: 3001,
-              user: { login: 'erin' },
-              path: 'src/a.ts',
+              user: { login: "erin" },
+              path: "src/a.ts",
               line: 10,
-              body: 'page one comment',
-              created_at: '2026-04-04T00:00:00Z',
+              body: "page one comment",
+              created_at: "2026-04-04T00:00:00Z",
             },
           ],
           [
             {
               pull_request_review_id: 3002,
-              user: { login: 'frank' },
-              path: 'src/b.ts',
+              user: { login: "frank" },
+              path: "src/b.ts",
               line: 20,
-              body: 'page two comment',
-              created_at: '2026-04-05T00:00:00Z',
+              body: "page two comment",
+              created_at: "2026-04-05T00:00:00Z",
             },
           ],
         ]);
 
-      const result = await prCommand(['view', '42', '--reviews'], ctx);
+      const result = await prCommand(["view", "42", "--reviews"], ctx);
 
-      expect(result).toContain('page one review');
-      expect(result).toContain('page two review');
-      expect(result).toContain('page one comment');
-      expect(result).toContain('page two comment');
+      expect(result).toContain("page one review");
+      expect(result).toContain("page two review");
+      expect(result).toContain("page one comment");
+      expect(result).toContain("page two comment");
     });
 
-    it('skips inline-comment fetch when there are no reviews', async () => {
+    it("skips inline-comment fetch when there are no reviews", async () => {
       mockedGhJson
         .mockResolvedValueOnce({
-          number: 42, title: 'My PR', state: 'OPEN', author: { login: 'alice' },
-          isDraft: false, mergedAt: null, statusCheckRollup: [], body: 'desc',
+          number: 42,
+          title: "My PR",
+          state: "OPEN",
+          author: { login: "alice" },
+          isDraft: false,
+          mergedAt: null,
+          statusCheckRollup: [],
+          body: "desc",
           comments: [],
           reviews: [],
         })
         .mockResolvedValueOnce([]); // empty reviews from REST
 
-      const result = await prCommand(['view', '42', '--reviews'], ctx);
+      const result = await prCommand(["view", "42", "--reviews"], ctx);
 
       // Two calls only: pr view --json and pulls/42/reviews. No comments call.
       expect(mockedGhJson).toHaveBeenCalledTimes(2);
-      expect(result).toContain('reviews');
+      expect(result).toContain("reviews");
     });
 
-    it('renders both comments and reviews when --comments --reviews are combined', async () => {
+    it("renders both comments and reviews when --comments --reviews are combined", async () => {
       mockedGhJson
         .mockResolvedValueOnce({
-          number: 42, title: 'My PR', state: 'OPEN', author: { login: 'alice' },
-          isDraft: false, mergedAt: null, statusCheckRollup: [], body: 'desc',
+          number: 42,
+          title: "My PR",
+          state: "OPEN",
+          author: { login: "alice" },
+          isDraft: false,
+          mergedAt: null,
+          statusCheckRollup: [],
+          body: "desc",
           comments: [
-            { author: { login: 'carol' }, body: 'top-level chat', createdAt: '2026-04-01T00:00:00Z' },
+            {
+              author: { login: "carol" },
+              body: "top-level chat",
+              createdAt: "2026-04-01T00:00:00Z",
+            },
           ],
-          reviews: [{ id: 'PRR_1' }],
+          reviews: [{ id: "PRR_1" }],
         })
         .mockResolvedValueOnce([
           {
             id: 2001,
-            user: { login: 'dave' },
-            body: 'lgtm with nits',
-            state: 'CHANGES_REQUESTED',
-            submitted_at: '2026-04-03T00:00:00Z',
+            user: { login: "dave" },
+            body: "lgtm with nits",
+            state: "CHANGES_REQUESTED",
+            submitted_at: "2026-04-03T00:00:00Z",
           },
         ])
         .mockResolvedValueOnce([
           {
             pull_request_review_id: 2001,
-            user: { login: 'dave' },
-            path: 'README.md',
+            user: { login: "dave" },
+            path: "README.md",
             line: 1,
-            body: 'fix typo',
-            created_at: '2026-04-03T00:00:00Z',
+            body: "fix typo",
+            created_at: "2026-04-03T00:00:00Z",
           },
         ]);
 
-      const result = await prCommand(['view', '42', '--comments', '--reviews'], ctx);
+      const result = await prCommand(
+        ["view", "42", "--comments", "--reviews"],
+        ctx,
+      );
 
-      expect(result).toContain('top-level chat');
-      expect(result).toContain('carol');
-      expect(result).toContain('lgtm with nits');
-      expect(result).toContain('changes_requested');
-      expect(result).toContain('fix typo');
-      expect(result).not.toContain('use --comments to see full comments');
-      expect(result).not.toContain('use --reviews to see full reviews');
+      expect(result).toContain("top-level chat");
+      expect(result).toContain("carol");
+      expect(result).toContain("lgtm with nits");
+      expect(result).toContain("changes_requested");
+      expect(result).toContain("fix typo");
+      expect(result).not.toContain("use --comments to see full comments");
+      expect(result).not.toContain("use --reviews to see full reviews");
     });
   });
 
-  describe('close', () => {
-    it('returns already closed when PR is already closed (idempotent)', async () => {
-      mockedGhJson.mockResolvedValue({ state: 'CLOSED' });
+  describe("close", () => {
+    it("returns already closed when PR is already closed (idempotent)", async () => {
+      mockedGhJson.mockResolvedValue({ state: "CLOSED" });
 
-      const result = await prCommand(['close', '10'], ctx);
+      const result = await prCommand(["close", "10"], ctx);
 
-      expect(result).toContain('closed');
-      expect(result).toContain('already');
+      expect(result).toContain("closed");
+      expect(result).toContain("already");
       expect(mockedGhExec).not.toHaveBeenCalled();
     });
   });
 
-  describe('merge', () => {
-    it('returns already merged when PR is already merged (idempotent)', async () => {
+  describe("merge", () => {
+    it("returns already merged when PR is already merged (idempotent)", async () => {
       mockedGhJson.mockResolvedValue({
-        state: 'MERGED',
-        mergedBy: { login: 'alice' },
-        mergedAt: '2024-01-01T00:00:00Z',
+        state: "MERGED",
+        mergedBy: { login: "alice" },
+        mergedAt: "2024-01-01T00:00:00Z",
       });
 
-      const result = await prCommand(['merge', '10'], ctx);
+      const result = await prCommand(["merge", "10"], ctx);
 
-      expect(result).toContain('merged');
-      expect(result).toContain('alice');
+      expect(result).toContain("merged");
+      expect(result).toContain("alice");
       expect(mockedGhExec).not.toHaveBeenCalled();
     });
   });
 
-  describe('checks', () => {
-    it('returns message when no checks configured', async () => {
+  describe("checks", () => {
+    it("returns message when no checks configured", async () => {
       mockedGhJson.mockResolvedValue({ statusCheckRollup: [] });
 
-      const result = await prCommand(['checks', '5'], ctx);
+      const result = await prCommand(["checks", "5"], ctx);
 
-      expect(result).toContain('no CI checks configured');
+      expect(result).toContain("no CI checks configured");
     });
 
-    it('returns check summary with checks', async () => {
+    it("returns check summary with checks", async () => {
       mockedGhJson.mockResolvedValue({
         statusCheckRollup: [
-          { name: 'build', conclusion: 'SUCCESS' },
-          { name: 'lint', conclusion: 'FAILURE' },
-          { name: 'test', conclusion: 'SKIPPED' },
+          { name: "build", conclusion: "SUCCESS" },
+          { name: "lint", conclusion: "FAILURE" },
+          { name: "test", conclusion: "SKIPPED" },
         ],
       });
 
-      const result = await prCommand(['checks', '5'], ctx);
+      const result = await prCommand(["checks", "5"], ctx);
 
-      expect(result).toContain('1 passed');
-      expect(result).toContain('1 failed');
-      expect(result).toContain('1 skipped');
-      expect(result).toContain('3 total');
+      expect(result).toContain("1 passed");
+      expect(result).toContain("1 failed");
+      expect(result).toContain("1 skipped");
+      expect(result).toContain("3 total");
     });
   });
 
-  describe('diff', () => {
-    it('wraps diff output in TOON envelope', async () => {
-      mockedGhExec.mockResolvedValue('diff --git a/file.ts b/file.ts\n+added line\n');
+  describe("diff", () => {
+    it("wraps diff output in TOON envelope", async () => {
+      mockedGhExec.mockResolvedValue(
+        "diff --git a/file.ts b/file.ts\n+added line\n",
+      );
 
-      const result = await prCommand(['diff', '7'], ctx);
+      const result = await prCommand(["diff", "7"], ctx);
 
-      expect(result).toContain('pr_diff:');
-      expect(result).toContain('number: 7');
-      expect(result).toContain('diff --git');
-      expect(result).not.toContain('truncated:');
-      expect(result).not.toContain('--full');
+      expect(result).toContain("pr_diff:");
+      expect(result).toContain("number: 7");
+      expect(result).toContain("diff --git");
+      expect(result).not.toContain("truncated:");
+      expect(result).not.toContain("--full");
     });
 
-    it('truncates large diffs with metadata and --full escape hatch', async () => {
-      const largeDiff = 'x'.repeat(25000);
+    it("truncates large diffs with metadata and --full escape hatch", async () => {
+      const largeDiff = "x".repeat(25000);
       mockedGhExec.mockResolvedValue(largeDiff);
 
-      const result = await prCommand(['diff', '7'], ctx);
+      const result = await prCommand(["diff", "7"], ctx);
 
-      expect(result).toContain('truncated: true');
-      expect(result).toContain('original_length: 25000');
-      expect(result).toContain('pr diff 7 --full');
-      expect(result).toContain('to see the complete diff');
+      expect(result).toContain("truncated: true");
+      expect(result).toContain("original_length: 25000");
+      expect(result).toContain("pr diff 7 --full");
+      expect(result).toContain("to see the complete diff");
     });
 
-    it('skips truncation with --full flag', async () => {
-      const largeDiff = 'x'.repeat(25000);
+    it("skips truncation with --full flag", async () => {
+      const largeDiff = "x".repeat(25000);
       mockedGhExec.mockResolvedValue(largeDiff);
 
-      const result = await prCommand(['diff', '7', '--full'], ctx);
+      const result = await prCommand(["diff", "7", "--full"], ctx);
 
-      expect(result).not.toContain('truncated:');
-      expect(result).not.toContain('original_length');
+      expect(result).not.toContain("truncated:");
+      expect(result).not.toContain("original_length");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `gh-axi pr view --reviews` output for review submissions and their inline comments, with a review-count hint when full reviews are not requested.
- Fetches review data through paginated REST API calls so inline comments can be correlated to reviews and repo-scoped contexts work correctly.
- Expands PR command tests for review rendering, pagination, empty-review handling, and combined `--comments --reviews` output.

## Risk Assessment

⚠️ Medium: The change is well scoped and the prior blocking issues were addressed, but there is still a non-blocking performance regression from duplicate review fetching.

## Testing

- Summary: Exercised the PR command tests covering review rendering, REST pagination flattening, and the full existing Vitest suite; all tests passed.
- `npm test -- test/commands/pr.test.ts`
- `npm test`
- Outcome: ✅ passed across 1 run (1m1s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 2 issues (1 error, 1 warning)
- 🚨 `src/commands/pr.ts:286` - The new gh api calls pass ctx into ghJson, so buildArgs appends --repo for -R/--repo or GH_REPO contexts, but gh api rejects --repo. This makes `gh-axi pr view 42 --reviews --repo owner/repo` fail before the API request. Build the REST URL from ctx.owner/ctx.name and avoid passing ctx to gh api, or make buildArgs handle api specially.
- ⚠️ `src/commands/pr.ts:286` - gh api --paginate emits one JSON array per page unless --slurp is used, while ghJson parses stdout as a single JSON value. PRs with reviews or inline comments spanning multiple pages will throw `Unexpected gh output` instead of rendering reviews. Use --slurp and flatten pages, or add a pagination-aware helper.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `src/commands/pr.ts:275` - When --reviews is passed, gh pr view still requests the reviews JSON field even though pr.reviews is discarded and reviews are fetched again through REST. On heavily reviewed PRs this duplicates network work and can noticeably slow the command. Build the gh pr view field list dynamically and omit reviews when includeReviews is true.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npm test -- test/commands/pr.test.ts`
- `npm test`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Lint** - 3 issues found → auto-fixed</summary>

**Round 1** - found 3 issues (1 error, 2 warnings)
- ⚠️ `src/commands/pr.ts:1` - Prettier reported formatting differences.
- ⚠️ `test/commands/pr.test.ts:1` - Prettier reported formatting differences.
- 🚨 `test/commands/pr.test.ts:16` - &#39;mockedGhRaw&#39; is assigned a value but never used. Rule: @typescript-eslint/no-unused-vars.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
