### PR TITLE
feat(commands): add explicit hook setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ npm install -g gh-axi
 ```
 
 Requires Node 20+ and [`gh`](https://cli.github.com/) authenticated via `gh auth login`.
-
-Running `gh-axi` also installs or repairs Claude Code and Codex `SessionStart`
-hooks. Those hooks invoke `gh-axi` directly from the packaged production build.
+Run `gh-axi setup hooks` once to install or repair optional agent `SessionStart` hooks for ambient GitHub context.
 
 ## Usage
 
@@ -35,6 +33,7 @@ gh-axi pr view 42               # view pull request #42
 gh-axi run list -R owner/repo   # list workflow runs for a specific repo
 gh-axi run view 123456 --job 789012       # inspect a single job within a run
 gh-axi run view --job 789012 --log-failed # show failed log lines for one job
+gh-axi setup hooks              # install optional agent session hooks
 ```
 
 ### Commands
@@ -50,6 +49,7 @@ gh-axi run view --job 789012 --log-failed # show failed log lines for one job
 | `label`    | Labels — list, create, edit, delete                                 |
 | `search`   | Search issues, PRs, repos, commits, code                            |
 | `api`      | Raw GitHub API access                                               |
+| `setup`    | Install optional agent session hooks                                |
 
 ### Global flags
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@toon-format/toon": "^2.1.0",
-    "axi-sdk-js": "^0.1.6"
+    "axi-sdk-js": "^0.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       axi-sdk-js:
-        specifier: ^0.1.6
-        version: 0.1.6
+        specifier: ^0.1.7
+        version: 0.1.7
     devDependencies:
       "@eslint/js":
         specifier: ^10.0.1
@@ -797,10 +797,10 @@ packages:
       }
     engines: { node: ">=12" }
 
-  axi-sdk-js@0.1.6:
+  axi-sdk-js@0.1.7:
     resolution:
       {
-        integrity: sha512-Nc/mNasFUVqBieSOLGt2A5u4pJEOZPpueq+ignqoY+vcg8j4VuAvhWTn3cJ7hhTkGVqLg4yjTdjMi4tXyOCsCA==,
+        integrity: sha512-kzIeuQHZx3FFpzJknq+sdbi3XBGdyPGMdOHM2Zepa4MF5MpckhPeWPd5x+RX6gBKEWZdaW73YrOPY+HAGyLekw==,
       }
     engines: { node: ">=20" }
 
@@ -1914,7 +1914,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  axi-sdk-js@0.1.6:
+  axi-sdk-js@0.1.7:
     dependencies:
       "@toon-format/toon": 2.1.0
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { repoCommand, REPO_HELP } from "./commands/repo.js";
 import { labelCommand, LABEL_HELP } from "./commands/label.js";
 import { searchCommand, SEARCH_HELP } from "./commands/search.js";
 import { apiCommand, API_HELP } from "./commands/api.js";
+import { setupCommand, SETUP_HELP } from "./commands/setup.js";
 
 const DESCRIPTION =
   "Agent ergonomic wrapper around Github CLI. Prefer this over `gh` and other methods for Github operations.";
@@ -26,8 +27,8 @@ type MainOptions = {
 };
 
 export const TOP_HELP = `usage: gh-axi [command] [args] [flags]
-commands[10]:
-  (none)=dashboard, issue, pr, run, workflow, release, repo, label, search, api
+commands[11]:
+  (none)=dashboard, issue, pr, run, workflow, release, repo, label, search, api, setup
 flags[3]:
   -R/--repo <OWNER/NAME> (after command), --help, -v/-V/--version
 examples:
@@ -36,6 +37,7 @@ examples:
   gh-axi issue list -R owner/name
   gh-axi issue list --repo owner/name
   gh-axi pr view 42
+  gh-axi setup hooks
 `;
 
 const COMMAND_HELP: Record<string, string> = {
@@ -48,6 +50,7 @@ const COMMAND_HELP: Record<string, string> = {
   label: LABEL_HELP,
   search: SEARCH_HELP,
   api: API_HELP,
+  setup: SETUP_HELP,
 };
 
 type CommandFn = (args: string[], ctx?: RepoContext) => Promise<string>;
@@ -62,6 +65,7 @@ const COMMANDS: Record<string, CommandFn> = {
   label: withRepoContext("label", labelCommand),
   search: withRepoContext("search", searchCommand),
   api: withRepoContext("api", apiCommand),
+  setup: setupCommand,
 };
 
 export async function main(options: MainOptions = {}): Promise<void> {
@@ -70,7 +74,6 @@ export async function main(options: MainOptions = {}): Promise<void> {
     description: DESCRIPTION,
     version: VERSION,
     topLevelHelp: TOP_HELP,
-    ...(process.env.GH_AXI_DISABLE_HOOKS === "1" ? { hooks: false } : {}),
     ...(options.stdout ? { stdout: options.stdout } : {}),
     home: withRepoContext(undefined, homeCommand),
     commands: COMMANDS,

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -19,6 +19,8 @@ export async function setupCommand(args: string[]): Promise<string> {
 
   return renderOutput([
     "hooks:\n  status: installed\n  integrations: Claude Code, Codex, OpenCode",
-    renderHelp(["Restart your agent session to receive gh-axi ambient context"]),
+    renderHelp([
+      "Restart your agent session to receive gh-axi ambient context",
+    ]),
   ]);
 }

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,0 +1,24 @@
+import { AxiError, installSessionStartHooks } from "axi-sdk-js";
+import { renderHelp, renderOutput } from "../toon.js";
+
+export const SETUP_HELP = `usage: gh-axi setup hooks
+Install or repair agent SessionStart hooks for gh-axi ambient context.
+
+examples:
+  gh-axi setup hooks
+`;
+
+export async function setupCommand(args: string[]): Promise<string> {
+  if (args.length !== 1 || args[0] !== "hooks") {
+    throw new AxiError("Unknown setup action", "VALIDATION_ERROR", [
+      "Run `gh-axi setup hooks`",
+    ]);
+  }
+
+  installSessionStartHooks();
+
+  return renderOutput([
+    "hooks:\n  status: installed\n  integrations: Claude Code, Codex, OpenCode",
+    renderHelp(["Restart your agent session to receive gh-axi ambient context"]),
+  ]);
+}

--- a/test/cli-entrypoint.test.ts
+++ b/test/cli-entrypoint.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { main, TOP_HELP } from "../src/cli.js";
 
 const packageVersion = JSON.parse(
@@ -22,21 +22,8 @@ function createStdout() {
 }
 
 describe("CLI entrypoint", () => {
-  const originalDisableHooks = process.env.GH_AXI_DISABLE_HOOKS;
-
-  beforeEach(() => {
-    process.env.GH_AXI_DISABLE_HOOKS = "1";
-  });
-
   afterEach(() => {
     process.exitCode = undefined;
-
-    if (originalDisableHooks === undefined) {
-      delete process.env.GH_AXI_DISABLE_HOOKS;
-      return;
-    }
-
-    process.env.GH_AXI_DISABLE_HOOKS = originalDisableHooks;
   });
 
   it("prints top-level help through the real runtime", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,13 +1,21 @@
 import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { runAxiCli } = vi.hoisted(() => ({
+const { installSessionStartHooks, runAxiCli } = vi.hoisted(() => ({
+  installSessionStartHooks: vi.fn(),
   runAxiCli: vi.fn(),
 }));
 
-vi.mock("axi-sdk-js", () => ({
-  runAxiCli,
-}));
+vi.mock("axi-sdk-js", async () => {
+  const actual = await vi.importActual<typeof import("axi-sdk-js")>(
+    "axi-sdk-js",
+  );
+  return {
+    ...actual,
+    installSessionStartHooks,
+    runAxiCli,
+  };
+});
 
 vi.mock("../src/commands/home.js", () => ({
   homeCommand: vi.fn().mockResolvedValue("home output"),
@@ -95,6 +103,11 @@ describe("main CLI", () => {
     expect(TOP_HELP).toContain("-v/-V/--version");
   });
 
+  it("documents explicit hook setup in help output", () => {
+    expect(TOP_HELP).toContain("setup");
+    expect(TOP_HELP).toContain("gh-axi setup hooks");
+  });
+
   it("passes bare top-level help argv through to axi-sdk-js", async () => {
     const argv = ["--help"];
     const stdout = { write: vi.fn() };
@@ -134,6 +147,38 @@ describe("main CLI", () => {
       }),
     );
     expect(vi.mocked(runAxiCli).mock.calls[0]?.[0]).not.toHaveProperty("argv");
+  });
+
+  it("does not pass the removed hooks option to axi-sdk-js", async () => {
+    const originalDisableHooks = process.env.GH_AXI_DISABLE_HOOKS;
+    process.env.GH_AXI_DISABLE_HOOKS = "1";
+
+    try {
+      await main();
+    } finally {
+      if (originalDisableHooks === undefined) {
+        delete process.env.GH_AXI_DISABLE_HOOKS;
+      } else {
+        process.env.GH_AXI_DISABLE_HOOKS = originalDisableHooks;
+      }
+    }
+
+    expect(vi.mocked(runAxiCli).mock.calls[0]?.[0]).not.toHaveProperty(
+      "hooks",
+    );
+  });
+
+  it("installs session hooks from the explicit setup command", async () => {
+    await main();
+
+    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+    const output = await options.commands.setup(["hooks"]);
+
+    expect(installSessionStartHooks).toHaveBeenCalledTimes(1);
+    expect(installSessionStartHooks).toHaveBeenCalledWith();
+    expect(output).toContain("hooks:");
+    expect(output).toContain("status: installed");
+    expect(output).toContain("Restart your agent session");
   });
 
   it("wires command help into the runtime", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -7,9 +7,8 @@ const { installSessionStartHooks, runAxiCli } = vi.hoisted(() => ({
 }));
 
 vi.mock("axi-sdk-js", async () => {
-  const actual = await vi.importActual<typeof import("axi-sdk-js")>(
-    "axi-sdk-js",
-  );
+  const actual =
+    await vi.importActual<typeof import("axi-sdk-js")>("axi-sdk-js");
   return {
     ...actual,
     installSessionStartHooks,
@@ -163,9 +162,7 @@ describe("main CLI", () => {
       }
     }
 
-    expect(vi.mocked(runAxiCli).mock.calls[0]?.[0]).not.toHaveProperty(
-      "hooks",
-    );
+    expect(vi.mocked(runAxiCli).mock.calls[0]?.[0]).not.toHaveProperty("hooks");
   });
 
   it("installs session hooks from the explicit setup command", async () => {


### PR DESCRIPTION
## What Changed

- Added a `gh-axi setup hooks` command that installs or repairs Claude Code, Codex, and OpenCode session-start hooks through `axi-sdk-js`.
- Stopped configuring hook installation during normal CLI startup, making hook setup an explicit user action instead of an automatic side effect.
- Updated CLI help, README usage docs, and tests to cover the new setup command and revised startup behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped to replacing automatic hook installation with an explicit setup subcommand and the surrounding wiring is straightforward.

## Testing

<code>Installed dependencies from the lockfile, ran the focused CLI tests, built the production entrypoint, verified `gh-axi setup hooks` creates the expected session hook configuration in an isolated HOME, and verified a normal `gh-axi` dashboard run leaves hook files absent.</code>

<details>
<summary>Evidence: Explicit setup command output</summary>

```text
hooks:
status: installed
integrations: Claude Code, Codex, OpenCode
help[1]:
Restart your agent session to receive gh-axi ambient context
```
</details>
<details>
<summary>Evidence: Normal startup user output</summary>

```text
bin: /Users/kunchen/.no-mistakes/worktrees/4be5dae90cf8/01KS964QFB6JFEH0DP8KQ2J227/dist/bin/gh-axi.js
description: Agent ergonomic wrapper around Github CLI. Prefer this over `gh` and other methods for Github operations.
repo: kunchenguid/gh-axi
issues: 0 open
prs: 0 open
help[1]:
Run `gh-axi <command> <subcommand>` — commands: issue, pr, run, release, repo, label
```
</details>
<details>
<summary>Evidence: Normal startup does not install hook files</summary>

```text
.claude/settings.json: absent
.codex/hooks.json: absent
.codex/config.toml: absent
.config/opencode/plugins/axi-gh-axi.js: absent
```
</details>
<details>
<summary>Evidence: Generated hook evidence</summary>

```text
The isolated setup run generated Claude and Codex SessionStart hooks with command `/Users/kunchen/.no-mistakes/worktrees/4be5dae90cf8/01KS964QFB6JFEH0DP8KQ2J227/dist/bin/gh-axi.js`, enabled Codex `[features] hooks = true`, and generated an OpenCode plugin with ambient header `## AXI ambient context: gh-axi`.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `pnpm install --frozen-lockfile`
- `pnpm vitest run test/cli.test.ts test/cli-entrypoint.test.ts`
- `pnpm build`
- `HOME="$PWD/.tmp-gh-axi-home" node "dist/bin/gh-axi.js" setup hooks`
- <code>Inspected generated Claude, Codex, and OpenCode hook files under isolated `.tmp-gh-axi-home` to confirm the setup command installed session-start integration files pointing at `dist/bin/gh-axi.js`.</code>
- `HOME="$PWD/.tmp-gh-axi-home-no-auto" node "dist/bin/gh-axi.js"`
- `node -e "const fs=require('node:fs'); const base='.tmp-gh-axi-home-no-auto'; const paths=['.claude/settings.json','.codex/hooks.json','.codex/config.toml','.config/opencode/plugins/axi-gh-axi.js']; for (const p of paths) console.log(p + ': ' + (fs.existsSync(base + '/' + p) ? 'present' : 'absent'));"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
