### PR TITLE
feat(commands): add issue subissue management

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,17 @@ gh-axi run view --job 789012 --log-failed # show failed log lines for one job
 
 ### Commands
 
-| Command    | Description                                               |
-| ---------- | --------------------------------------------------------- |
+| Command    | Description                                                         |
+| ---------- | ------------------------------------------------------------------- |
 | `issue`    | Issues — list, view, create, edit, close, reopen, comment, subissue |
-| `pr`       | Pull requests — list, view, create, merge, review, checks |
-| `run`      | Workflow runs — list, view, rerun, cancel, watch          |
-| `workflow` | Workflows — list, view, run, enable, disable              |
-| `release`  | Releases — list, view, create, edit, delete               |
-| `repo`     | Repositories — list, view, create, edit, clone, fork      |
-| `label`    | Labels — list, create, edit, delete                       |
-| `search`   | Search issues, PRs, repos, commits, code                  |
-| `api`      | Raw GitHub API access                                     |
+| `pr`       | Pull requests — list, view, create, merge, review, checks           |
+| `run`      | Workflow runs — list, view, rerun, cancel, watch                    |
+| `workflow` | Workflows — list, view, run, enable, disable                        |
+| `release`  | Releases — list, view, create, edit, delete                         |
+| `repo`     | Repositories — list, view, create, edit, clone, fork                |
+| `label`    | Labels — list, create, edit, delete                                 |
+| `search`   | Search issues, PRs, repos, commits, code                            |
+| `api`      | Raw GitHub API access                                               |
 
 ### Global flags
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ hooks. Those hooks invoke `gh-axi` directly from the packaged production build.
 ```bash
 gh-axi                          # dashboard - live state, no args needed
 gh-axi issue list               # list issues in current repo
+gh-axi issue subissue list 16   # list sub-issues for issue #16
 gh-axi pr view 42               # view pull request #42
 gh-axi run list -R owner/repo   # list workflow runs for a specific repo
 gh-axi run view 123456 --job 789012       # inspect a single job within a run
@@ -40,7 +41,7 @@ gh-axi run view --job 789012 --log-failed # show failed log lines for one job
 
 | Command    | Description                                               |
 | ---------- | --------------------------------------------------------- |
-| `issue`    | Issues — list, view, create, edit, close, reopen, comment |
+| `issue`    | Issues — list, view, create, edit, close, reopen, comment, subissue |
 | `pr`       | Pull requests — list, view, create, merge, review, checks |
 | `run`      | Workflow runs — list, view, rerun, cancel, watch          |
 | `workflow` | Workflows — list, view, run, enable, disable              |

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -1025,10 +1025,7 @@ function requireRepo(ctx?: RepoContext): RepoContext {
   return ctx;
 }
 
-async function gqlRequest<T>(
-  query: string,
-  ctx?: RepoContext,
-): Promise<T> {
+async function gqlRequest<T>(query: string, ctx?: RepoContext): Promise<T> {
   // Don't pass ctx through to ghJson — `gh api graphql` ignores --repo, and
   // passing it produces a deprecation warning. The owner/name are baked into
   // the query string instead.
@@ -1048,9 +1045,7 @@ async function resolveIssueIds(
   ctx: RepoContext,
 ): Promise<{ parent: ResolvedIssue; children: ResolvedIssue[] }> {
   const childFields = children
-    .map(
-      (n, i) => `c${i}: issue(number: ${n}) { id number }`,
-    )
+    .map((n, i) => `c${i}: issue(number: ${n}) { id number }`)
     .join(" ");
   const query = `query { repository(owner: "${ctx.owner}", name: "${ctx.name}") { parent: issue(number: ${parent}) { id number } ${childFields} } }`;
   const result = await gqlRequest<{
@@ -1060,10 +1055,7 @@ async function resolveIssueIds(
   const repo = result.repository ?? {};
   const parentNode = repo.parent;
   if (!parentNode) {
-    throw new AxiError(
-      `Issue #${parent} not found in ${ctx.nwo}`,
-      "NOT_FOUND",
-    );
+    throw new AxiError(`Issue #${parent} not found in ${ctx.nwo}`, "NOT_FOUND");
   }
   const childNodes: ResolvedIssue[] = [];
   for (let i = 0; i < children.length; i++) {
@@ -1079,10 +1071,7 @@ async function resolveIssueIds(
   return { parent: parentNode, children: childNodes };
 }
 
-async function subissueAdd(
-  args: string[],
-  ctx?: RepoContext,
-): Promise<string> {
+async function subissueAdd(args: string[], ctx?: RepoContext): Promise<string> {
   const repo = requireRepo(ctx);
   const parentRaw = args[2];
   const childRaw = args.slice(3).filter((a) => !a.startsWith("--"));
@@ -1095,7 +1084,11 @@ async function subissueAdd(
   }
   const childNums = childRaw.map((r) => requireNumber(r, "child"));
 
-  const { parent, children } = await resolveIssueIds(parentNum, childNums, repo);
+  const { parent, children } = await resolveIssueIds(
+    parentNum,
+    childNums,
+    repo,
+  );
 
   const addedNumbers: number[] = [];
   for (const child of children) {
@@ -1173,10 +1166,7 @@ async function subissueRemove(
     removed: `#${child.number}`,
   };
   const blocks: string[] = [
-    renderDetail("subissue_remove", item, [
-      field("parent"),
-      field("removed"),
-    ]),
+    renderDetail("subissue_remove", item, [field("parent"), field("removed")]),
   ];
   blocks.push(
     renderHelp([
@@ -1219,11 +1209,7 @@ async function subissueList(
     totalCount,
   });
 
-  const schema: FieldDef[] = [
-    field("number"),
-    field("title"),
-    lower("state"),
-  ];
+  const schema: FieldDef[] = [field("number"), field("title"), lower("state")];
 
   const blocks: string[] = [
     `parent: #${parentNum}`,

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -1097,23 +1097,15 @@ async function subissueAdd(
 
   const { parent, children } = await resolveIssueIds(parentNum, childNums, repo);
 
-  const mutationBody = children
-    .map(
-      (c, i) =>
-        `m${i}: addSubIssue(input: { issueId: "${parent.id}", subIssueId: "${c.id}" }) { subIssue { number } }`,
-    )
-    .join(" ");
-  const mutation = `mutation { ${mutationBody} }`;
-  const result = await gqlRequest<Record<string, { subIssue: { number: number } }>>(
-    mutation,
-    repo,
-  );
-
   const addedNumbers: number[] = [];
-  for (let i = 0; i < children.length; i++) {
-    const r = result[`m${i}`];
+  for (const child of children) {
+    const mutation = `mutation { addSubIssue(input: { issueId: "${parent.id}", subIssueId: "${child.id}" }) { subIssue { number } } }`;
+    const result = await gqlRequest<{
+      addSubIssue?: { subIssue?: { number?: number } };
+    }>(mutation, repo);
+    const r = result.addSubIssue;
     if (r?.subIssue?.number != null) addedNumbers.push(r.subIssue.number);
-    else addedNumbers.push(children[i].number);
+    else addedNumbers.push(child.number);
   }
 
   const item = {

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -1288,6 +1288,10 @@ export async function issueCommand(
 ): Promise<string> {
   const sub = args[0];
 
+  if (sub === "subissue") {
+    return subissueCommand(args, ctx);
+  }
+
   if (!sub || hasFlag(args, "--help")) {
     const blocks: string[] = [ISSUE_HELP];
     const help = getSuggestions({ domain: "issue", action: "help", repo: ctx });
@@ -1322,8 +1326,6 @@ export async function issueCommand(
       return unpinIssue(args, ctx);
     case "transfer":
       return transferIssue(args, ctx);
-    case "subissue":
-      return subissueCommand(args, ctx);
     default:
       return renderError(
         `Unknown issue subcommand: ${sub}`,

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -1100,9 +1100,25 @@ async function subissueAdd(
   const addedNumbers: number[] = [];
   for (const child of children) {
     const mutation = `mutation { addSubIssue(input: { issueId: "${parent.id}", subIssueId: "${child.id}" }) { subIssue { number } } }`;
-    const result = await gqlRequest<{
-      addSubIssue?: { subIssue?: { number?: number } };
-    }>(mutation, repo);
+    let result: { addSubIssue?: { subIssue?: { number?: number } } };
+    try {
+      result = await gqlRequest<{
+        addSubIssue?: { subIssue?: { number?: number } };
+      }>(mutation, repo);
+    } catch (error) {
+      if (addedNumbers.length === 0) throw error;
+      const added = addedNumbers.map((n) => `#${n}`).join(", ");
+      if (error instanceof AxiError) {
+        throw new AxiError(
+          `${error.message}\nAdded before failure: ${added}`,
+          error.code,
+        );
+      }
+      throw new AxiError(
+        `Failed to add sub-issue #${child.number}\nAdded before failure: ${added}`,
+        "UNKNOWN",
+      );
+    }
     const r = result.addSubIssue;
     if (r?.subIssue?.number != null) addedNumbers.push(r.subIssue.number);
     else addedNumbers.push(child.number);

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -55,8 +55,8 @@ interface IssueComment {
 // ---------------------------------------------------------------------------
 
 export const ISSUE_HELP = `usage: gh-axi issue <subcommand> [flags]
-subcommands[13]:
-  list, view <number>, create, edit <number>, close <number>, reopen <number>, comment <number>, delete <number>, lock <number>, unlock <number>, pin <number>, unpin <number>, transfer <number>
+subcommands[14]:
+  list, view <number>, create, edit <number>, close <number>, reopen <number>, comment <number>, delete <number>, lock <number>, unlock <number>, pin <number>, unpin <number>, transfer <number>, subissue <add|remove|list>
 flags{list}:
   --state <open|closed|all>, --label <name>, --assignee <login>, --author <login>, --milestone <name>, --sort <created|updated|comments>, --limit <n> (default 30), --fields <a,b,c>
 flags{view}:
@@ -71,12 +71,24 @@ flags{comment}:
   --body <text> (required)
 flags{transfer}:
   --to-repo <owner/name> (required)
+subissue:
+  add <parent> <child> [<child> ...], remove <parent> <child>, list <parent>
 examples:
   gh-axi issue list --state closed --label bug
   gh-axi issue view 42 --comments
   gh-axi issue create --title "Fix login" --body "Steps to reproduce..."
   gh-axi issue close 42 --reason completed
-  gh-axi issue transfer 42 -R source/repo --to-repo dest/repo`;
+  gh-axi issue transfer 42 -R source/repo --to-repo dest/repo
+  gh-axi issue subissue add 16 20 101 125
+  gh-axi issue subissue list 16`;
+
+export const SUBISSUE_HELP = `usage: gh-axi issue subissue <add|remove|list> <parent> [child...]
+subcommands[3]:
+  add <parent> <child> [<child> ...], remove <parent> <child>, list <parent>
+examples:
+  gh-axi issue subissue add 16 20 101 125
+  gh-axi issue subissue remove 16 101
+  gh-axi issue subissue list 16`;
 
 // ---------------------------------------------------------------------------
 // Field schemas
@@ -299,14 +311,41 @@ async function viewIssue(args: string[], ctx?: RepoContext): Promise<string> {
     }
   }
 
-  const schema = supportsIssueType
+  const baseSchema = supportsIssueType
     ? full
       ? viewSchemaFull
       : viewSchema
     : full
       ? viewSchemaFullWithoutType
       : viewSchemaWithoutType;
-  const blocks: string[] = [renderDetail("issue", item, schema)];
+
+  // Best-effort augmentation with sub-issue relationships. The sub-issues API
+  // is only available via GraphQL and requires repo context; failures here
+  // should not block the primary view output.
+  let parentNum: number | null = null;
+  let childNums: number[] = [];
+  if (ctx) {
+    try {
+      const rel = await fetchSubIssueRelationships(num, ctx);
+      parentNum = rel.parent;
+      childNums = rel.subIssues;
+    } catch {
+      // Sub-issues are a preview feature on some repos; ignore failures.
+    }
+  }
+
+  const schema: FieldDef[] = [...baseSchema];
+  const augmented: Record<string, unknown> = { ...item };
+  if (childNums.length > 0) {
+    augmented._subissues = childNums.map((n) => `#${n}`);
+    schema.push(custom("subissues", (it) => it._subissues));
+  }
+  if (parentNum != null) {
+    augmented._parent = `#${parentNum}`;
+    schema.push(custom("parent", (it) => it._parent));
+  }
+
+  const blocks: string[] = [renderDetail("issue", augmented, schema)];
 
   if (withComments && Array.isArray(item.comments)) {
     blocks.push(
@@ -961,6 +1000,277 @@ async function transferIssue(
 }
 
 // ---------------------------------------------------------------------------
+// Sub-issue helpers
+// ---------------------------------------------------------------------------
+
+interface ResolvedIssue {
+  id: string;
+  number: number;
+}
+
+interface SubIssueNode {
+  [key: string]: unknown;
+  number: number;
+  title?: string;
+  state?: string;
+}
+
+function requireRepo(ctx?: RepoContext): RepoContext {
+  if (!ctx) {
+    throw new AxiError(
+      "Could not determine repository — pass --repo <owner/name> or run inside a git checkout",
+      "VALIDATION_ERROR",
+    );
+  }
+  return ctx;
+}
+
+async function gqlRequest<T>(
+  query: string,
+  ctx?: RepoContext,
+): Promise<T> {
+  // Don't pass ctx through to ghJson — `gh api graphql` ignores --repo, and
+  // passing it produces a deprecation warning. The owner/name are baked into
+  // the query string instead.
+  void ctx;
+  const data = await ghJson<{ data: T }>([
+    "api",
+    "graphql",
+    "-f",
+    `query=${query}`,
+  ]);
+  return data.data;
+}
+
+async function resolveIssueIds(
+  parent: number,
+  children: number[],
+  ctx: RepoContext,
+): Promise<{ parent: ResolvedIssue; children: ResolvedIssue[] }> {
+  const childFields = children
+    .map(
+      (n, i) => `c${i}: issue(number: ${n}) { id number }`,
+    )
+    .join(" ");
+  const query = `query { repository(owner: "${ctx.owner}", name: "${ctx.name}") { parent: issue(number: ${parent}) { id number } ${childFields} } }`;
+  const result = await gqlRequest<{
+    repository: Record<string, ResolvedIssue | null>;
+  }>(query, ctx);
+
+  const repo = result.repository ?? {};
+  const parentNode = repo.parent;
+  if (!parentNode) {
+    throw new AxiError(
+      `Issue #${parent} not found in ${ctx.nwo}`,
+      "NOT_FOUND",
+    );
+  }
+  const childNodes: ResolvedIssue[] = [];
+  for (let i = 0; i < children.length; i++) {
+    const node = repo[`c${i}`];
+    if (!node) {
+      throw new AxiError(
+        `Issue #${children[i]} not found in ${ctx.nwo}`,
+        "NOT_FOUND",
+      );
+    }
+    childNodes.push(node);
+  }
+  return { parent: parentNode, children: childNodes };
+}
+
+async function subissueAdd(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
+  const repo = requireRepo(ctx);
+  const parentRaw = args[2];
+  const childRaw = args.slice(3).filter((a) => !a.startsWith("--"));
+  const parentNum = requireNumber(parentRaw, "parent");
+  if (childRaw.length === 0) {
+    throw new AxiError(
+      "subissue add requires at least one child issue number",
+      "VALIDATION_ERROR",
+    );
+  }
+  const childNums = childRaw.map((r) => requireNumber(r, "child"));
+
+  const { parent, children } = await resolveIssueIds(parentNum, childNums, repo);
+
+  const mutationBody = children
+    .map(
+      (c, i) =>
+        `m${i}: addSubIssue(input: { issueId: "${parent.id}", subIssueId: "${c.id}" }) { subIssue { number } }`,
+    )
+    .join(" ");
+  const mutation = `mutation { ${mutationBody} }`;
+  const result = await gqlRequest<Record<string, { subIssue: { number: number } }>>(
+    mutation,
+    repo,
+  );
+
+  const addedNumbers: number[] = [];
+  for (let i = 0; i < children.length; i++) {
+    const r = result[`m${i}`];
+    if (r?.subIssue?.number != null) addedNumbers.push(r.subIssue.number);
+    else addedNumbers.push(children[i].number);
+  }
+
+  const item = {
+    parent: `#${parent.number}`,
+    added: addedNumbers.map((n) => `#${n}`),
+  };
+  const blocks: string[] = [
+    renderDetail("subissue_add", item, [
+      field("parent"),
+      custom("added", (it: Record<string, unknown>) => it.added),
+    ]),
+  ];
+  blocks.push(
+    renderHelp([
+      `Run \`gh-axi issue view ${parent.number}\` to see the parent with its sub-issues`,
+    ]),
+  );
+  return renderOutput(blocks);
+}
+
+async function subissueRemove(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
+  const repo = requireRepo(ctx);
+  const parentRaw = args[2];
+  const childRaw = args[3];
+  const parentNum = requireNumber(parentRaw, "parent");
+  if (!childRaw) {
+    throw new AxiError(
+      "subissue remove requires a child issue number",
+      "VALIDATION_ERROR",
+    );
+  }
+  const childNum = requireNumber(childRaw, "child");
+
+  const { parent, children } = await resolveIssueIds(
+    parentNum,
+    [childNum],
+    repo,
+  );
+  const child = children[0];
+
+  const mutation = `mutation { removeSubIssue(input: { issueId: "${parent.id}", subIssueId: "${child.id}" }) { issue { number } } }`;
+  await gqlRequest<unknown>(mutation, repo);
+
+  const item = {
+    parent: `#${parent.number}`,
+    removed: `#${child.number}`,
+  };
+  const blocks: string[] = [
+    renderDetail("subissue_remove", item, [
+      field("parent"),
+      field("removed"),
+    ]),
+  ];
+  blocks.push(
+    renderHelp([
+      `Run \`gh-axi issue subissue list ${parent.number}\` to see remaining sub-issues`,
+    ]),
+  );
+  return renderOutput(blocks);
+}
+
+async function subissueList(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
+  const repo = requireRepo(ctx);
+  const parentRaw = args[2];
+  const parentNum = requireNumber(parentRaw, "parent");
+
+  const query = `query { repository(owner: "${repo.owner}", name: "${repo.name}") { issue(number: ${parentNum}) { subIssues(first: 100) { totalCount nodes { number title state } } } } }`;
+  const data = await gqlRequest<{
+    repository: {
+      issue: {
+        subIssues: { totalCount: number; nodes: SubIssueNode[] };
+      } | null;
+    };
+  }>(query, repo);
+
+  const issue = data.repository?.issue;
+  if (!issue) {
+    throw new AxiError(
+      `Issue #${parentNum} not found in ${repo.nwo}`,
+      "NOT_FOUND",
+    );
+  }
+
+  const nodes = issue.subIssues.nodes ?? [];
+  const totalCount = issue.subIssues.totalCount ?? nodes.length;
+  const countLine = formatCountLine({
+    count: nodes.length,
+    limit: 100,
+    totalCount,
+  });
+
+  const schema: FieldDef[] = [
+    field("number"),
+    field("title"),
+    lower("state"),
+  ];
+
+  const blocks: string[] = [
+    `parent: #${parentNum}`,
+    countLine,
+    renderList("subissues", nodes as Record<string, unknown>[], schema),
+  ];
+  return renderOutput(blocks);
+}
+
+async function fetchSubIssueRelationships(
+  num: number,
+  ctx: RepoContext,
+): Promise<{ parent: number | null; subIssues: number[] }> {
+  const query = `query { repository(owner: "${ctx.owner}", name: "${ctx.name}") { issue(number: ${num}) { parent { number } subIssues(first: 100) { totalCount nodes { number } } } } }`;
+  const data = await gqlRequest<{
+    repository: {
+      issue: {
+        parent: { number: number } | null;
+        subIssues: { totalCount: number; nodes: { number: number }[] };
+      } | null;
+    };
+  }>(query, ctx);
+  const issue = data.repository?.issue;
+  if (!issue) return { parent: null, subIssues: [] };
+  return {
+    parent: issue.parent?.number ?? null,
+    subIssues: (issue.subIssues?.nodes ?? []).map((n) => n.number),
+  };
+}
+
+async function subissueCommand(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
+  const sub = args[1];
+  if (!sub || hasFlag(args, "--help")) {
+    return renderOutput([SUBISSUE_HELP]);
+  }
+  switch (sub) {
+    case "add":
+      return subissueAdd(args, ctx);
+    case "remove":
+      return subissueRemove(args, ctx);
+    case "list":
+      return subissueList(args, ctx);
+    default:
+      return renderError(
+        `Unknown subissue subcommand: ${sub}`,
+        "VALIDATION_ERROR",
+        ["Run `gh-axi issue subissue --help` for usage"],
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main dispatcher
 // ---------------------------------------------------------------------------
 
@@ -1004,6 +1314,8 @@ export async function issueCommand(
       return unpinIssue(args, ctx);
     case "transfer":
       return transferIssue(args, ctx);
+    case "subissue":
+      return subissueCommand(args, ctx);
     default:
       return renderError(
         `Unknown issue subcommand: ${sub}`,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -82,6 +82,21 @@ const patterns: ErrorPattern[] = [
     ],
   },
   {
+    pattern: /sub-issue is already a sub-issue of issue with number (\d+)/i,
+    code: "VALIDATION_ERROR",
+    message: (m) => `Issue is already a sub-issue of #${m[1]}`,
+  },
+  {
+    pattern: /sub-?issue.*?(cycle|circular)/i,
+    code: "VALIDATION_ERROR",
+    message: () => "Cannot add sub-issue: would create a cycle",
+  },
+  {
+    pattern: /issue cannot be a sub-?issue of itself/i,
+    code: "VALIDATION_ERROR",
+    message: () => "An issue cannot be a sub-issue of itself",
+  },
+  {
     pattern: /HTTP 403/,
     code: "FORBIDDEN",
     message: () => "Insufficient permissions for this action",

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -687,6 +687,33 @@ describe("issueCommand", () => {
           AxiError,
         );
       });
+
+      it("reports already added children when a later add fails", async () => {
+        mockedGhJson.mockImplementation(async (args: string[]) => {
+          const query = graphqlQueryArg(args);
+          if (query.includes("query") && !query.includes("mutation")) {
+            return {
+              data: {
+                repository: {
+                  parent: { id: "P_1", number: 1 },
+                  c0: { id: "C_2", number: 2 },
+                  c1: { id: "C_3", number: 3 },
+                },
+              },
+            };
+          }
+          if (query.includes('subIssueId: "C_2"')) {
+            return {
+              data: { addSubIssue: { subIssue: { number: 2 } } },
+            };
+          }
+          throw new AxiError("GraphQL add failed", "UNKNOWN");
+        });
+
+        await expect(
+          issueCommand(["subissue", "add", "1", "2", "3"], ctx),
+        ).rejects.toThrow(/Added before failure: #2/);
+      });
     });
 
     describe("remove", () => {

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -7,7 +7,11 @@ vi.mock("../../src/gh.js", () => ({
 }));
 
 import { ghJson, ghExec, ghRaw } from "../../src/gh.js";
-import { issueCommand, ISSUE_HELP } from "../../src/commands/issue.js";
+import {
+  issueCommand,
+  ISSUE_HELP,
+  SUBISSUE_HELP,
+} from "../../src/commands/issue.js";
 import { AxiError } from "../../src/errors.js";
 import type { RepoContext } from "../../src/context.js";
 
@@ -51,6 +55,12 @@ describe("issueCommand", () => {
     it("returns help when --help is passed", async () => {
       const result = await issueCommand(["--help"], ctx);
       expect(result).toContain(ISSUE_HELP);
+    });
+
+    it("returns subissue help for subissue --help", async () => {
+      const result = await issueCommand(["subissue", "--help"], ctx);
+      expect(result).toContain(SUBISSUE_HELP);
+      expect(result).not.toContain("usage: gh-axi issue <subcommand>");
     });
 
     it("returns help when no subcommand is given", async () => {

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -499,4 +499,283 @@ describe("issueCommand", () => {
       ]);
     });
   });
+
+  describe("view with sub-issue relationships", () => {
+    it("includes parent and subissues when the GraphQL augmentation returns data", async () => {
+      mockedGhJson.mockImplementation(async (args: string[]) => {
+        if (args[0] === "issue" && args[1] === "view") {
+          return {
+            number: 42,
+            title: "Parent issue",
+            state: "OPEN",
+            author: { login: "alice" },
+            createdAt: "2024-01-01T00:00:00Z",
+            body: "body",
+          };
+        }
+        if (args[0] === "api" && args[1] === "graphql") {
+          return {
+            data: {
+              repository: {
+                issue: {
+                  parent: { number: 16 },
+                  subIssues: {
+                    totalCount: 3,
+                    nodes: [{ number: 20 }, { number: 101 }, { number: 125 }],
+                  },
+                },
+              },
+            },
+          };
+        }
+        throw new Error(`Unexpected ghJson call: ${args.join(" ")}`);
+      });
+
+      const result = await issueCommand(["view", "42"], ctx);
+
+      expect(result).toContain("subissues[3]: #20,#101,#125");
+      expect(result).toContain("parent: #16");
+    });
+
+    it("omits parent and subissues fields when neither is present", async () => {
+      mockedGhJson.mockImplementation(async (args: string[]) => {
+        if (args[0] === "issue" && args[1] === "view") {
+          return {
+            number: 42,
+            title: "Standalone",
+            state: "OPEN",
+            author: { login: "alice" },
+            createdAt: "2024-01-01T00:00:00Z",
+            body: "body",
+          };
+        }
+        if (args[0] === "api" && args[1] === "graphql") {
+          return {
+            data: {
+              repository: {
+                issue: {
+                  parent: null,
+                  subIssues: { totalCount: 0, nodes: [] },
+                },
+              },
+            },
+          };
+        }
+        throw new Error(`Unexpected ghJson call: ${args.join(" ")}`);
+      });
+
+      const result = await issueCommand(["view", "42"], ctx);
+
+      expect(result).not.toContain("subissues");
+      expect(result).not.toMatch(/^parent:/m);
+    });
+
+    it("still renders the issue when the sub-issue GraphQL call fails", async () => {
+      mockedGhJson.mockImplementation(async (args: string[]) => {
+        if (args[0] === "issue" && args[1] === "view") {
+          return {
+            number: 42,
+            title: "Critical bug",
+            state: "OPEN",
+            author: { login: "alice" },
+            createdAt: "2024-01-01T00:00:00Z",
+            body: "body",
+          };
+        }
+        if (args[0] === "api" && args[1] === "graphql") {
+          throw new AxiError("graphql failed", "UNKNOWN");
+        }
+        throw new Error(`Unexpected ghJson call: ${args.join(" ")}`);
+      });
+
+      const result = await issueCommand(["view", "42"], ctx);
+
+      expect(result).toContain("Critical bug");
+      expect(result).not.toContain("subissues");
+    });
+  });
+
+  describe("subissue", () => {
+    function graphqlQueryArg(args: string[]): string {
+      const fIdx = args.indexOf("-f");
+      if (fIdx === -1) return "";
+      const val = args[fIdx + 1] ?? "";
+      return val.replace(/^query=/, "");
+    }
+
+    it("rejects unknown subissue subcommand", async () => {
+      const result = await issueCommand(["subissue", "frobnicate"], ctx);
+      expect(result).toContain("Unknown");
+    });
+
+    it("returns help when no subissue subcommand given", async () => {
+      const result = await issueCommand(["subissue"], ctx);
+      expect(result).toContain("subissue");
+      expect(result).toContain("add");
+      expect(result).toContain("remove");
+      expect(result).toContain("list");
+    });
+
+    describe("add", () => {
+      it("issues a single batched mutation with aliased addSubIssue calls", async () => {
+        const ghJsonCalls: string[][] = [];
+        mockedGhJson.mockImplementation(async (args: string[]) => {
+          ghJsonCalls.push(args);
+          const query = graphqlQueryArg(args);
+          if (query.includes("query") && !query.includes("mutation")) {
+            // resolution query
+            return {
+              data: {
+                repository: {
+                  parent: { id: "P_1", number: 1 },
+                  c0: { id: "C_2", number: 2 },
+                  c1: { id: "C_3", number: 3 },
+                  c2: { id: "C_4", number: 4 },
+                },
+              },
+            };
+          }
+          // mutation
+          return {
+            data: {
+              m0: { subIssue: { number: 2 } },
+              m1: { subIssue: { number: 3 } },
+              m2: { subIssue: { number: 4 } },
+            },
+          };
+        });
+
+        const result = await issueCommand(
+          ["subissue", "add", "1", "2", "3", "4"],
+          ctx,
+        );
+
+        // Two GraphQL calls total: one resolution query, one mutation.
+        const graphqlCalls = ghJsonCalls.filter(
+          (c) => c[0] === "api" && c[1] === "graphql",
+        );
+        expect(graphqlCalls).toHaveLength(2);
+
+        const mutationCall = graphqlCalls.find((c) =>
+          graphqlQueryArg(c).includes("mutation"),
+        );
+        expect(mutationCall).toBeDefined();
+        const mutationQuery = graphqlQueryArg(mutationCall!);
+        // Single mutation, three aliases
+        expect(mutationQuery.match(/addSubIssue/g)?.length).toBe(3);
+        expect(mutationQuery).toContain("m0:");
+        expect(mutationQuery).toContain("m1:");
+        expect(mutationQuery).toContain("m2:");
+
+        expect(result).toContain("parent: #1");
+        expect(result).toContain("#2");
+        expect(result).toContain("#3");
+        expect(result).toContain("#4");
+      });
+
+      it("requires at least one child", async () => {
+        await expect(
+          issueCommand(["subissue", "add", "1"], ctx),
+        ).rejects.toThrow(AxiError);
+      });
+
+      it("requires a parent argument", async () => {
+        await expect(issueCommand(["subissue", "add"], ctx)).rejects.toThrow(
+          AxiError,
+        );
+      });
+    });
+
+    describe("remove", () => {
+      it("sends a single removeSubIssue mutation", async () => {
+        const ghJsonCalls: string[][] = [];
+        mockedGhJson.mockImplementation(async (args: string[]) => {
+          ghJsonCalls.push(args);
+          const query = graphqlQueryArg(args);
+          if (query.includes("query") && !query.includes("mutation")) {
+            return {
+              data: {
+                repository: {
+                  parent: { id: "P_1", number: 1 },
+                  c0: { id: "C_2", number: 2 },
+                },
+              },
+            };
+          }
+          return { data: { removeSubIssue: { issue: { number: 1 } } } };
+        });
+
+        const result = await issueCommand(
+          ["subissue", "remove", "1", "2"],
+          ctx,
+        );
+
+        const graphqlCalls = ghJsonCalls.filter(
+          (c) => c[0] === "api" && c[1] === "graphql",
+        );
+        const mutationCall = graphqlCalls.find((c) =>
+          graphqlQueryArg(c).includes("mutation"),
+        );
+        expect(mutationCall).toBeDefined();
+        expect(graphqlQueryArg(mutationCall!)).toContain("removeSubIssue");
+
+        expect(result).toContain("parent: #1");
+        expect(result).toContain("removed: #2");
+      });
+
+      it("requires both parent and child", async () => {
+        await expect(
+          issueCommand(["subissue", "remove", "1"], ctx),
+        ).rejects.toThrow(AxiError);
+      });
+    });
+
+    describe("list", () => {
+      it("lists sub-issues of a parent", async () => {
+        mockedGhJson.mockResolvedValue({
+          data: {
+            repository: {
+              issue: {
+                subIssues: {
+                  totalCount: 2,
+                  nodes: [
+                    { number: 20, title: "Foo", state: "OPEN" },
+                    { number: 101, title: "Bar", state: "CLOSED" },
+                  ],
+                },
+              },
+            },
+          },
+        });
+
+        const result = await issueCommand(["subissue", "list", "1"], ctx);
+
+        expect(result).toContain("parent: #1");
+        expect(result).toContain("count: 2");
+        expect(result).toContain("Foo");
+        expect(result).toContain("Bar");
+        expect(result).toContain("open");
+        expect(result).toContain("closed");
+      });
+
+      it("renders count: 0 when there are no sub-issues", async () => {
+        mockedGhJson.mockResolvedValue({
+          data: {
+            repository: {
+              issue: { subIssues: { totalCount: 0, nodes: [] } },
+            },
+          },
+        });
+
+        const result = await issueCommand(["subissue", "list", "1"], ctx);
+        expect(result).toContain("count: 0");
+      });
+
+      it("requires a parent argument", async () => {
+        await expect(issueCommand(["subissue", "list"], ctx)).rejects.toThrow(
+          AxiError,
+        );
+      });
+    });
+  });
 });

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -617,7 +617,7 @@ describe("issueCommand", () => {
     });
 
     describe("add", () => {
-      it("issues a single batched mutation with aliased addSubIssue calls", async () => {
+      it("issues one addSubIssue mutation per child", async () => {
         const ghJsonCalls: string[][] = [];
         mockedGhJson.mockImplementation(async (args: string[]) => {
           ghJsonCalls.push(args);
@@ -636,11 +636,14 @@ describe("issueCommand", () => {
             };
           }
           // mutation
+          const subIssueNumber = query.includes("C_2")
+            ? 2
+            : query.includes("C_3")
+              ? 3
+              : 4;
           return {
             data: {
-              m0: { subIssue: { number: 2 } },
-              m1: { subIssue: { number: 3 } },
-              m2: { subIssue: { number: 4 } },
+              addSubIssue: { subIssue: { number: subIssueNumber } },
             },
           };
         });
@@ -650,22 +653,22 @@ describe("issueCommand", () => {
           ctx,
         );
 
-        // Two GraphQL calls total: one resolution query, one mutation.
+        // Four GraphQL calls total: one resolution query, one mutation per child.
         const graphqlCalls = ghJsonCalls.filter(
           (c) => c[0] === "api" && c[1] === "graphql",
         );
-        expect(graphqlCalls).toHaveLength(2);
+        expect(graphqlCalls).toHaveLength(4);
 
-        const mutationCall = graphqlCalls.find((c) =>
-          graphqlQueryArg(c).includes("mutation"),
-        );
-        expect(mutationCall).toBeDefined();
-        const mutationQuery = graphqlQueryArg(mutationCall!);
-        // Single mutation, three aliases
-        expect(mutationQuery.match(/addSubIssue/g)?.length).toBe(3);
-        expect(mutationQuery).toContain("m0:");
-        expect(mutationQuery).toContain("m1:");
-        expect(mutationQuery).toContain("m2:");
+        const mutationQueries = graphqlCalls
+          .map(graphqlQueryArg)
+          .filter((q) => q.includes("mutation"));
+        expect(mutationQueries).toHaveLength(3);
+        expect(mutationQueries[0]).toContain('subIssueId: "C_2"');
+        expect(mutationQueries[1]).toContain('subIssueId: "C_3"');
+        expect(mutationQueries[2]).toContain('subIssueId: "C_4"');
+        for (const mutationQuery of mutationQueries) {
+          expect(mutationQuery.match(/addSubIssue/g)?.length).toBe(1);
+        }
 
         expect(result).toContain("parent: #1");
         expect(result).toContain("#2");

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -137,6 +137,33 @@ describe("mapGhError", () => {
     expect(err.code).toBe("NOT_FOUND");
   });
 
+  it("maps sub-issue already-linked errors to an actionable message", () => {
+    const err = mapGhError(
+      'GraphQL: Sub-issue is already a sub-issue of issue with number 5 (addSubIssue)',
+      1,
+    );
+    expect(err.code).toBe("VALIDATION_ERROR");
+    expect(err.message).toMatch(/already a sub-issue of #?5/);
+  });
+
+  it("maps sub-issue cycle errors", () => {
+    const err = mapGhError(
+      "GraphQL: Sub-issue would create a cycle (addSubIssue)",
+      1,
+    );
+    expect(err.code).toBe("VALIDATION_ERROR");
+    expect(err.message).toMatch(/cycle/i);
+  });
+
+  it("maps sub-issue self-parent errors", () => {
+    const err = mapGhError(
+      "GraphQL: An issue cannot be a sub-issue of itself (addSubIssue)",
+      1,
+    );
+    expect(err.code).toBe("VALIDATION_ERROR");
+    expect(err.message).toMatch(/itself/i);
+  });
+
   it("returns UNKNOWN for unrecognized errors", () => {
     const err = mapGhError("some random error", 1);
     expect(err.code).toBe("UNKNOWN");

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -139,7 +139,7 @@ describe("mapGhError", () => {
 
   it("maps sub-issue already-linked errors to an actionable message", () => {
     const err = mapGhError(
-      'GraphQL: Sub-issue is already a sub-issue of issue with number 5 (addSubIssue)',
+      "GraphQL: Sub-issue is already a sub-issue of issue with number 5 (addSubIssue)",
       1,
     );
     expect(err.code).toBe("VALIDATION_ERROR");


### PR DESCRIPTION
## Intent

The developer wanted a maintainer-style triage of GitHub issue https://github.com/kunchenguid/gh-axi/issues/27 using the managed local checkout and any relevant GitHub context, without cloning or mutating the repository. They required structured JSON options describing proposed resolutions, including comments, coding-agent handoff prompts, state changes, waiting-on status, and confidence. They emphasized preferring actionable issues to be marked fix_required with a detailed multi-line fix prompt, while also surfacing reasonable alternatives when appropriate. The resulting triage identified the issue as legitimate and actionable, recommending a coding-agent handoff for GraphQL fallback support because gh does not expose --type, plus improved validation-error UX and acceptance criteria.

## What Changed

- Added `gh-axi issue subissue` support for listing, adding, and removing GitHub issue parent/child relationships.
- Improved subissue error handling so partial add failures report already-linked issue numbers and retries are safer.
- Updated subissue help routing, README command documentation, and coverage for issue subcommands and errors.

## Risk Assessment

✅ Low: The changes are well-bounded to issue subissue support and best-effort view augmentation, with no material introduced risks found in the reviewed diff.

## Testing

- Summary: Exercised the changed issue subissue GraphQL behavior, issue view relationship augmentation, and sub-issue error mapping tests; all targeted and full-suite Vitest runs passed.
- `pnpm test -- test/commands/issue.test.ts test/errors.test.ts`
- `pnpm exec vitest run test/commands/issue.test.ts test/errors.test.ts`
- Outcome: ✅ passed across 1 run (1m12s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3)</summary>

**Round 1** - found 1 warning
- ⚠️ `src/commands/issue.ts:913` - `subissue add` batches every child into one GraphQL mutation, but GraphQL mutation fields can apply earlier aliases before a later alias fails; in that case the command throws without reporting which links were already created, leaving callers with ambiguous partial state. Execute additions sequentially or catch GraphQL partial results and report per-child success/failure so retries are safe.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `src/commands/issue.ts:910` - `subissue add` now sends one mutation per child, but if an earlier child is linked and a later mutation fails, the command still throws only the later error and does not report which sub-issues were already added. Catch mutation failures after tracking `addedNumbers` and include the successful child numbers in the error/output so callers can retry safely.
- ⚠️ `src/commands/issue.ts:1067` - The unknown-subcommand suggestion points users to `gh-axi issue subissue --help`, but `issueCommand` handles any `--help` before dispatching to `subissueCommand`, so that command shows the general issue help instead of `SUBISSUE_HELP`. Dispatch `subissue` before the top-level help shortcut or special-case `subissue --help`.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `src/commands/issue.ts:1098` - `gh-axi issue subissue --help` still returns the general issue help because the top-level `hasFlag(args, &#34;--help&#34;)` check runs before dispatching to `subissueCommand`, making the new `SUBISSUE_HELP` unreachable through the suggested help command. Dispatch `subissue` before the top-level help shortcut or special-case `subissue --help`.

**Round 4** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `pnpm test -- test/commands/issue.test.ts test/errors.test.ts`
- `pnpm exec vitest run test/commands/issue.test.ts test/errors.test.ts`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `README.md:43` - The change adds a public `gh-axi issue subissue &lt;add|remove|list&gt;` feature for managing GitHub issue parent/child relationships, but the README command table still describes `issue` as only covering list, view, create, edit, close, reopen, and comment. Update the README to mention sub-issue management and include at least one usage example such as `gh-axi issue subissue add 16 20` or `gh-axi issue subissue list 16`, so users can discover the new command outside inline `--help`.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>🔧 **Lint** - 3 issues found → auto-fixed</summary>

**Round 1** - found 3 warnings
- ⚠️ `README.md:1` - Prettier reported formatting differences in README.md. Run `pnpm exec prettier --write README.md` to apply the configured formatting.
- ⚠️ `src/commands/issue.ts:1` - Prettier reported formatting differences in src/commands/issue.ts. Run `pnpm exec prettier --write src/commands/issue.ts` to apply the configured formatting.
- ⚠️ `test/errors.test.ts:1` - Prettier reported formatting differences in test/errors.test.ts. Run `pnpm exec prettier --write test/errors.test.ts` to apply the configured formatting.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
