### PR TITLE
feat(errors): add RATE_LIMITED error code for GitHub rate limits

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,6 +6,7 @@ export type ErrorCode =
   | "AUTH_REQUIRED"
   | "FORBIDDEN"
   | "VALIDATION_ERROR"
+  | "RATE_LIMITED"
   | "GH_NOT_INSTALLED"
   | "UNKNOWN";
 
@@ -61,6 +62,24 @@ const patterns: ErrorPattern[] = [
     pattern: /gh auth login/,
     code: "AUTH_REQUIRED",
     message: () => "GitHub auth required — run `gh auth login` first",
+  },
+  {
+    pattern: /secondary rate limit/i,
+    code: "RATE_LIMITED",
+    message: () => "GitHub secondary rate limit hit — wait ~60s and retry",
+    suggestions: () => [
+      "Wait 60s before retrying",
+      "Use `gh api` (REST) for read-only ops, which has a separate budget",
+    ],
+  },
+  {
+    pattern: /API rate limit (?:already )?exceeded/i,
+    code: "RATE_LIMITED",
+    message: () => "GitHub API rate limit exceeded",
+    suggestions: () => [
+      "Wait until the hourly window resets (run `gh api rate_limit` to check)",
+      "Use a different identity with `gh auth switch` if available",
+    ],
   },
   {
     pattern: /HTTP 403/,

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -82,6 +82,33 @@ describe("mapGhError", () => {
     expect(err.code).toBe("FORBIDDEN");
   });
 
+  it("matches GraphQL primary rate limit pattern", () => {
+    const err = mapGhError(
+      "GraphQL: API rate limit already exceeded for user ID 189865151.",
+      1,
+    );
+    expect(err.code).toBe("RATE_LIMITED");
+    expect(err.message).toContain("rate limit");
+    expect(err.suggestions.length).toBeGreaterThan(0);
+  });
+
+  it("matches REST primary rate limit pattern (HTTP 403 form)", () => {
+    const err = mapGhError(
+      "HTTP 403: API rate limit exceeded for user ID 12345.",
+      1,
+    );
+    expect(err.code).toBe("RATE_LIMITED");
+  });
+
+  it("matches secondary rate limit pattern", () => {
+    const err = mapGhError(
+      "HTTP 403: You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
+      1,
+    );
+    expect(err.code).toBe("RATE_LIMITED");
+    expect(err.message).toContain("secondary");
+  });
+
   it("matches validation error pattern with message extraction", () => {
     const stderr = 'HTTP 422: {"message": "Validation Failed", "errors": []}';
     const err = mapGhError(stderr, 1);
@@ -161,6 +188,11 @@ describe("exitCodeForError", () => {
 
   it("returns 1 for FORBIDDEN", () => {
     const err = new AxiError("forbidden", "FORBIDDEN");
+    expect(exitCodeForError(err)).toBe(1);
+  });
+
+  it("returns 1 for RATE_LIMITED", () => {
+    const err = new AxiError("rate limited", "RATE_LIMITED");
     expect(exitCodeForError(err)).toBe(1);
   });
 


### PR DESCRIPTION
## What Changed

- Added `RATE_LIMITED` to the `ErrorCode` union in `src/errors.ts` with two new stderr patterns matching GitHub's secondary rate limit and hourly API rate limit messages, each producing tailored suggestions (wait/retry, switch identity, use `gh api`).
- Added `test/errors.test.ts` cases covering both rate-limit pattern matches and their suggestion payloads.

## Risk Assessment

✅ Low: Small, additive change to error classification with correct pattern ordering ahead of the generic HTTP 403 matcher and test coverage for all three stderr variants.

## Testing

- Summary: Ran the targeted errors test file and the full vitest suite; all tests pass, including the new RATE_LIMITED pattern matchers and exit-code mapping case.
- `npx vitest run test/errors.test.ts`
- <code>`npx vitest run` (full suite, 22 files / 346 tests)</code>
- Outcome: ✅ passed across 1 run (3m9s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npx vitest run test/errors.test.ts`
- <code>`npx vitest run` (full suite, 22 files / 346 tests)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>

