### PR TITLE
feat(issue): support GitHub issue types

### DIFF
--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -306,9 +306,7 @@ async function viewIssue(args: string[], ctx?: RepoContext): Promise<string> {
     : full
       ? viewSchemaFullWithoutType
       : viewSchemaWithoutType;
-  const blocks: string[] = [
-    renderDetail("issue", item, schema),
-  ];
+  const blocks: string[] = [renderDetail("issue", item, schema)];
 
   if (withComments && Array.isArray(item.comments)) {
     blocks.push(
@@ -379,15 +377,14 @@ async function resolveIssueType(
   try {
     parsed = JSON.parse(result.stdout);
   } catch {
-    throw new AxiError(
-      "Unable to resolve issue types from GitHub",
-      "UNKNOWN",
-    );
+    throw new AxiError("Unable to resolve issue types from GitHub", "UNKNOWN");
   }
   const nodes = (
     parsed as {
       data?: {
-        repository?: { issueTypes?: { nodes?: Array<{ id: string; name: string }> } };
+        repository?: {
+          issueTypes?: { nodes?: Array<{ id: string; name: string }> };
+        };
       };
     }
   )?.data?.repository?.issueTypes?.nodes;

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -111,7 +111,19 @@ const viewSchema: FieldDef[] = [
   ),
 ];
 
+const viewSchemaWithoutType: FieldDef[] = viewSchema.filter(
+  (f) => f !== issueTypeField,
+);
+
 const viewSchemaFull: FieldDef[] = viewSchema.map((f) =>
+  "as" in f && f.as === "body"
+    ? custom("body", (item: Record<string, unknown>) =>
+        typeof item.body === "string" ? item.body : "",
+      )
+    : f,
+);
+
+const viewSchemaFullWithoutType: FieldDef[] = viewSchemaWithoutType.map((f) =>
   "as" in f && f.as === "body"
     ? custom("body", (item: Record<string, unknown>) =>
         typeof item.body === "string" ? item.body : "",
@@ -272,10 +284,12 @@ async function viewIssue(args: string[], ctx?: RepoContext): Promise<string> {
   const ghArgs = ["issue", "view", String(num), "--json", fields];
 
   let item: Record<string, unknown>;
+  let supportsIssueType = true;
   try {
     item = await ghJson<Record<string, unknown>>(ghArgs, ctx);
   } catch (e) {
     if (e instanceof AxiError && /issueType/i.test(e.message)) {
+      supportsIssueType = false;
       item = await ghJson<Record<string, unknown>>(
         ["issue", "view", String(num), "--json", baseFields],
         ctx,
@@ -285,8 +299,15 @@ async function viewIssue(args: string[], ctx?: RepoContext): Promise<string> {
     }
   }
 
+  const schema = supportsIssueType
+    ? full
+      ? viewSchemaFull
+      : viewSchema
+    : full
+      ? viewSchemaFullWithoutType
+      : viewSchemaWithoutType;
   const blocks: string[] = [
-    renderDetail("issue", item, full ? viewSchemaFull : viewSchema),
+    renderDetail("issue", item, schema),
   ];
 
   if (withComments && Array.isArray(item.comments)) {
@@ -307,6 +328,18 @@ async function viewIssue(args: string[], ctx?: RepoContext): Promise<string> {
 interface ResolvedIssueType {
   id: string;
   name: string;
+}
+
+function getOptionalRequiredFlag(
+  args: string[],
+  name: string,
+): string | undefined {
+  if (!hasFlag(args, name)) return undefined;
+  const value = getFlag(args, name);
+  if (value === undefined || value.trim() === "" || value.startsWith("--")) {
+    throw new AxiError(`${name} requires a value`, "VALIDATION_ERROR");
+  }
+  return value;
 }
 
 async function getOwnerName(
@@ -406,7 +439,7 @@ async function createIssue(args: string[], ctx?: RepoContext): Promise<string> {
   const label = getFlag(args, "--label");
   const milestone = getFlag(args, "--milestone");
   const project = getFlag(args, "--project");
-  const typeName = getFlag(args, "--type");
+  const typeName = getOptionalRequiredFlag(args, "--type");
 
   // Resolve type up front so an invalid value fails before creating the issue.
   let resolvedType: ResolvedIssueType | undefined;
@@ -469,9 +502,8 @@ async function editIssue(args: string[], ctx?: RepoContext): Promise<string> {
   const removeAssignee = getFlag(args, "--remove-assignee");
   const milestone = getFlag(args, "--milestone");
   const clearType = takeBoolFlag(args, "--no-type");
-  const rawType = getFlag(args, "--type");
-  const typeName = rawType && rawType.length > 0 ? rawType : undefined;
-  const clearTypeFlag = clearType || rawType === "";
+  const typeName = getOptionalRequiredFlag(args, "--type");
+  const clearTypeFlag = clearType;
 
   // Resolve type up front so an invalid value fails before mutating the issue.
   let resolvedType: ResolvedIssueType | undefined;

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -1,6 +1,6 @@
 import type { RepoContext } from "../context.js";
 import { ghJson, ghExec, ghRaw } from "../gh.js";
-import { AxiError } from "../errors.js";
+import { AxiError, mapGhError } from "../errors.js";
 import { getSuggestions } from "../suggestions.js";
 import {
   getFlag,
@@ -8,6 +8,7 @@ import {
   getPositional,
   requireNumber,
   takeFlag,
+  takeBoolFlag,
 } from "../args.js";
 import { truncateBody } from "../body.js";
 import { parseFields, type ExtraFieldSpec } from "../fields.js";
@@ -61,9 +62,9 @@ flags{list}:
 flags{view}:
   --comments, --full (show complete body without truncation)
 flags{create}:
-  --title <text> (required), --body <text>, --assignee <login>, --label <name>, --milestone <name>
+  --title <text> (required), --body <text>, --assignee <login>, --label <name>, --milestone <name>, --type <name>
 flags{edit}:
-  --title, --body, --add-label, --remove-label, --add-assignee, --remove-assignee, --milestone
+  --title, --body, --add-label, --remove-label, --add-assignee, --remove-assignee, --milestone, --type <name>, --no-type
 flags{close}:
   --reason <completed|not_planned>, --comment <text>
 flags{comment}:
@@ -89,12 +90,22 @@ const listSchema: FieldDef[] = [
   relativeTime("createdAt", "created"),
 ];
 
+const issueTypeField = custom("type", (item: Record<string, unknown>) => {
+  const it = item.issueType;
+  if (it && typeof it === "object") {
+    const name = (it as Record<string, unknown>).name;
+    if (typeof name === "string" && name.length > 0) return name;
+  }
+  return "none";
+});
+
 const viewSchema: FieldDef[] = [
   field("number"),
   field("title"),
   lower("state"),
   pluck("author", "login", "author"),
   relativeTime("createdAt", "created"),
+  issueTypeField,
   custom("body", (item: Record<string, unknown>) =>
     truncateBody(item.body, 500),
   ),
@@ -254,12 +265,25 @@ async function viewIssue(args: string[], ctx?: RepoContext): Promise<string> {
   const withComments = hasFlag(args, "--comments");
   const full = hasFlag(args, "--full");
 
-  const fields =
+  const baseFields =
     "number,title,state,author,createdAt,body" +
     (withComments ? ",comments" : "");
+  const fields = baseFields + ",issueType";
   const ghArgs = ["issue", "view", String(num), "--json", fields];
 
-  const item = await ghJson<Record<string, unknown>>(ghArgs, ctx);
+  let item: Record<string, unknown>;
+  try {
+    item = await ghJson<Record<string, unknown>>(ghArgs, ctx);
+  } catch (e) {
+    if (e instanceof AxiError && /issueType/i.test(e.message)) {
+      item = await ghJson<Record<string, unknown>>(
+        ["issue", "view", String(num), "--json", baseFields],
+        ctx,
+      );
+    } else {
+      throw e;
+    }
+  }
 
   const blocks: string[] = [
     renderDetail("issue", item, full ? viewSchemaFull : viewSchema),
@@ -280,6 +304,99 @@ async function viewIssue(args: string[], ctx?: RepoContext): Promise<string> {
   return renderOutput(blocks);
 }
 
+interface ResolvedIssueType {
+  id: string;
+  name: string;
+}
+
+async function getOwnerName(
+  ctx?: RepoContext,
+): Promise<{ owner: string; name: string }> {
+  if (ctx) return { owner: ctx.owner, name: ctx.name };
+  const repo = await ghJson<{ owner: { login: string }; name: string }>([
+    "repo",
+    "view",
+    "--json",
+    "owner,name",
+  ]);
+  return { owner: repo.owner.login, name: repo.name };
+}
+
+async function resolveIssueType(
+  typeName: string,
+  ctx?: RepoContext,
+): Promise<ResolvedIssueType> {
+  const { owner, name } = await getOwnerName(ctx);
+  const query =
+    "query($owner:String!,$name:String!){repository(owner:$owner,name:$name){issueTypes(first:25){nodes{id name}}}}";
+  const result = await ghRaw([
+    "api",
+    "graphql",
+    "-f",
+    `owner=${owner}`,
+    "-f",
+    `name=${name}`,
+    "-f",
+    `query=${query}`,
+  ]);
+  if (result.exitCode !== 0) {
+    throw mapGhError(result.stderr, result.exitCode);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    throw new AxiError(
+      "Unable to resolve issue types from GitHub",
+      "UNKNOWN",
+    );
+  }
+  const nodes = (
+    parsed as {
+      data?: {
+        repository?: { issueTypes?: { nodes?: Array<{ id: string; name: string }> } };
+      };
+    }
+  )?.data?.repository?.issueTypes?.nodes;
+  if (!Array.isArray(nodes) || nodes.length === 0) {
+    throw new AxiError(
+      `Issue types are not configured for this repository. Enable them in repo settings before using --type.`,
+      "VALIDATION_ERROR",
+    );
+  }
+  const wanted = typeName.toLowerCase();
+  const match = nodes.find(
+    (n) => typeof n?.name === "string" && n.name.toLowerCase() === wanted,
+  );
+  if (!match) {
+    const available = nodes
+      .map((n) => n?.name)
+      .filter((s): s is string => typeof s === "string");
+    throw new AxiError(
+      `Unknown issue type "${typeName}". Available types: ${available.join(", ")}`,
+      "VALIDATION_ERROR",
+    );
+  }
+  return { id: match.id, name: match.name };
+}
+
+async function applyIssueType(
+  issueNodeId: string,
+  typeId: string | null,
+): Promise<void> {
+  const mutation =
+    typeId === null
+      ? `mutation($id:ID!){updateIssue(input:{id:$id,issueTypeId:null}){issue{id}}}`
+      : `mutation($id:ID!,$typeId:ID!){updateIssue(input:{id:$id,issueTypeId:$typeId}){issue{id}}}`;
+  const args = ["api", "graphql", "-f", `id=${issueNodeId}`];
+  if (typeId !== null) args.push("-f", `typeId=${typeId}`);
+  args.push("-f", `query=${mutation}`);
+  const result = await ghRaw(args);
+  if (result.exitCode !== 0) {
+    throw mapGhError(result.stderr, result.exitCode);
+  }
+}
+
 async function createIssue(args: string[], ctx?: RepoContext): Promise<string> {
   const title = getFlag(args, "--title");
   if (!title) throw new AxiError("--title is required", "VALIDATION_ERROR");
@@ -289,6 +406,13 @@ async function createIssue(args: string[], ctx?: RepoContext): Promise<string> {
   const label = getFlag(args, "--label");
   const milestone = getFlag(args, "--milestone");
   const project = getFlag(args, "--project");
+  const typeName = getFlag(args, "--type");
+
+  // Resolve type up front so an invalid value fails before creating the issue.
+  let resolvedType: ResolvedIssueType | undefined;
+  if (typeName) {
+    resolvedType = await resolveIssueType(typeName, ctx);
+  }
 
   const ghArgs = ["issue", "create", "--title", title];
   if (body) ghArgs.push("--body", body);
@@ -305,13 +429,24 @@ async function createIssue(args: string[], ctx?: RepoContext): Promise<string> {
   const numMatch = url.match(/\/issues\/(\d+)/);
   const num = numMatch ? parseInt(numMatch[1], 10) : 0;
 
-  // Fetch the created issue for structured output
+  // Fetch the created issue for structured output; include id for type mutation
   const item = await ghJson<Record<string, unknown>>(
-    ["issue", "view", String(num), "--json", "number,title,state,url"],
+    ["issue", "view", String(num), "--json", "number,title,state,url,id"],
     ctx,
   );
 
-  const blocks: string[] = [renderDetail("issue", item, createResultSchema)];
+  if (resolvedType) {
+    const issueNodeId = item.id;
+    if (typeof issueNodeId === "string" && issueNodeId.length > 0) {
+      await applyIssueType(issueNodeId, resolvedType.id);
+    }
+    item.issueType = { name: resolvedType.name };
+  }
+
+  const schema = resolvedType
+    ? [...createResultSchema, issueTypeField]
+    : createResultSchema;
+  const blocks: string[] = [renderDetail("issue", item, schema)];
   const help = getSuggestions({
     domain: "issue",
     action: "create",
@@ -333,6 +468,16 @@ async function editIssue(args: string[], ctx?: RepoContext): Promise<string> {
   const addAssignee = getFlag(args, "--add-assignee");
   const removeAssignee = getFlag(args, "--remove-assignee");
   const milestone = getFlag(args, "--milestone");
+  const clearType = takeBoolFlag(args, "--no-type");
+  const rawType = getFlag(args, "--type");
+  const typeName = rawType && rawType.length > 0 ? rawType : undefined;
+  const clearTypeFlag = clearType || rawType === "";
+
+  // Resolve type up front so an invalid value fails before mutating the issue.
+  let resolvedType: ResolvedIssueType | undefined;
+  if (typeName) {
+    resolvedType = await resolveIssueType(typeName, ctx);
+  }
 
   const ghArgs = ["issue", "edit", String(num)];
   if (title) ghArgs.push("--title", title);
@@ -343,21 +488,37 @@ async function editIssue(args: string[], ctx?: RepoContext): Promise<string> {
   if (removeAssignee) ghArgs.push("--remove-assignee", removeAssignee);
   if (milestone) ghArgs.push("--milestone", milestone);
 
-  await ghExec(ghArgs, ctx);
+  // Only call `gh issue edit` if there is a non-type field to update; otherwise
+  // calling with just the issue number errors out.
+  if (ghArgs.length > 3) {
+    await ghExec(ghArgs, ctx);
+  }
 
-  // Fetch updated issue
+  // Fetch updated issue (include id for type mutation)
   const item = await ghJson<Record<string, unknown>>(
     [
       "issue",
       "view",
       String(num),
       "--json",
-      "number,title,state,labels,assignees",
+      "number,title,state,labels,assignees,id",
     ],
     ctx,
   );
 
-  const blocks: string[] = [renderDetail("issue", item, editResultSchema)];
+  if (resolvedType || clearTypeFlag) {
+    const issueNodeId = item.id;
+    if (typeof issueNodeId === "string" && issueNodeId.length > 0) {
+      await applyIssueType(issueNodeId, resolvedType ? resolvedType.id : null);
+    }
+    item.issueType = resolvedType ? { name: resolvedType.name } : null;
+  }
+
+  const schema =
+    resolvedType || clearTypeFlag
+      ? [...editResultSchema, issueTypeField]
+      : editResultSchema;
+  const blocks: string[] = [renderDetail("issue", item, schema)];
   const help = getSuggestions({
     domain: "issue",
     action: "edit",

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -15,9 +15,7 @@ const mockedGhJson = vi.mocked(ghJson);
 const mockedGhExec = vi.mocked(ghExec);
 const mockedGhRaw = vi.mocked(ghRaw);
 
-function mockTypeQueryOnce(
-  nodes: Array<{ id: string; name: string }>,
-): void {
+function mockTypeQueryOnce(nodes: Array<{ id: string; name: string }>): void {
   mockedGhRaw.mockResolvedValueOnce({
     stdout: JSON.stringify({
       data: { repository: { issueTypes: { nodes } } },
@@ -292,7 +290,9 @@ describe("issueCommand", () => {
 
       // Verify resolve query was issued
       const resolveCall = mockedGhRaw.mock.calls.find((c) =>
-        (c[0] as string[]).some((a) => typeof a === "string" && a.includes("issueTypes")),
+        (c[0] as string[]).some(
+          (a) => typeof a === "string" && a.includes("issueTypes"),
+        ),
       );
       expect(resolveCall).toBeDefined();
 

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -218,6 +218,7 @@ describe("issueCommand", () => {
 
       const result = await issueCommand(["view", "42"], ctx);
       expect(result).toContain("Critical bug");
+      expect(result).not.toContain("type: none");
     });
 
     it("omits help suggestions from detail view", async () => {
@@ -357,6 +358,13 @@ describe("issueCommand", () => {
       // No gh issue create should have been called when type resolution fails
       expect(mockedGhExec).not.toHaveBeenCalled();
     });
+
+    it("rejects --type without a value", async () => {
+      await expect(
+        issueCommand(["create", "--title", "X", "--type"], ctx),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
   });
 
   describe("edit with --type", () => {
@@ -419,6 +427,14 @@ describe("issueCommand", () => {
       const flat = (mutationCall![0] as string[]).join(" ");
       // null literal embedded directly in the mutation
       expect(flat).toContain("issueTypeId:null");
+    });
+
+    it("rejects --type without a value", async () => {
+      await expect(issueCommand(["edit", "10", "--type"], ctx)).rejects.toThrow(
+        AxiError,
+      );
+      expect(mockedGhJson).not.toHaveBeenCalled();
+      expect(mockedGhExec).not.toHaveBeenCalled();
     });
   });
 

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -6,13 +6,36 @@ vi.mock("../../src/gh.js", () => ({
   ghRaw: vi.fn(),
 }));
 
-import { ghJson, ghExec } from "../../src/gh.js";
+import { ghJson, ghExec, ghRaw } from "../../src/gh.js";
 import { issueCommand, ISSUE_HELP } from "../../src/commands/issue.js";
 import { AxiError } from "../../src/errors.js";
 import type { RepoContext } from "../../src/context.js";
 
 const mockedGhJson = vi.mocked(ghJson);
 const mockedGhExec = vi.mocked(ghExec);
+const mockedGhRaw = vi.mocked(ghRaw);
+
+function mockTypeQueryOnce(
+  nodes: Array<{ id: string; name: string }>,
+): void {
+  mockedGhRaw.mockResolvedValueOnce({
+    stdout: JSON.stringify({
+      data: { repository: { issueTypes: { nodes } } },
+    }),
+    stderr: "",
+    exitCode: 0,
+  });
+}
+
+function mockTypeMutationOnce(): void {
+  mockedGhRaw.mockResolvedValueOnce({
+    stdout: JSON.stringify({
+      data: { updateIssue: { issue: { id: "I_node" } } },
+    }),
+    stderr: "",
+    exitCode: 0,
+  });
+}
 
 const ctx: RepoContext = {
   owner: "octo",
@@ -146,6 +169,57 @@ describe("issueCommand", () => {
       expect(result).toContain("alice");
     });
 
+    it("includes issueType in the --json field list and renders type", async () => {
+      mockedGhJson.mockResolvedValue({
+        number: 42,
+        title: "Critical bug",
+        state: "OPEN",
+        author: { login: "alice" },
+        createdAt: "2024-01-01T00:00:00Z",
+        body: "Some issue body",
+        issueType: { name: "Bug" },
+      });
+
+      const result = await issueCommand(["view", "42"], ctx);
+
+      const callArgs = mockedGhJson.mock.calls[0][0] as string[];
+      const jsonIdx = callArgs.indexOf("--json");
+      expect(callArgs[jsonIdx + 1]).toContain("issueType");
+      expect(result).toContain("type: Bug");
+    });
+
+    it("renders type as none when no issueType is set", async () => {
+      mockedGhJson.mockResolvedValue({
+        number: 42,
+        title: "Critical bug",
+        state: "OPEN",
+        author: { login: "alice" },
+        createdAt: "2024-01-01T00:00:00Z",
+        body: "Some issue body",
+        issueType: null,
+      });
+
+      const result = await issueCommand(["view", "42"], ctx);
+      expect(result).toContain("type: none");
+    });
+
+    it("falls back when gh does not support the issueType field", async () => {
+      mockedGhJson.mockRejectedValueOnce(
+        new AxiError('unknown JSON field: "issueType"', "UNKNOWN"),
+      );
+      mockedGhJson.mockResolvedValueOnce({
+        number: 42,
+        title: "Critical bug",
+        state: "OPEN",
+        author: { login: "alice" },
+        createdAt: "2024-01-01T00:00:00Z",
+        body: "Some issue body",
+      });
+
+      const result = await issueCommand(["view", "42"], ctx);
+      expect(result).toContain("Critical bug");
+    });
+
     it("omits help suggestions from detail view", async () => {
       mockedGhJson.mockResolvedValue({
         number: 42,
@@ -187,6 +261,164 @@ describe("issueCommand", () => {
         expect.arrayContaining(["issue", "create", "--title", "New issue"]),
         ctx,
       );
+    });
+
+    it("applies --type via graphql mutation and renders the type", async () => {
+      // 1) resolve type
+      mockTypeQueryOnce([
+        { id: "T_task", name: "Task" },
+        { id: "T_feat", name: "Feature" },
+      ]);
+      mockedGhExec.mockResolvedValue(
+        "https://github.com/octo/repo/issues/99\n",
+      );
+      mockedGhJson.mockResolvedValue({
+        number: 99,
+        title: "New",
+        state: "OPEN",
+        url: "https://github.com/octo/repo/issues/99",
+        id: "I_node99",
+      });
+      // 2) apply mutation
+      mockTypeMutationOnce();
+
+      const result = await issueCommand(
+        ["create", "--title", "New", "--type", "Task"],
+        ctx,
+      );
+
+      expect(result).toContain("type: Task");
+
+      // Verify resolve query was issued
+      const resolveCall = mockedGhRaw.mock.calls.find((c) =>
+        (c[0] as string[]).some((a) => typeof a === "string" && a.includes("issueTypes")),
+      );
+      expect(resolveCall).toBeDefined();
+
+      // Verify mutation was issued with issue node ID and type id
+      const mutationCall = mockedGhRaw.mock.calls.find((c) =>
+        (c[0] as string[]).some(
+          (a) => typeof a === "string" && a.includes("updateIssue"),
+        ),
+      );
+      expect(mutationCall).toBeDefined();
+      const flat = (mutationCall![0] as string[]).join(" ");
+      expect(flat).toContain("I_node99");
+      expect(flat).toContain("T_task");
+    });
+
+    it("matches --type case-insensitively", async () => {
+      mockTypeQueryOnce([{ id: "T_task", name: "Task" }]);
+      mockedGhExec.mockResolvedValue(
+        "https://github.com/octo/repo/issues/99\n",
+      );
+      mockedGhJson.mockResolvedValue({
+        number: 99,
+        title: "New",
+        state: "OPEN",
+        url: "https://github.com/octo/repo/issues/99",
+        id: "I_node99",
+      });
+      mockTypeMutationOnce();
+
+      const result = await issueCommand(
+        ["create", "--title", "New", "--type", "task"],
+        ctx,
+      );
+
+      expect(result).toContain("type: Task");
+    });
+
+    it("rejects unknown --type with a hint listing supported types", async () => {
+      mockTypeQueryOnce([
+        { id: "T_task", name: "Task" },
+        { id: "T_feat", name: "Feature" },
+        { id: "T_bug", name: "Bug" },
+      ]);
+
+      await expect(
+        issueCommand(["create", "--title", "X", "--type", "Bogus"], ctx),
+      ).rejects.toThrow(AxiError);
+
+      mockTypeQueryOnce([
+        { id: "T_task", name: "Task" },
+        { id: "T_feat", name: "Feature" },
+        { id: "T_bug", name: "Bug" },
+      ]);
+
+      try {
+        await issueCommand(["create", "--title", "X", "--type", "Bogus"], ctx);
+      } catch (e) {
+        expect((e as AxiError).code).toBe("VALIDATION_ERROR");
+        expect((e as AxiError).message).toContain("Task");
+        expect((e as AxiError).message).toContain("Feature");
+        expect((e as AxiError).message).toContain("Bug");
+      }
+      // No gh issue create should have been called when type resolution fails
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("edit with --type", () => {
+    it("applies --type via graphql mutation", async () => {
+      // 1) resolve type
+      mockTypeQueryOnce([
+        { id: "T_task", name: "Task" },
+        { id: "T_feat", name: "Feature" },
+      ]);
+      mockedGhJson.mockResolvedValue({
+        number: 10,
+        title: "X",
+        state: "OPEN",
+        labels: [],
+        assignees: [],
+        id: "I_node10",
+      });
+      // 2) apply mutation
+      mockTypeMutationOnce();
+
+      const result = await issueCommand(
+        ["edit", "10", "--type", "Feature"],
+        ctx,
+      );
+
+      expect(result).toContain("type: Feature");
+      // No `gh issue edit` should be invoked when only --type is provided
+      expect(mockedGhExec).not.toHaveBeenCalled();
+
+      const mutationCall = mockedGhRaw.mock.calls.find((c) =>
+        (c[0] as string[]).some(
+          (a) => typeof a === "string" && a.includes("updateIssue"),
+        ),
+      );
+      expect(mutationCall).toBeDefined();
+      const flat = (mutationCall![0] as string[]).join(" ");
+      expect(flat).toContain("I_node10");
+      expect(flat).toContain("T_feat");
+    });
+
+    it("clears the type when --no-type is passed", async () => {
+      mockedGhJson.mockResolvedValue({
+        number: 10,
+        title: "X",
+        state: "OPEN",
+        labels: [],
+        assignees: [],
+        id: "I_node10",
+      });
+      mockTypeMutationOnce();
+
+      await issueCommand(["edit", "10", "--no-type"], ctx);
+
+      const mutationCall = mockedGhRaw.mock.calls.find((c) =>
+        (c[0] as string[]).some(
+          (a) => typeof a === "string" && a.includes("updateIssue"),
+        ),
+      );
+      expect(mutationCall).toBeDefined();
+      const flat = (mutationCall![0] as string[]).join(" ");
+      // null literal embedded directly in the mutation
+      expect(flat).toContain("issueTypeId:null");
     });
   });
 


### PR DESCRIPTION
## Intent

The developer wanted a maintainer-style triage of GitHub issue https://github.com/kunchenguid/gh-axi/issues/27 using the managed local checkout and any relevant GitHub context, without cloning or mutating the repository. They required structured JSON options describing proposed resolutions, including comments, coding-agent handoff prompts, state changes, waiting-on status, and confidence. They emphasized preferring actionable issues to be marked fix_required with a detailed multi-line fix prompt, while also surfacing reasonable alternatives when appropriate. The resulting triage identified the issue as legitimate and actionable, recommending a coding-agent handoff for GraphQL fallback support because gh does not expose --type, plus improved validation-error UX and acceptance criteria.

## What Changed
- Added issue type display to `gh-axi issue view`, with a fallback path when the installed `gh` version does not expose the `issueType` JSON field.
- Added `--type` support for `issue create` and `issue edit`, plus `--no-type` for clearing issue types, using GitHub GraphQL to resolve and update issue type IDs.
- Expanded issue command tests for type rendering, GraphQL mutation behavior, case-insensitive type matching, missing-value validation, unknown type errors, and clearing types.

## Risk Assessment

✅ Low: The changes are narrowly scoped to issue type viewing and mutation paths, previous edge-case findings are addressed, and no material correctness or security risks were found in the reviewed diff.

## Testing

- Summary: Exercised the issue command’s new issue-type view/create/edit paths with the focused Vitest suite, then ran the full existing test suite; all tests passed.
- `pnpm vitest run test/commands/issue.test.ts`
- `pnpm test`
- Outcome: ✅ passed across 1 run (1m26s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `src/commands/issue.ts:409` - `--type` is treated as absent when the flag is provided without a value, so `issue create --title X --type` will still create an untyped issue instead of failing validation; the same parsing pattern at line 472 makes `issue edit 10 --type` report success without changing the type. Validate presence of a non-empty value whenever the new `--type` flag is present.
- ⚠️ `src/commands/issue.ts:289` - When `gh issue view --json issueType` is unsupported, the fallback refetches without `issueType` but still renders `viewSchema`, causing `type: none` to be displayed even though the type is unknown. Use a schema without the type field on fallback, or render an explicit unavailable value, to avoid misreporting issues as untyped.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `pnpm vitest run test/commands/issue.test.ts`
- `pnpm test`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Lint** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `src/commands/issue.ts:1` - Prettier reported formatting differences in this changed file. Run `pnpm exec prettier --write &#34;src/commands/issue.ts&#34;` or format the changed files together.
- ⚠️ `test/commands/issue.test.ts:1` - Prettier reported formatting differences in this changed file. Run `pnpm exec prettier --write &#34;test/commands/issue.test.ts&#34;` or format the changed files together.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
