### PR TITLE
Fix repo flag placement in suggestions

### DIFF
--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -22,6 +22,10 @@ function repoFlag(ctx: SuggestionContext): string {
   return "";
 }
 
+function normalizeRepoFlagLine(line: string): string {
+  return line.replace(/`gh-axi -R ([^`\s]+) ([^`]+)`/g, "`gh-axi $2 -R $1`");
+}
+
 const table: SuggestionEntry[] = [
   // Home
   {
@@ -491,7 +495,7 @@ const table: SuggestionEntry[] = [
 export function getSuggestions(ctx: SuggestionContext): string[] {
   for (const entry of table) {
     if (entry.match(ctx)) {
-      return entry.lines(ctx);
+      return entry.lines(ctx).map(normalizeRepoFlagLine);
     }
   }
   return [];

--- a/test/suggestions.test.ts
+++ b/test/suggestions.test.ts
@@ -38,6 +38,8 @@ describe('getSuggestions', () => {
       repo: { owner: 'cli', name: 'cli', nwo: 'cli/cli', source: 'flag' },
     });
     expect(lines.every((l) => l.includes('-R cli/cli'))).toBe(true);
+    expect(lines.every((l) => !l.includes('gh-axi -R'))).toBe(true);
+    expect(lines).toContain('Run `gh-axi issue view <number> -R cli/cli` to view details');
   });
 
   it('does not carry -R flag when repo source is git', () => {


### PR DESCRIPTION
## Summary
- Normalize generated help suggestions so repo-qualified commands place `-R` after the command/subcommand arguments
- Add a regression assertion for repo-qualified suggestions

## Test plan
- `corepack pnpm exec eslint src test/suggestions.test.ts`
- `corepack pnpm run build`
- `corepack pnpm exec vitest run test/suggestions.test.ts`
- `corepack pnpm test`