### PR TITLE
fix: preserve gh argument forwarding

### DIFF
--- a/.no-mistakes/evidence/fm/gh-axi-argfix-r3/cli-e2e-transcript.txt
+++ b/.no-mistakes/evidence/fm/gh-axi-argfix-r3/cli-e2e-transcript.txt
@@ -1,0 +1,71 @@
+$ pnpm exec tsx bin/gh-axi.ts release create v1.2.3 --repo octo/release-target --target main --title Ship 1.2.3 --notes hello notes dist/app.zip
+created: ok
+tag: v1.2.3
+help[2]:
+  Run `gh-axi -R octo/release-target release view v1.2.3` to view the release
+  Run `gh-axi -R octo/release-target release upload v1.2.3 <files...>` to upload assets
+
+$ pnpm exec tsx bin/gh-axi.ts release create v1.2.4 --repo=octo/equals-target --target=main --notes-file=notes.md --discussion-category=Announcements --notes-start-tag v1.2.0 dist/app.zip
+created: ok
+tag: v1.2.4
+help[2]:
+  Run `gh-axi -R octo/equals-target release view v1.2.4` to view the release
+  Run `gh-axi -R octo/equals-target release upload v1.2.4 <files...>` to upload assets
+
+$ pnpm exec tsx bin/gh-axi.ts pr merge 42 --repo octo/pr-target --squash --delete-branch
+merged:
+  number: 42
+  status: ok
+  method: squash
+help[1]:
+  Run `gh-axi -R octo/pr-target pr revert 42` to revert if needed
+
+Recorded gh argv:
+[
+  "release",
+  "create",
+  "v1.2.3",
+  "--title",
+  "Ship 1.2.3",
+  "--notes",
+  "hello notes",
+  "--target",
+  "main",
+  "dist/app.zip",
+  "--repo",
+  "octo/release-target"
+]
+[
+  "release",
+  "create",
+  "v1.2.4",
+  "--notes-file",
+  "notes.md",
+  "--target",
+  "main",
+  "--discussion-category",
+  "Announcements",
+  "--notes-start-tag",
+  "v1.2.0",
+  "dist/app.zip",
+  "--repo",
+  "octo/equals-target"
+]
+[
+  "pr",
+  "view",
+  "42",
+  "--json",
+  "state,mergedBy,mergedAt",
+  "--repo",
+  "octo/pr-target"
+]
+[
+  "pr",
+  "merge",
+  "42",
+  "--squash",
+  "--delete-branch",
+  "--repo",
+  "octo/pr-target"
+]

--- a/.no-mistakes/evidence/fm/gh-axi-argfix-r3/fake-bin/gh
+++ b/.no-mistakes/evidence/fm/gh-axi-argfix-r3/fake-bin/gh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+log_file="${GH_AXI_ARG_LOG:?GH_AXI_ARG_LOG is required}"
+
+json_array='['
+first=1
+for arg in "$@"; do
+  escaped=$(printf '%s' "$arg" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  if [ "$first" -eq 1 ]; then
+    first=0
+  else
+    json_array="$json_array,"
+  fi
+  json_array="$json_array\"$escaped\""
+done
+json_array="$json_array]"
+printf '%s\n' "$json_array" >> "$log_file"
+
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  printf '{"state":"OPEN"}\n'
+fi

--- a/.no-mistakes/evidence/fm/gh-axi-argfix-r3/gh-argv.jsonl
+++ b/.no-mistakes/evidence/fm/gh-axi-argfix-r3/gh-argv.jsonl
@@ -1,0 +1,4 @@
+["release","create","v1.2.3","--title","Ship 1.2.3","--notes","hello notes","--target","main","dist/app.zip","--repo","octo/release-target"]
+["release","create","v1.2.4","--notes-file","notes.md","--target","main","--discussion-category","Announcements","--notes-start-tag","v1.2.0","dist/app.zip","--repo","octo/equals-target"]
+["pr","view","42","--json","state,mergedBy,mergedAt","--repo","octo/pr-target"]
+["pr","merge","42","--squash","--delete-branch","--repo","octo/pr-target"]

--- a/.no-mistakes/evidence/fm/gh-axi-argfix-r3/run-e2e.sh
+++ b/.no-mistakes/evidence/fm/gh-axi-argfix-r3/run-e2e.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+evidence_dir=".no-mistakes/evidence/fm/gh-axi-argfix-r3"
+transcript="$evidence_dir/cli-e2e-transcript.txt"
+arg_log="$evidence_dir/gh-argv.jsonl"
+fake_bin="$PWD/$evidence_dir/fake-bin"
+
+: > "$transcript"
+: > "$arg_log"
+
+run_case() {
+  printf '$ %s\n' "$*" >> "$transcript"
+  GH_AXI_ARG_LOG="$PWD/$arg_log" PATH="$fake_bin:$PATH" "$@" >> "$transcript" 2>&1
+  printf '\n' >> "$transcript"
+}
+
+run_case pnpm exec tsx bin/gh-axi.ts release create v1.2.3 --repo octo/release-target --target main --title "Ship 1.2.3" --notes "hello notes" dist/app.zip
+run_case pnpm exec tsx bin/gh-axi.ts release create v1.2.4 --repo=octo/equals-target --target=main --notes-file=notes.md --discussion-category=Announcements --notes-start-tag v1.2.0 dist/app.zip
+run_case pnpm exec tsx bin/gh-axi.ts pr merge 42 --repo octo/pr-target --squash --delete-branch
+
+printf 'Recorded gh argv:\n' >> "$transcript"
+node -e "const fs=require('fs'); for (const line of fs.readFileSync(process.argv[1], 'utf8').trim().split(/\\n/)) console.log(JSON.stringify(JSON.parse(line), null, 2));" "$arg_log" >> "$transcript"

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Repository targeting is command-first too:
 
 - `gh-axi issue list -R owner/name`
 - `gh-axi issue list --repo owner/name`
+- `gh-axi issue list --repo=owner/name`
 - `gh-axi run list -R owner/name`
 - `gh-axi search issues "login bug" --repo owner/name`
 

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -26,7 +26,7 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 
 1. Run `npx -y gh-axi` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: `issue list`, `issue view <n>`, `pr view <n>`, `pr checks <n>`, `run view <id>`, and so on.
-3. Target another repository by placing `-R owner/name` (or `--repo owner/name`) AFTER the command, e.g. `npx -y gh-axi issue list -R owner/name` - the flag is not accepted before the command.
+3. Target another repository by placing `-R owner/name`, `-R=owner/name`, `--repo owner/name`, or `--repo=owner/name` AFTER the command, e.g. `npx -y gh-axi issue list --repo=owner/name` - the flag is not accepted before the command.
 4. Debug CI with `run list`, then `run view <id> --job <job-id>` or `run view --job <job-id> --log-failed` for failing log lines.
    Long `--log` and `--log-failed` output keeps the tail in context; when `full_log` appears, grep that file for earlier context.
 5. Every response ends with contextual next-step hints under `help:` - follow them.

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,4 +1,4 @@
-import { AxiError } from './errors.js';
+import { AxiError } from "./errors.js";
 
 function flagEqualsPrefix(flag: string): string {
   return `${flag}=`;
@@ -69,25 +69,29 @@ export function getAllFlags(args: string[], flag: string): string[] {
 }
 
 /** Get the first positional arg (non-flag) starting from startIndex. */
-export function getPositional(args: string[], startIndex: number): string | undefined {
+export function getPositional(
+  args: string[],
+  startIndex: number,
+): string | undefined {
   for (let i = startIndex; i < args.length; i++) {
-    if (!args[i].startsWith('--')) return args[i];
+    if (!args[i].startsWith("--")) return args[i];
   }
   return undefined;
 }
 
 /** Parse and validate a required numeric argument. */
 export function requireNumber(raw: string | undefined, label: string): number {
-  if (!raw) throw new AxiError(`Missing ${label} number`, 'VALIDATION_ERROR');
+  if (!raw) throw new AxiError(`Missing ${label} number`, "VALIDATION_ERROR");
   const n = parseInt(raw, 10);
-  if (isNaN(n)) throw new AxiError(`Invalid ${label} number: ${raw}`, 'VALIDATION_ERROR');
+  if (isNaN(n))
+    throw new AxiError(`Invalid ${label} number: ${raw}`, "VALIDATION_ERROR");
   return n;
 }
 
 /** Find the first numeric positional arg, remove it from args, and return it as a number. */
 export function takeNumber(args: string[], label: string): number {
   const raw = args.find((a) => /^\d+$/.test(a));
-  if (!raw) throw new AxiError(`Missing ${label} number`, 'VALIDATION_ERROR');
+  if (!raw) throw new AxiError(`Missing ${label} number`, "VALIDATION_ERROR");
   args.splice(args.indexOf(raw), 1);
   return Number(raw);
 }

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,19 +1,42 @@
 import { AxiError } from './errors.js';
 
+function flagEqualsPrefix(flag: string): string {
+  return `${flag}=`;
+}
+
 /** Get a flag's value without modifying the args array. */
 export function getFlag(args: string[], name: string): string | undefined {
-  const idx = args.indexOf(name);
-  if (idx === -1 || idx + 1 >= args.length) return undefined;
-  return args[idx + 1];
+  const equalsPrefix = flagEqualsPrefix(name);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === name) {
+      if (i + 1 >= args.length) return undefined;
+      return args[i + 1];
+    }
+    if (arg.startsWith(equalsPrefix)) {
+      return arg.slice(equalsPrefix.length);
+    }
+  }
+  return undefined;
 }
 
 /** Get a flag's value and remove both the flag and value from args. */
 export function takeFlag(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  if (idx === -1) return undefined;
-  const val = args[idx + 1];
-  args.splice(idx, 2);
-  return val;
+  const equalsPrefix = flagEqualsPrefix(flag);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === flag) {
+      const val = args[i + 1];
+      args.splice(i, 2);
+      return val;
+    }
+    if (arg.startsWith(equalsPrefix)) {
+      const val = arg.slice(equalsPrefix.length);
+      args.splice(i, 1);
+      return val;
+    }
+  }
+  return undefined;
 }
 
 /** Check if a boolean flag is present. */
@@ -32,10 +55,14 @@ export function takeBoolFlag(args: string[], flag: string): boolean {
 /** Collect all values for a repeatable flag. */
 export function getAllFlags(args: string[], flag: string): string[] {
   const result: string[] = [];
+  const equalsPrefix = flagEqualsPrefix(flag);
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === flag && i + 1 < args.length) {
+    const arg = args[i];
+    if (arg === flag && i + 1 < args.length) {
       result.push(args[i + 1]);
       i++;
+    } else if (arg.startsWith(equalsPrefix)) {
+      result.push(arg.slice(equalsPrefix.length));
     }
   }
   return result;

--- a/src/args.ts
+++ b/src/args.ts
@@ -4,7 +4,7 @@ function flagEqualsPrefix(flag: string): string {
   return `${flag}=`;
 }
 
-/** Get a flag's value without modifying the args array. */
+/** Get a flag's value from --flag value or --flag=value without modifying args. */
 export function getFlag(args: string[], name: string): string | undefined {
   const equalsPrefix = flagEqualsPrefix(name);
   for (let i = 0; i < args.length; i++) {
@@ -20,7 +20,7 @@ export function getFlag(args: string[], name: string): string | undefined {
   return undefined;
 }
 
-/** Get a flag's value and remove both the flag and value from args. */
+/** Get a flag's value from --flag value or --flag=value and remove it from args. */
 export function takeFlag(args: string[], flag: string): string | undefined {
   const equalsPrefix = flagEqualsPrefix(flag);
   for (let i = 0; i < args.length; i++) {
@@ -52,7 +52,7 @@ export function takeBoolFlag(args: string[], flag: string): boolean {
   return true;
 }
 
-/** Collect all values for a repeatable flag. */
+/** Collect all values for a repeatable flag in --flag value or --flag=value form. */
 export function getAllFlags(args: string[], flag: string): string[] {
   const result: string[] = [];
   const equalsPrefix = flagEqualsPrefix(flag);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,6 +128,11 @@ function parseRepoContextArgs(
       continue;
     }
 
+    if (arg.startsWith("-R=") && arg.length > 3) {
+      repoFlag = arg.slice(3);
+      continue;
+    }
+
     if (arg === "--repo" && index + 1 < args.length) {
       const value = args[index + 1];
 
@@ -138,6 +143,16 @@ function parseRepoContextArgs(
       }
 
       index++;
+      continue;
+    }
+
+    if (arg.startsWith("--repo=") && arg.length > "--repo=".length) {
+      repoFlag = arg.slice("--repo=".length);
+
+      if (command === "search") {
+        stripped.push(arg);
+      }
+
       continue;
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,12 +30,12 @@ export const TOP_HELP = `usage: gh-axi [command] [args] [flags]
 commands[11]:
   (none)=dashboard, issue, pr, run, workflow, release, repo, label, search, api, setup
 flags[3]:
-  -R/--repo <OWNER/NAME> (after command), --help, -v/-V/--version
+  -R/--repo <OWNER/NAME> (after command), accepts space or equals form, --help, -v/-V/--version
 examples:
   gh-axi
   gh-axi issue list --state open
   gh-axi issue list -R owner/name
-  gh-axi issue list --repo owner/name
+  gh-axi issue list --repo=owner/name
   gh-axi pr view 42
   gh-axi setup hooks
 `;

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -229,7 +229,7 @@ flags{view}:
 flags{create}:
   --title <text> (required), --body, --base, --head, --draft, --assignee, --reviewer, --label, --milestone
 flags{merge}:
-  --method <merge|squash|rebase>, --auto, --delete-branch, --body, --subject
+  --method <merge|squash|rebase>, --merge, --squash, --rebase, --auto, --delete-branch, --body, --subject
 flags{review}:
   --approve, --request-changes, --comment, --body
 flags{checks}:
@@ -536,7 +536,33 @@ async function prClose(args: string[], ctx?: RepoContext): Promise<string> {
 
 async function prMerge(args: string[], ctx?: RepoContext): Promise<string> {
   const num = takeNumber(args, "PR");
-  const method = takeFlag(args, "--method");
+  const explicitMethod = takeFlag(args, "--method");
+  const shorthandMethods = ["merge", "squash", "rebase"].filter((candidate) =>
+    takeBoolFlag(args, `--${candidate}`),
+  );
+  if (shorthandMethods.length > 1) {
+    throw new AxiError(
+      "Choose only one merge method: --merge, --squash, or --rebase",
+      "VALIDATION_ERROR",
+    );
+  }
+  if (
+    explicitMethod &&
+    shorthandMethods.length === 1 &&
+    explicitMethod !== shorthandMethods[0]
+  ) {
+    throw new AxiError(
+      "Choose either --method or a matching merge method shorthand, not both",
+      "VALIDATION_ERROR",
+    );
+  }
+  const method = explicitMethod ?? shorthandMethods[0];
+  if (method && !["merge", "squash", "rebase"].includes(method)) {
+    throw new AxiError(
+      "--method must be one of: merge, squash, rebase",
+      "VALIDATION_ERROR",
+    );
+  }
   const auto = takeBoolFlag(args, "--auto");
   const deleteBranch = takeBoolFlag(args, "--delete-branch");
   const body = takeFlag(args, "--body");

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -90,6 +90,24 @@ function appendBoolFlag(
   }
 }
 
+function appendOptionalValueBoolFlag(
+  ghArgs: string[],
+  args: string[],
+  outputFlag: string,
+  inputFlags: string[] = [outputFlag],
+): void {
+  for (const flag of inputFlags) {
+    const equalsPrefix = `${flag}=`;
+    const equalsIndex = args.findIndex((arg) => arg.startsWith(equalsPrefix));
+    if (equalsIndex !== -1) {
+      ghArgs.push(`${outputFlag}=${args[equalsIndex].slice(equalsPrefix.length)}`);
+      args.splice(equalsIndex, 1);
+      return;
+    }
+  }
+  appendBoolFlag(ghArgs, args, outputFlag, inputFlags);
+}
+
 
 async function listReleases(args: string[], ctx?: RepoContext): Promise<string> {
   const limit = getFlag(args, '--limit') ?? '10';
@@ -145,7 +163,7 @@ async function createRelease(args: string[], ctx?: RepoContext): Promise<string>
   appendBoolFlag(optionArgs, remaining, '--verify-tag');
   appendBoolFlag(optionArgs, remaining, '--notes-from-tag');
   appendBoolFlag(optionArgs, remaining, '--fail-on-no-commits');
-  appendBoolFlag(optionArgs, remaining, '--latest');
+  appendOptionalValueBoolFlag(optionArgs, remaining, '--latest');
 
   const positionals = remaining.filter((a) => !a.startsWith('-'));
   const tag = positionals[0];

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -27,7 +27,7 @@ flags{list}:
 flags{view}:
   --full (show complete release notes without truncation)
 flags{create}:
-  --title, --notes, --notes-file, --draft, --prerelease, --target, --generate-notes, --discussion-category, --notes-start-tag, --verify-tag
+  --title/-t, --notes/-n, --notes-file/-F, --draft/-d, --prerelease/-p, --target, --generate-notes, --discussion-category, --notes-start-tag, --verify-tag, --notes-from-tag, --fail-on-no-commits, --latest[=true|false], <files...>
 flags{edit}:
   --title, --notes, --draft, --prerelease
 flags{download}:
@@ -35,7 +35,7 @@ flags{download}:
 examples:
   gh-axi release list --exclude-drafts
   gh-axi release view v1.2.0 --full
-  gh-axi release create v1.3.0 --generate-notes --draft`;
+  gh-axi release create v1.3.0 --generate-notes --draft dist/app.zip`;
 
 const listSchema: FieldDef[] = [
   field('tagName', 'tag'),

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -1,9 +1,9 @@
-import { encode } from '@toon-format/toon';
-import type { RepoContext } from '../context.js';
-import { ghJson, ghExec } from '../gh.js';
-import { AxiError } from '../errors.js';
-import { getFlag, hasFlag, takeBoolFlag, takeFlag } from '../args.js';
-import { truncateBody } from '../body.js';
+import { encode } from "@toon-format/toon";
+import type { RepoContext } from "../context.js";
+import { ghJson, ghExec } from "../gh.js";
+import { AxiError } from "../errors.js";
+import { getFlag, hasFlag, takeBoolFlag, takeFlag } from "../args.js";
+import { truncateBody } from "../body.js";
 import {
   field,
   boolYesNo,
@@ -16,8 +16,8 @@ import {
   renderOutput,
   renderError,
   type FieldDef,
-} from '../toon.js';
-import { getSuggestions } from '../suggestions.js';
+} from "../toon.js";
+import { getSuggestions } from "../suggestions.js";
 
 export const RELEASE_HELP = `usage: gh-axi release <subcommand> [flags]
 subcommands[7]:
@@ -38,27 +38,27 @@ examples:
   gh-axi release create v1.3.0 --generate-notes --draft dist/app.zip`;
 
 const listSchema: FieldDef[] = [
-  field('tagName', 'tag'),
-  field('name'),
-  boolYesNo('isDraft', 'draft'),
-  boolYesNo('isPrerelease', 'prerelease'),
-  relativeTime('publishedAt', 'published'),
+  field("tagName", "tag"),
+  field("name"),
+  boolYesNo("isDraft", "draft"),
+  boolYesNo("isPrerelease", "prerelease"),
+  relativeTime("publishedAt", "published"),
 ];
 
 const viewSchema: FieldDef[] = [
-  field('tagName', 'tag'),
-  field('name'),
-  relativeTime('publishedAt', 'published'),
-  pluck('author', 'login', 'author'),
-  custom('body', (item) => truncateBody(item.body, 1000)),
+  field("tagName", "tag"),
+  field("name"),
+  relativeTime("publishedAt", "published"),
+  pluck("author", "login", "author"),
+  custom("body", (item) => truncateBody(item.body, 1000)),
 ];
 
 const viewSchemaFull: FieldDef[] = [
-  field('tagName', 'tag'),
-  field('name'),
-  relativeTime('publishedAt', 'published'),
-  pluck('author', 'login', 'author'),
-  custom('body', (item) => typeof item.body === 'string' ? item.body : ''),
+  field("tagName", "tag"),
+  field("name"),
+  relativeTime("publishedAt", "published"),
+  pluck("author", "login", "author"),
+  custom("body", (item) => (typeof item.body === "string" ? item.body : "")),
 ];
 
 function takeFirstFlag(args: string[], flags: string[]): string | undefined {
@@ -100,7 +100,9 @@ function appendOptionalValueBoolFlag(
     const equalsPrefix = `${flag}=`;
     const equalsIndex = args.findIndex((arg) => arg.startsWith(equalsPrefix));
     if (equalsIndex !== -1) {
-      ghArgs.push(`${outputFlag}=${args[equalsIndex].slice(equalsPrefix.length)}`);
+      ghArgs.push(
+        `${outputFlag}=${args[equalsIndex].slice(equalsPrefix.length)}`,
+      );
       args.splice(equalsIndex, 1);
       return;
     }
@@ -108,186 +110,276 @@ function appendOptionalValueBoolFlag(
   appendBoolFlag(ghArgs, args, outputFlag, inputFlags);
 }
 
-
-async function listReleases(args: string[], ctx?: RepoContext): Promise<string> {
-  const limit = getFlag(args, '--limit') ?? '10';
+async function listReleases(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
+  const limit = getFlag(args, "--limit") ?? "10";
   const ghArgs = [
-    'release', 'list',
-    '--json', 'tagName,name,isDraft,isPrerelease,publishedAt',
-    '--limit', limit,
+    "release",
+    "list",
+    "--json",
+    "tagName,name,isDraft,isPrerelease,publishedAt",
+    "--limit",
+    limit,
   ];
-  if (hasFlag(args, '--exclude-drafts')) ghArgs.push('--exclude-drafts');
-  if (hasFlag(args, '--exclude-pre-releases')) ghArgs.push('--exclude-pre-releases');
+  if (hasFlag(args, "--exclude-drafts")) ghArgs.push("--exclude-drafts");
+  if (hasFlag(args, "--exclude-pre-releases"))
+    ghArgs.push("--exclude-pre-releases");
 
   const releases = await ghJson<Record<string, unknown>[]>(ghArgs, ctx);
   const isEmpty = releases.length === 0;
   const limitNum = Number(limit);
-  const countLine = releases.length === limitNum
-    ? `count: ${releases.length} (showing first ${releases.length}; run \`gh-axi repo view\` for total count)`
-    : `count: ${releases.length}`;
-  const suggestions = getSuggestions({ domain: 'release', action: 'list', isEmpty, repo: ctx });
+  const countLine =
+    releases.length === limitNum
+      ? `count: ${releases.length} (showing first ${releases.length}; run \`gh-axi repo view\` for total count)`
+      : `count: ${releases.length}`;
+  const suggestions = getSuggestions({
+    domain: "release",
+    action: "list",
+    isEmpty,
+    repo: ctx,
+  });
   return renderOutput([
     countLine,
-    renderList('releases', releases, listSchema),
+    renderList("releases", releases, listSchema),
     renderHelp(suggestions),
   ]);
 }
 
 async function viewRelease(args: string[], ctx?: RepoContext): Promise<string> {
-  const full = hasFlag(args, '--full');
-  const positionals = args.filter((a) => !a.startsWith('--'));
+  const full = hasFlag(args, "--full");
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const tag = positionals[1];
-  if (!tag) throw new AxiError('Tag is required: gh-axi release view <tag>', 'VALIDATION_ERROR');
+  if (!tag)
+    throw new AxiError(
+      "Tag is required: gh-axi release view <tag>",
+      "VALIDATION_ERROR",
+    );
 
   const release = await ghJson<Record<string, unknown>>(
-    ['release', 'view', tag, '--json', 'tagName,name,publishedAt,author,body'],
+    ["release", "view", tag, "--json", "tagName,name,publishedAt,author,body"],
     ctx,
   );
 
-  return renderOutput([renderDetail('release', release, full ? viewSchemaFull : viewSchema)]);
+  return renderOutput([
+    renderDetail("release", release, full ? viewSchemaFull : viewSchema),
+  ]);
 }
 
-async function createRelease(args: string[], ctx?: RepoContext): Promise<string> {
+async function createRelease(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
   const remaining = args.slice(1);
   const optionArgs: string[] = [];
 
-  appendValueFlag(optionArgs, remaining, '--title', ['--title', '-t']);
-  appendValueFlag(optionArgs, remaining, '--notes', ['--notes', '-n']);
-  appendValueFlag(optionArgs, remaining, '--notes-file', ['--notes-file', '-F']);
-  appendValueFlag(optionArgs, remaining, '--target');
-  appendValueFlag(optionArgs, remaining, '--discussion-category');
-  appendValueFlag(optionArgs, remaining, '--notes-start-tag');
-  appendBoolFlag(optionArgs, remaining, '--draft', ['--draft', '-d']);
-  appendBoolFlag(optionArgs, remaining, '--prerelease', ['--prerelease', '-p']);
-  appendBoolFlag(optionArgs, remaining, '--generate-notes');
-  appendBoolFlag(optionArgs, remaining, '--verify-tag');
-  appendBoolFlag(optionArgs, remaining, '--notes-from-tag');
-  appendBoolFlag(optionArgs, remaining, '--fail-on-no-commits');
-  appendOptionalValueBoolFlag(optionArgs, remaining, '--latest');
+  appendValueFlag(optionArgs, remaining, "--title", ["--title", "-t"]);
+  appendValueFlag(optionArgs, remaining, "--notes", ["--notes", "-n"]);
+  appendValueFlag(optionArgs, remaining, "--notes-file", [
+    "--notes-file",
+    "-F",
+  ]);
+  appendValueFlag(optionArgs, remaining, "--target");
+  appendValueFlag(optionArgs, remaining, "--discussion-category");
+  appendValueFlag(optionArgs, remaining, "--notes-start-tag");
+  appendBoolFlag(optionArgs, remaining, "--draft", ["--draft", "-d"]);
+  appendBoolFlag(optionArgs, remaining, "--prerelease", ["--prerelease", "-p"]);
+  appendBoolFlag(optionArgs, remaining, "--generate-notes");
+  appendBoolFlag(optionArgs, remaining, "--verify-tag");
+  appendBoolFlag(optionArgs, remaining, "--notes-from-tag");
+  appendBoolFlag(optionArgs, remaining, "--fail-on-no-commits");
+  appendOptionalValueBoolFlag(optionArgs, remaining, "--latest");
 
-  const positionals = remaining.filter((a) => !a.startsWith('-'));
+  const positionals = remaining.filter((a) => !a.startsWith("-"));
   const tag = positionals[0];
-  if (!tag) throw new AxiError('Tag is required: gh-axi release create <tag>', 'VALIDATION_ERROR');
+  if (!tag)
+    throw new AxiError(
+      "Tag is required: gh-axi release create <tag>",
+      "VALIDATION_ERROR",
+    );
 
-  const ghArgs = ['release', 'create', tag, ...optionArgs, ...positionals.slice(1)];
+  const ghArgs = [
+    "release",
+    "create",
+    tag,
+    ...optionArgs,
+    ...positionals.slice(1),
+  ];
 
   await ghExec(ghArgs, ctx);
-  const suggestions = getSuggestions({ domain: 'release', action: 'create', id: tag, repo: ctx });
+  const suggestions = getSuggestions({
+    domain: "release",
+    action: "create",
+    id: tag,
+    repo: ctx,
+  });
   return renderOutput([
-    encode({ created: 'ok', tag }),
+    encode({ created: "ok", tag }),
     renderHelp(suggestions),
   ]);
 }
 
 async function editRelease(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const tag = positionals[1];
-  if (!tag) throw new AxiError('Tag is required: gh-axi release edit <tag>', 'VALIDATION_ERROR');
+  if (!tag)
+    throw new AxiError(
+      "Tag is required: gh-axi release edit <tag>",
+      "VALIDATION_ERROR",
+    );
 
-  const ghArgs = ['release', 'edit', tag];
-  const title = getFlag(args, '--title');
-  if (title) ghArgs.push('--title', title);
-  const notes = getFlag(args, '--notes');
-  if (notes) ghArgs.push('--notes', notes);
-  if (hasFlag(args, '--draft')) ghArgs.push('--draft');
-  if (hasFlag(args, '--prerelease')) ghArgs.push('--prerelease');
+  const ghArgs = ["release", "edit", tag];
+  const title = getFlag(args, "--title");
+  if (title) ghArgs.push("--title", title);
+  const notes = getFlag(args, "--notes");
+  if (notes) ghArgs.push("--notes", notes);
+  if (hasFlag(args, "--draft")) ghArgs.push("--draft");
+  if (hasFlag(args, "--prerelease")) ghArgs.push("--prerelease");
 
   await ghExec(ghArgs, ctx);
-  const suggestions = getSuggestions({ domain: 'release', action: 'edit', id: tag, repo: ctx });
-  return renderOutput([
-    encode({ edit: 'ok', tag }),
-    renderHelp(suggestions),
-  ]);
+  const suggestions = getSuggestions({
+    domain: "release",
+    action: "edit",
+    id: tag,
+    repo: ctx,
+  });
+  return renderOutput([encode({ edit: "ok", tag }), renderHelp(suggestions)]);
 }
 
-async function deleteRelease(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+async function deleteRelease(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const tag = positionals[1];
-  if (!tag) throw new AxiError('Tag is required: gh-axi release delete <tag>', 'VALIDATION_ERROR');
+  if (!tag)
+    throw new AxiError(
+      "Tag is required: gh-axi release delete <tag>",
+      "VALIDATION_ERROR",
+    );
 
   // Idempotent: check if release exists before deleting
   try {
     await ghJson<Record<string, unknown>>(
-      ['release', 'view', tag, '--json', 'tagName'],
+      ["release", "view", tag, "--json", "tagName"],
       ctx,
     );
   } catch (err) {
-    if (err instanceof AxiError && err.code === 'NOT_FOUND') {
-      const suggestions = getSuggestions({ domain: 'release', action: 'delete', id: tag, repo: ctx });
+    if (err instanceof AxiError && err.code === "NOT_FOUND") {
+      const suggestions = getSuggestions({
+        domain: "release",
+        action: "delete",
+        id: tag,
+        repo: ctx,
+      });
       return renderOutput([
-        encode({ delete: 'already_deleted', tag }),
+        encode({ delete: "already_deleted", tag }),
         renderHelp(suggestions),
       ]);
     }
     throw err;
   }
 
-  await ghExec(['release', 'delete', tag, '--yes'], ctx);
-  const suggestions = getSuggestions({ domain: 'release', action: 'delete', id: tag, repo: ctx });
-  return renderOutput([
-    encode({ delete: 'ok', tag }),
-    renderHelp(suggestions),
-  ]);
+  await ghExec(["release", "delete", tag, "--yes"], ctx);
+  const suggestions = getSuggestions({
+    domain: "release",
+    action: "delete",
+    id: tag,
+    repo: ctx,
+  });
+  return renderOutput([encode({ delete: "ok", tag }), renderHelp(suggestions)]);
 }
 
-async function downloadRelease(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+async function downloadRelease(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const tag = positionals[1];
-  if (!tag) throw new AxiError('Tag is required: gh-axi release download <tag>', 'VALIDATION_ERROR');
+  if (!tag)
+    throw new AxiError(
+      "Tag is required: gh-axi release download <tag>",
+      "VALIDATION_ERROR",
+    );
 
-  const ghArgs = ['release', 'download', tag];
-  const pattern = getFlag(args, '--pattern');
-  if (pattern) ghArgs.push('--pattern', pattern);
-  const dir = getFlag(args, '--dir');
-  if (dir) ghArgs.push('--dir', dir);
+  const ghArgs = ["release", "download", tag];
+  const pattern = getFlag(args, "--pattern");
+  if (pattern) ghArgs.push("--pattern", pattern);
+  const dir = getFlag(args, "--dir");
+  if (dir) ghArgs.push("--dir", dir);
 
   await ghExec(ghArgs, ctx);
-  const suggestions = getSuggestions({ domain: 'release', action: 'download', id: tag, repo: ctx });
+  const suggestions = getSuggestions({
+    domain: "release",
+    action: "download",
+    id: tag,
+    repo: ctx,
+  });
   return renderOutput([
-    encode({ download: 'ok', tag }),
+    encode({ download: "ok", tag }),
     renderHelp(suggestions),
   ]);
 }
 
-async function uploadRelease(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+async function uploadRelease(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const tag = positionals[1];
-  if (!tag) throw new AxiError('Tag is required: gh-axi release upload <tag> <files...>', 'VALIDATION_ERROR');
+  if (!tag)
+    throw new AxiError(
+      "Tag is required: gh-axi release upload <tag> <files...>",
+      "VALIDATION_ERROR",
+    );
 
   const files = positionals.slice(2);
-  if (files.length === 0) throw new AxiError('At least one file is required: gh-axi release upload <tag> <files...>', 'VALIDATION_ERROR');
+  if (files.length === 0)
+    throw new AxiError(
+      "At least one file is required: gh-axi release upload <tag> <files...>",
+      "VALIDATION_ERROR",
+    );
 
-  await ghExec(['release', 'upload', tag, ...files], ctx);
-  const suggestions = getSuggestions({ domain: 'release', action: 'upload', id: tag, repo: ctx });
+  await ghExec(["release", "upload", tag, ...files], ctx);
+  const suggestions = getSuggestions({
+    domain: "release",
+    action: "upload",
+    id: tag,
+    repo: ctx,
+  });
   return renderOutput([
-    encode({ upload: 'ok', tag, files: files.length }),
+    encode({ upload: "ok", tag, files: files.length }),
     renderHelp(suggestions),
   ]);
 }
 
-export async function releaseCommand(args: string[], ctx?: RepoContext): Promise<string> {
+export async function releaseCommand(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
   const sub = args[0];
 
-  if (sub === '--help' || sub === undefined) return RELEASE_HELP;
+  if (sub === "--help" || sub === undefined) return RELEASE_HELP;
 
   switch (sub) {
-    case 'list':
+    case "list":
       return listReleases(args, ctx);
-    case 'view':
+    case "view":
       return viewRelease(args, ctx);
-    case 'create':
+    case "create":
       return createRelease(args, ctx);
-    case 'edit':
+    case "edit":
       return editRelease(args, ctx);
-    case 'delete':
+    case "delete":
       return deleteRelease(args, ctx);
-    case 'download':
+    case "download":
       return downloadRelease(args, ctx);
-    case 'upload':
+    case "upload":
       return uploadRelease(args, ctx);
     default:
-      return renderError(`Unknown subcommand: ${sub}`, 'VALIDATION_ERROR', [
-        'Available subcommands: list, view, create, edit, delete, download, upload',
+      return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [
+        "Available subcommands: list, view, create, edit, delete, download, upload",
       ]);
   }
 }

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -2,7 +2,7 @@ import { encode } from '@toon-format/toon';
 import type { RepoContext } from '../context.js';
 import { ghJson, ghExec } from '../gh.js';
 import { AxiError } from '../errors.js';
-import { getFlag, hasFlag } from '../args.js';
+import { getFlag, hasFlag, takeBoolFlag, takeFlag } from '../args.js';
 import { truncateBody } from '../body.js';
 import {
   field,
@@ -27,7 +27,7 @@ flags{list}:
 flags{view}:
   --full (show complete release notes without truncation)
 flags{create}:
-  --title, --notes, --notes-file, --draft, --prerelease, --target, --generate-notes
+  --title, --notes, --notes-file, --draft, --prerelease, --target, --generate-notes, --discussion-category, --notes-start-tag, --verify-tag
 flags{edit}:
   --title, --notes, --draft, --prerelease
 flags{download}:
@@ -61,6 +61,34 @@ const viewSchemaFull: FieldDef[] = [
   custom('body', (item) => typeof item.body === 'string' ? item.body : ''),
 ];
 
+function takeFirstFlag(args: string[], flags: string[]): string | undefined {
+  for (const flag of flags) {
+    const value = takeFlag(args, flag);
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
+function appendValueFlag(
+  ghArgs: string[],
+  args: string[],
+  outputFlag: string,
+  inputFlags: string[] = [outputFlag],
+): void {
+  const value = takeFirstFlag(args, inputFlags);
+  if (value !== undefined) ghArgs.push(outputFlag, value);
+}
+
+function appendBoolFlag(
+  ghArgs: string[],
+  args: string[],
+  outputFlag: string,
+  inputFlags: string[] = [outputFlag],
+): void {
+  if (inputFlags.some((flag) => takeBoolFlag(args, flag))) {
+    ghArgs.push(outputFlag);
+  }
+}
 
 
 async function listReleases(args: string[], ctx?: RepoContext): Promise<string> {
@@ -102,29 +130,28 @@ async function viewRelease(args: string[], ctx?: RepoContext): Promise<string> {
 }
 
 async function createRelease(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
-  const tag = positionals[1];
+  const remaining = args.slice(1);
+  const optionArgs: string[] = [];
+
+  appendValueFlag(optionArgs, remaining, '--title', ['--title', '-t']);
+  appendValueFlag(optionArgs, remaining, '--notes', ['--notes', '-n']);
+  appendValueFlag(optionArgs, remaining, '--notes-file', ['--notes-file', '-F']);
+  appendValueFlag(optionArgs, remaining, '--target');
+  appendValueFlag(optionArgs, remaining, '--discussion-category');
+  appendValueFlag(optionArgs, remaining, '--notes-start-tag');
+  appendBoolFlag(optionArgs, remaining, '--draft', ['--draft', '-d']);
+  appendBoolFlag(optionArgs, remaining, '--prerelease', ['--prerelease', '-p']);
+  appendBoolFlag(optionArgs, remaining, '--generate-notes');
+  appendBoolFlag(optionArgs, remaining, '--verify-tag');
+  appendBoolFlag(optionArgs, remaining, '--notes-from-tag');
+  appendBoolFlag(optionArgs, remaining, '--fail-on-no-commits');
+  appendBoolFlag(optionArgs, remaining, '--latest');
+
+  const positionals = remaining.filter((a) => !a.startsWith('-'));
+  const tag = positionals[0];
   if (!tag) throw new AxiError('Tag is required: gh-axi release create <tag>', 'VALIDATION_ERROR');
 
-  const ghArgs = ['release', 'create', tag];
-  const title = getFlag(args, '--title');
-  if (title) ghArgs.push('--title', title);
-  const notes = getFlag(args, '--notes');
-  if (notes) ghArgs.push('--notes', notes);
-  const notesFile = getFlag(args, '--notes-file');
-  if (notesFile) ghArgs.push('--notes-file', notesFile);
-  if (hasFlag(args, '--draft')) ghArgs.push('--draft');
-  if (hasFlag(args, '--prerelease')) ghArgs.push('--prerelease');
-  const target = getFlag(args, '--target');
-  if (target) ghArgs.push('--target', target);
-  if (hasFlag(args, '--generate-notes')) ghArgs.push('--generate-notes');
-
-  // Positional files (after tag, excluding flags and their values)
-  const files: string[] = [];
-  for (let i = 2; i < positionals.length; i++) {
-    files.push(positionals[i]);
-  }
-  ghArgs.push(...files);
+  const ghArgs = ['release', 'create', tag, ...optionArgs, ...positionals.slice(1)];
 
   await ghExec(ghArgs, ctx);
   const suggestions = getSuggestions({ domain: 'release', action: 'create', id: tag, repo: ctx });

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -20,6 +20,19 @@ import { getSuggestions } from "../suggestions.js";
 
 const DEFAULT_SEARCH_LIMIT = "1000";
 const DISPLAY_LIMIT = 30;
+const SEARCH_VALUE_FLAGS = new Set([
+  "--repo",
+  "--owner",
+  "--state",
+  "--label",
+  "--assignee",
+  "--author",
+  "--sort",
+  "--limit",
+  "--review",
+  "--language",
+  "--stars",
+]);
 
 export const SEARCH_HELP = `usage: gh-axi search <type> <query> [flags]
 types[5]:
@@ -92,8 +105,7 @@ function extractQuery(args: string[]): string {
   let i = 1; // skip subcommand (issues/prs/repos/commits/code)
   while (i < args.length) {
     if (args[i].startsWith("--")) {
-      // Skip flag + value
-      i += 2;
+      i += args[i].includes("=") || !SEARCH_VALUE_FLAGS.has(args[i]) ? 1 : 2;
     } else {
       positionals.push(args[i]);
       i++;

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -116,7 +116,9 @@ const COMMON_FILTER_FLAGS = [
 ];
 
 function hasSearchFilters(args: string[], extraFlags: string[] = []): boolean {
-  return [...COMMON_FILTER_FLAGS, ...extraFlags].some((f) => hasFlag(args, f));
+  return [...COMMON_FILTER_FLAGS, ...extraFlags].some(
+    (f) => hasFlag(args, f) || getFlag(args, f) !== undefined,
+  );
 }
 
 async function searchIssues(

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -69,7 +69,7 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 
 1. Run \`npx -y gh-axi\` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: \`issue list\`, \`issue view <n>\`, \`pr view <n>\`, \`pr checks <n>\`, \`run view <id>\`, and so on.
-3. Target another repository by placing \`-R owner/name\` (or \`--repo owner/name\`) AFTER the command, e.g. \`npx -y gh-axi issue list -R owner/name\` - the flag is not accepted before the command.
+3. Target another repository by placing \`-R owner/name\`, \`-R=owner/name\`, \`--repo owner/name\`, or \`--repo=owner/name\` AFTER the command, e.g. \`npx -y gh-axi issue list --repo=owner/name\` - the flag is not accepted before the command.
 4. Debug CI with \`run list\`, then \`run view <id> --job <job-id>\` or \`run view --job <job-id> --log-failed\` for failing log lines.
    Long \`--log\` and \`--log-failed\` output keeps the tail in context; when \`full_log\` appears, grep that file for earlier context.
 5. Every response ends with contextual next-step hints under \`help:\` - follow them.

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 import {
   getFlag,
   takeFlag,
@@ -7,173 +7,188 @@ import {
   getAllFlags,
   getPositional,
   requireNumber,
-} from '../src/args.js';
-import { AxiError } from '../src/errors.js';
+} from "../src/args.js";
+import { AxiError } from "../src/errors.js";
 
-describe('getFlag', () => {
-  it('returns the value following the flag', () => {
-    expect(getFlag(['--repo', 'cli/cli', '--state', 'open'], '--repo')).toBe('cli/cli');
+describe("getFlag", () => {
+  it("returns the value following the flag", () => {
+    expect(getFlag(["--repo", "cli/cli", "--state", "open"], "--repo")).toBe(
+      "cli/cli",
+    );
   });
 
-  it('returns the value from --flag=value form', () => {
-    expect(getFlag(['--repo=cli/cli', '--state', 'open'], '--repo')).toBe('cli/cli');
+  it("returns the value from --flag=value form", () => {
+    expect(getFlag(["--repo=cli/cli", "--state", "open"], "--repo")).toBe(
+      "cli/cli",
+    );
   });
 
-  it('returns undefined when flag is missing', () => {
-    expect(getFlag(['--state', 'open'], '--repo')).toBeUndefined();
+  it("returns undefined when flag is missing", () => {
+    expect(getFlag(["--state", "open"], "--repo")).toBeUndefined();
   });
 
-  it('returns undefined when flag is last element (no value)', () => {
-    expect(getFlag(['--state', 'open', '--repo'], '--repo')).toBeUndefined();
+  it("returns undefined when flag is last element (no value)", () => {
+    expect(getFlag(["--state", "open", "--repo"], "--repo")).toBeUndefined();
   });
 
-  it('does not modify the args array', () => {
-    const args = ['--repo', 'cli/cli'];
-    getFlag(args, '--repo');
-    expect(args).toEqual(['--repo', 'cli/cli']);
+  it("does not modify the args array", () => {
+    const args = ["--repo", "cli/cli"];
+    getFlag(args, "--repo");
+    expect(args).toEqual(["--repo", "cli/cli"]);
   });
 });
 
-describe('takeFlag', () => {
-  it('returns value and removes flag+value from args', () => {
-    const args = ['--repo', 'cli/cli', '--state', 'open'];
-    const val = takeFlag(args, '--repo');
-    expect(val).toBe('cli/cli');
-    expect(args).toEqual(['--state', 'open']);
+describe("takeFlag", () => {
+  it("returns value and removes flag+value from args", () => {
+    const args = ["--repo", "cli/cli", "--state", "open"];
+    const val = takeFlag(args, "--repo");
+    expect(val).toBe("cli/cli");
+    expect(args).toEqual(["--state", "open"]);
   });
 
-  it('returns value and removes --flag=value from args', () => {
-    const args = ['--repo=cli/cli', '--state', 'open'];
-    const val = takeFlag(args, '--repo');
-    expect(val).toBe('cli/cli');
-    expect(args).toEqual(['--state', 'open']);
+  it("returns value and removes --flag=value from args", () => {
+    const args = ["--repo=cli/cli", "--state", "open"];
+    const val = takeFlag(args, "--repo");
+    expect(val).toBe("cli/cli");
+    expect(args).toEqual(["--state", "open"]);
   });
 
-  it('returns undefined when flag is missing', () => {
-    const args = ['--state', 'open'];
-    expect(takeFlag(args, '--repo')).toBeUndefined();
-    expect(args).toEqual(['--state', 'open']);
+  it("returns undefined when flag is missing", () => {
+    const args = ["--state", "open"];
+    expect(takeFlag(args, "--repo")).toBeUndefined();
+    expect(args).toEqual(["--state", "open"]);
   });
 
-  it('removes flag+value even when value is undefined-ish', () => {
-    const args = ['--flag', 'val', '--other'];
+  it("removes flag+value even when value is undefined-ish", () => {
+    const args = ["--flag", "val", "--other"];
     // --other is at index 2, takeFlag('--flag') removes indices 0,1
-    const val = takeFlag(args, '--flag');
-    expect(val).toBe('val');
-    expect(args).toEqual(['--other']);
+    const val = takeFlag(args, "--flag");
+    expect(val).toBe("val");
+    expect(args).toEqual(["--other"]);
   });
 });
 
-describe('hasFlag', () => {
-  it('returns true when flag is present', () => {
-    expect(hasFlag(['--full', '--json'], '--full')).toBe(true);
+describe("hasFlag", () => {
+  it("returns true when flag is present", () => {
+    expect(hasFlag(["--full", "--json"], "--full")).toBe(true);
   });
 
-  it('returns false when flag is absent', () => {
-    expect(hasFlag(['--json'], '--full')).toBe(false);
+  it("returns false when flag is absent", () => {
+    expect(hasFlag(["--json"], "--full")).toBe(false);
   });
 
-  it('returns false for empty args', () => {
-    expect(hasFlag([], '--full')).toBe(false);
-  });
-});
-
-describe('takeBoolFlag', () => {
-  it('returns true and removes flag', () => {
-    const args = ['--full', '--json'];
-    expect(takeBoolFlag(args, '--full')).toBe(true);
-    expect(args).toEqual(['--json']);
-  });
-
-  it('returns false when flag is absent', () => {
-    const args = ['--json'];
-    expect(takeBoolFlag(args, '--full')).toBe(false);
-    expect(args).toEqual(['--json']);
+  it("returns false for empty args", () => {
+    expect(hasFlag([], "--full")).toBe(false);
   });
 });
 
-describe('getAllFlags', () => {
-  it('collects all values for a repeatable flag', () => {
-    const args = ['--label', 'bug', '--state', 'open', '--label', 'help wanted'];
-    expect(getAllFlags(args, '--label')).toEqual(['bug', 'help wanted']);
+describe("takeBoolFlag", () => {
+  it("returns true and removes flag", () => {
+    const args = ["--full", "--json"];
+    expect(takeBoolFlag(args, "--full")).toBe(true);
+    expect(args).toEqual(["--json"]);
   });
 
-  it('collects repeatable values from --flag=value form', () => {
-    const args = ['--label=bug', '--state', 'open', '--label=help wanted'];
-    expect(getAllFlags(args, '--label')).toEqual(['bug', 'help wanted']);
-  });
-
-  it('returns empty array when flag is absent', () => {
-    expect(getAllFlags(['--state', 'open'], '--label')).toEqual([]);
-  });
-
-  it('returns empty array for empty args', () => {
-    expect(getAllFlags([], '--label')).toEqual([]);
-  });
-
-  it('skips flag at end of array with no value', () => {
-    const args = ['--label', 'bug', '--label'];
-    expect(getAllFlags(args, '--label')).toEqual(['bug']);
+  it("returns false when flag is absent", () => {
+    const args = ["--json"];
+    expect(takeBoolFlag(args, "--full")).toBe(false);
+    expect(args).toEqual(["--json"]);
   });
 });
 
-describe('getPositional', () => {
-  it('returns first non-flag arg from startIndex', () => {
-    expect(getPositional(['view', '42', '--full'], 0)).toBe('view');
+describe("getAllFlags", () => {
+  it("collects all values for a repeatable flag", () => {
+    const args = [
+      "--label",
+      "bug",
+      "--state",
+      "open",
+      "--label",
+      "help wanted",
+    ];
+    expect(getAllFlags(args, "--label")).toEqual(["bug", "help wanted"]);
   });
 
-  it('skips -- prefixed flags but not their values', () => {
+  it("collects repeatable values from --flag=value form", () => {
+    const args = ["--label=bug", "--state", "open", "--label=help wanted"];
+    expect(getAllFlags(args, "--label")).toEqual(["bug", "help wanted"]);
+  });
+
+  it("returns empty array when flag is absent", () => {
+    expect(getAllFlags(["--state", "open"], "--label")).toEqual([]);
+  });
+
+  it("returns empty array for empty args", () => {
+    expect(getAllFlags([], "--label")).toEqual([]);
+  });
+
+  it("skips flag at end of array with no value", () => {
+    const args = ["--label", "bug", "--label"];
+    expect(getAllFlags(args, "--label")).toEqual(["bug"]);
+  });
+});
+
+describe("getPositional", () => {
+  it("returns first non-flag arg from startIndex", () => {
+    expect(getPositional(["view", "42", "--full"], 0)).toBe("view");
+  });
+
+  it("skips -- prefixed flags but not their values", () => {
     // getPositional only skips args starting with '--', flag values are treated as positionals
-    expect(getPositional(['--state', 'open', '42'], 0)).toBe('open');
+    expect(getPositional(["--state", "open", "42"], 0)).toBe("open");
   });
 
-  it('returns first non-flag token', () => {
-    expect(getPositional(['--verbose', '42'], 0)).toBe('42');
+  it("returns first non-flag token", () => {
+    expect(getPositional(["--verbose", "42"], 0)).toBe("42");
   });
 
-  it('returns undefined when all args are flags', () => {
-    expect(getPositional(['--state', '--verbose'], 0)).toBeUndefined();
+  it("returns undefined when all args are flags", () => {
+    expect(getPositional(["--state", "--verbose"], 0)).toBeUndefined();
   });
 
-  it('respects startIndex', () => {
-    expect(getPositional(['view', '42', '--full'], 1)).toBe('42');
+  it("respects startIndex", () => {
+    expect(getPositional(["view", "42", "--full"], 1)).toBe("42");
   });
 
-  it('returns undefined for empty args', () => {
+  it("returns undefined for empty args", () => {
     expect(getPositional([], 0)).toBeUndefined();
   });
 });
 
-describe('requireNumber', () => {
-  it('parses a valid number string', () => {
-    expect(requireNumber('42', 'issue')).toBe(42);
+describe("requireNumber", () => {
+  it("parses a valid number string", () => {
+    expect(requireNumber("42", "issue")).toBe(42);
   });
 
-  it('parses zero', () => {
-    expect(requireNumber('0', 'issue')).toBe(0);
+  it("parses zero", () => {
+    expect(requireNumber("0", "issue")).toBe(0);
   });
 
-  it('throws AxiError for undefined input', () => {
-    expect(() => requireNumber(undefined, 'issue')).toThrow(AxiError);
-    expect(() => requireNumber(undefined, 'issue')).toThrow('Missing issue number');
+  it("throws AxiError for undefined input", () => {
+    expect(() => requireNumber(undefined, "issue")).toThrow(AxiError);
+    expect(() => requireNumber(undefined, "issue")).toThrow(
+      "Missing issue number",
+    );
   });
 
-  it('throws AxiError for empty string', () => {
-    expect(() => requireNumber('', 'pr')).toThrow(AxiError);
-    expect(() => requireNumber('', 'pr')).toThrow('Missing pr number');
+  it("throws AxiError for empty string", () => {
+    expect(() => requireNumber("", "pr")).toThrow(AxiError);
+    expect(() => requireNumber("", "pr")).toThrow("Missing pr number");
   });
 
-  it('throws AxiError for non-numeric string', () => {
-    expect(() => requireNumber('abc', 'issue')).toThrow(AxiError);
-    expect(() => requireNumber('abc', 'issue')).toThrow('Invalid issue number: abc');
+  it("throws AxiError for non-numeric string", () => {
+    expect(() => requireNumber("abc", "issue")).toThrow(AxiError);
+    expect(() => requireNumber("abc", "issue")).toThrow(
+      "Invalid issue number: abc",
+    );
   });
 
-  it('thrown error has VALIDATION_ERROR code', () => {
+  it("thrown error has VALIDATION_ERROR code", () => {
     try {
-      requireNumber('abc', 'issue');
+      requireNumber("abc", "issue");
     } catch (e) {
       expect(e).toBeInstanceOf(AxiError);
-      expect((e as AxiError).code).toBe('VALIDATION_ERROR');
+      expect((e as AxiError).code).toBe("VALIDATION_ERROR");
     }
   });
 });

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -15,6 +15,10 @@ describe('getFlag', () => {
     expect(getFlag(['--repo', 'cli/cli', '--state', 'open'], '--repo')).toBe('cli/cli');
   });
 
+  it('returns the value from --flag=value form', () => {
+    expect(getFlag(['--repo=cli/cli', '--state', 'open'], '--repo')).toBe('cli/cli');
+  });
+
   it('returns undefined when flag is missing', () => {
     expect(getFlag(['--state', 'open'], '--repo')).toBeUndefined();
   });
@@ -33,6 +37,13 @@ describe('getFlag', () => {
 describe('takeFlag', () => {
   it('returns value and removes flag+value from args', () => {
     const args = ['--repo', 'cli/cli', '--state', 'open'];
+    const val = takeFlag(args, '--repo');
+    expect(val).toBe('cli/cli');
+    expect(args).toEqual(['--state', 'open']);
+  });
+
+  it('returns value and removes --flag=value from args', () => {
+    const args = ['--repo=cli/cli', '--state', 'open'];
     const val = takeFlag(args, '--repo');
     expect(val).toBe('cli/cli');
     expect(args).toEqual(['--state', 'open']);
@@ -84,6 +95,11 @@ describe('takeBoolFlag', () => {
 describe('getAllFlags', () => {
   it('collects all values for a repeatable flag', () => {
     const args = ['--label', 'bug', '--state', 'open', '--label', 'help wanted'];
+    expect(getAllFlags(args, '--label')).toEqual(['bug', 'help wanted']);
+  });
+
+  it('collects repeatable values from --flag=value form', () => {
+    const args = ['--label=bug', '--state', 'open', '--label=help wanted'];
     expect(getAllFlags(args, '--label')).toEqual(['bug', 'help wanted']);
   });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -68,6 +68,7 @@ vi.mock("../src/context.js", () => ({
 import { main, TOP_HELP } from "../src/cli.js";
 import { homeCommand } from "../src/commands/home.js";
 import { issueCommand } from "../src/commands/issue.js";
+import { releaseCommand } from "../src/commands/release.js";
 import { resolveRepo } from "../src/context.js";
 
 const packageVersion = JSON.parse(
@@ -82,6 +83,7 @@ describe("main CLI", () => {
     process.argv = [...originalArgv];
     vi.mocked(homeCommand).mockResolvedValue("home output");
     vi.mocked(issueCommand).mockResolvedValue("issue output");
+    vi.mocked(releaseCommand).mockResolvedValue("release output");
     vi.mocked(resolveRepo).mockReturnValue({
       owner: "octo",
       name: "repo",
@@ -212,6 +214,19 @@ describe("main CLI", () => {
     expect(context).toEqual(expect.objectContaining({ nwo: "octo/repo" }));
   });
 
+  it("accepts --repo=value as a repo-context alias after the command", async () => {
+    await main();
+
+    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+    const context = options.resolveContext({
+      command: "release",
+      args: ["create", "v1.0.0", "--repo=owner/name"],
+    });
+
+    expect(vi.mocked(resolveRepo)).toHaveBeenCalledWith("owner/name");
+    expect(context).toEqual(expect.objectContaining({ nwo: "octo/repo" }));
+  });
+
   it("routes the home handler through resolved repo context", async () => {
     await main();
 
@@ -258,6 +273,28 @@ describe("main CLI", () => {
     await options.commands.issue(["list", "--repo", "owner/name"], ctx);
 
     expect(vi.mocked(issueCommand)).toHaveBeenCalledWith(["list"], ctx);
+  });
+
+  it("strips --repo=value before invoking release handlers when used as repo context", async () => {
+    await main();
+
+    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+    const ctx = {
+      owner: "octo",
+      name: "repo",
+      nwo: "octo/repo",
+      source: "flag",
+    };
+
+    await options.commands.release(
+      ["create", "v1.0.0", "--repo=owner/name", "--target", "main"],
+      ctx,
+    );
+
+    expect(vi.mocked(releaseCommand)).toHaveBeenCalledWith(
+      ["create", "v1.0.0", "--target", "main"],
+      ctx,
+    );
   });
 
   it("uses -R as repo context for issue transfer and preserves --to-repo", async () => {

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -473,18 +473,24 @@ describe("prCommand", () => {
       ["--squash", "--squash", "squash"],
       ["--merge", "--merge", "merge"],
       ["--rebase", "--rebase", "rebase"],
-    ])("maps %s shorthand to a gh merge method flag", async (input, ghFlag, method) => {
-      mockedGhJson.mockResolvedValue({ state: "OPEN" });
-      mockedGhExec.mockResolvedValue("");
+    ])(
+      "maps %s shorthand to a gh merge method flag",
+      async (input, ghFlag, method) => {
+        mockedGhJson.mockResolvedValue({ state: "OPEN" });
+        mockedGhExec.mockResolvedValue("");
 
-      const result = await prCommand(["merge", "10", input, "--delete-branch"], ctx);
+        const result = await prCommand(
+          ["merge", "10", input, "--delete-branch"],
+          ctx,
+        );
 
-      expect(mockedGhExec).toHaveBeenCalledWith(
-        ["pr", "merge", "10", ghFlag, "--delete-branch"],
-        ctx,
-      );
-      expect(result).toContain(`method: ${method}`);
-    });
+        expect(mockedGhExec).toHaveBeenCalledWith(
+          ["pr", "merge", "10", ghFlag, "--delete-branch"],
+          ctx,
+        );
+        expect(result).toContain(`method: ${method}`);
+      },
+    );
 
     it("keeps --method working", async () => {
       mockedGhJson.mockResolvedValue({ state: "OPEN" });

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -468,6 +468,35 @@ describe("prCommand", () => {
       expect(result).toContain("alice");
       expect(mockedGhExec).not.toHaveBeenCalled();
     });
+
+    it.each([
+      ["--squash", "--squash", "squash"],
+      ["--merge", "--merge", "merge"],
+      ["--rebase", "--rebase", "rebase"],
+    ])("maps %s shorthand to a gh merge method flag", async (input, ghFlag, method) => {
+      mockedGhJson.mockResolvedValue({ state: "OPEN" });
+      mockedGhExec.mockResolvedValue("");
+
+      const result = await prCommand(["merge", "10", input, "--delete-branch"], ctx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["pr", "merge", "10", ghFlag, "--delete-branch"],
+        ctx,
+      );
+      expect(result).toContain(`method: ${method}`);
+    });
+
+    it("keeps --method working", async () => {
+      mockedGhJson.mockResolvedValue({ state: "OPEN" });
+      mockedGhExec.mockResolvedValue("");
+
+      await prCommand(["merge", "10", "--method", "squash"], ctx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["pr", "merge", "10", "--squash"],
+        ctx,
+      );
+    });
   });
 
   describe("checks", () => {

--- a/test/commands/release.test.ts
+++ b/test/commands/release.test.ts
@@ -187,6 +187,17 @@ describe('releaseCommand', () => {
       ], ctx);
     });
 
+    it('forwards latest equals-form values', async () => {
+      await releaseCommand(['create', 'v1.0.0', '--latest=false'], ctx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith([
+        'release',
+        'create',
+        'v1.0.0',
+        '--latest=false',
+      ], ctx);
+    });
+
     it('threads repo context through create', async () => {
       await releaseCommand(['create', 'v1.0.0', '--target', 'main'], ctx);
 

--- a/test/commands/release.test.ts
+++ b/test/commands/release.test.ts
@@ -1,227 +1,267 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from "vitest";
 
-vi.mock('../../src/gh.js', () => ({
+vi.mock("../../src/gh.js", () => ({
   ghJson: vi.fn(),
   ghExec: vi.fn(),
   ghRaw: vi.fn(),
 }));
 
-import { ghJson, ghExec } from '../../src/gh.js';
-import { releaseCommand, RELEASE_HELP } from '../../src/commands/release.js';
-import { AxiError } from '../../src/errors.js';
-import type { RepoContext } from '../../src/context.js';
+import { ghJson, ghExec } from "../../src/gh.js";
+import { releaseCommand, RELEASE_HELP } from "../../src/commands/release.js";
+import { AxiError } from "../../src/errors.js";
+import type { RepoContext } from "../../src/context.js";
 
 const mockedGhJson = vi.mocked(ghJson);
 const mockedGhExec = vi.mocked(ghExec);
 
-const ctx: RepoContext = { owner: 'octo', name: 'repo', nwo: 'octo/repo', source: 'flag' };
+const ctx: RepoContext = {
+  owner: "octo",
+  name: "repo",
+  nwo: "octo/repo",
+  source: "flag",
+};
 
-describe('releaseCommand', () => {
+describe("releaseCommand", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  describe('router', () => {
-    it('returns help when --help is passed', async () => {
-      const result = await releaseCommand(['--help']);
+  describe("router", () => {
+    it("returns help when --help is passed", async () => {
+      const result = await releaseCommand(["--help"]);
       expect(result).toBe(RELEASE_HELP);
     });
 
-    it('returns help when no subcommand is given', async () => {
+    it("returns help when no subcommand is given", async () => {
       const result = await releaseCommand([]);
       expect(result).toBe(RELEASE_HELP);
     });
 
-    it('returns error for unknown subcommand', async () => {
-      const result = await releaseCommand(['unknown']);
-      expect(result).toContain('Unknown subcommand: unknown');
+    it("returns error for unknown subcommand", async () => {
+      const result = await releaseCommand(["unknown"]);
+      expect(result).toContain("Unknown subcommand: unknown");
     });
   });
 
-  describe('list', () => {
-    it('returns release list', async () => {
+  describe("list", () => {
+    it("returns release list", async () => {
       mockedGhJson.mockResolvedValue([
-        { tagName: 'v1.0.0', name: 'Release 1.0', isDraft: false, isPrerelease: false, publishedAt: '2024-01-01T00:00:00Z' },
-        { tagName: 'v0.9.0', name: 'Beta', isDraft: false, isPrerelease: true, publishedAt: '2023-12-01T00:00:00Z' },
+        {
+          tagName: "v1.0.0",
+          name: "Release 1.0",
+          isDraft: false,
+          isPrerelease: false,
+          publishedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          tagName: "v0.9.0",
+          name: "Beta",
+          isDraft: false,
+          isPrerelease: true,
+          publishedAt: "2023-12-01T00:00:00Z",
+        },
       ]);
 
-      const result = await releaseCommand(['list'], ctx);
+      const result = await releaseCommand(["list"], ctx);
 
-      expect(result).toContain('count: 2');
-      expect(result).toContain('v1.0.0');
-      expect(result).toContain('v0.9.0');
+      expect(result).toContain("count: 2");
+      expect(result).toContain("v1.0.0");
+      expect(result).toContain("v0.9.0");
     });
   });
 
-  describe('view', () => {
-    it('requires tag', async () => {
-      await expect(
-        releaseCommand(['view'], ctx),
-      ).rejects.toThrow(AxiError);
+  describe("view", () => {
+    it("requires tag", async () => {
+      await expect(releaseCommand(["view"], ctx)).rejects.toThrow(AxiError);
     });
 
-    it('returns release detail when tag is provided', async () => {
+    it("returns release detail when tag is provided", async () => {
       mockedGhJson.mockResolvedValue({
-        tagName: 'v1.0.0',
-        name: 'Release 1.0',
-        publishedAt: '2024-01-01T00:00:00Z',
-        author: { login: 'alice' },
-        body: 'Release notes here',
+        tagName: "v1.0.0",
+        name: "Release 1.0",
+        publishedAt: "2024-01-01T00:00:00Z",
+        author: { login: "alice" },
+        body: "Release notes here",
       });
 
-      const result = await releaseCommand(['view', 'v1.0.0'], ctx);
+      const result = await releaseCommand(["view", "v1.0.0"], ctx);
 
-      expect(result).toContain('v1.0.0');
-      expect(result).toContain('Release 1.0');
-      expect(result).toContain('alice');
+      expect(result).toContain("v1.0.0");
+      expect(result).toContain("Release 1.0");
+      expect(result).toContain("alice");
     });
 
-    it('omits help suggestions from detail view', async () => {
+    it("omits help suggestions from detail view", async () => {
       mockedGhJson.mockResolvedValue({
-        tagName: 'v1.0.0', name: 'Release 1.0', publishedAt: '2024-01-01T00:00:00Z',
-        author: { login: 'alice' }, body: 'notes',
+        tagName: "v1.0.0",
+        name: "Release 1.0",
+        publishedAt: "2024-01-01T00:00:00Z",
+        author: { login: "alice" },
+        body: "notes",
       });
-      const result = await releaseCommand(['view', 'v1.0.0'], ctx);
+      const result = await releaseCommand(["view", "v1.0.0"], ctx);
       expect(result).not.toMatch(/^help\[/m);
     });
   });
 
-  describe('create', () => {
+  describe("create", () => {
     beforeEach(() => {
-      mockedGhExec.mockResolvedValue('');
+      mockedGhExec.mockResolvedValue("");
     });
 
-    it('does not treat space-form valued flag values as asset files', async () => {
-      await releaseCommand([
-        'create',
-        'v1.0.0',
-        '--target',
-        'main',
-        '--title',
-        'HomeMux 0.1.0 (TestFlight)',
-        '--notes',
-        'hello notes',
-      ], ctx);
+    it("does not treat space-form valued flag values as asset files", async () => {
+      await releaseCommand(
+        [
+          "create",
+          "v1.0.0",
+          "--target",
+          "main",
+          "--title",
+          "HomeMux 0.1.0 (TestFlight)",
+          "--notes",
+          "hello notes",
+        ],
+        ctx,
+      );
 
-      expect(mockedGhExec).toHaveBeenCalledWith([
-        'release',
-        'create',
-        'v1.0.0',
-        '--title',
-        'HomeMux 0.1.0 (TestFlight)',
-        '--notes',
-        'hello notes',
-        '--target',
-        'main',
-      ], ctx);
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        [
+          "release",
+          "create",
+          "v1.0.0",
+          "--title",
+          "HomeMux 0.1.0 (TestFlight)",
+          "--notes",
+          "hello notes",
+          "--target",
+          "main",
+        ],
+        ctx,
+      );
     });
 
-    it('accepts equals-form valued flags', async () => {
-      await releaseCommand([
-        'create',
-        'v1.0.0',
-        '--target=abc123',
-        '--title=HomeMux 0.1.0 (TestFlight)',
-        '--notes=hello notes',
-      ], ctx);
+    it("accepts equals-form valued flags", async () => {
+      await releaseCommand(
+        [
+          "create",
+          "v1.0.0",
+          "--target=abc123",
+          "--title=HomeMux 0.1.0 (TestFlight)",
+          "--notes=hello notes",
+        ],
+        ctx,
+      );
 
-      expect(mockedGhExec).toHaveBeenCalledWith([
-        'release',
-        'create',
-        'v1.0.0',
-        '--title',
-        'HomeMux 0.1.0 (TestFlight)',
-        '--notes',
-        'hello notes',
-        '--target',
-        'abc123',
-      ], ctx);
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        [
+          "release",
+          "create",
+          "v1.0.0",
+          "--title",
+          "HomeMux 0.1.0 (TestFlight)",
+          "--notes",
+          "hello notes",
+          "--target",
+          "abc123",
+        ],
+        ctx,
+      );
     });
 
-    it('keeps trailing asset files positional after valued flags are consumed', async () => {
-      await releaseCommand([
-        'create',
-        'v1.0.0',
-        '--target',
-        'main',
-        '--title',
-        'Release title',
-        'dist/app.zip',
-      ], ctx);
+    it("keeps trailing asset files positional after valued flags are consumed", async () => {
+      await releaseCommand(
+        [
+          "create",
+          "v1.0.0",
+          "--target",
+          "main",
+          "--title",
+          "Release title",
+          "dist/app.zip",
+        ],
+        ctx,
+      );
 
-      expect(mockedGhExec).toHaveBeenCalledWith([
-        'release',
-        'create',
-        'v1.0.0',
-        '--title',
-        'Release title',
-        '--target',
-        'main',
-        'dist/app.zip',
-      ], ctx);
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        [
+          "release",
+          "create",
+          "v1.0.0",
+          "--title",
+          "Release title",
+          "--target",
+          "main",
+          "dist/app.zip",
+        ],
+        ctx,
+      );
     });
 
-    it('consumes all supported valued release-create flags before assets', async () => {
-      await releaseCommand([
-        'create',
-        'v1.0.0',
-        '--notes-file',
-        'notes.md',
-        '--discussion-category=Announcements',
-        '--notes-start-tag',
-        'v0.9.0',
-        'dist/app.zip',
-      ], ctx);
+    it("consumes all supported valued release-create flags before assets", async () => {
+      await releaseCommand(
+        [
+          "create",
+          "v1.0.0",
+          "--notes-file",
+          "notes.md",
+          "--discussion-category=Announcements",
+          "--notes-start-tag",
+          "v0.9.0",
+          "dist/app.zip",
+        ],
+        ctx,
+      );
 
-      expect(mockedGhExec).toHaveBeenCalledWith([
-        'release',
-        'create',
-        'v1.0.0',
-        '--notes-file',
-        'notes.md',
-        '--discussion-category',
-        'Announcements',
-        '--notes-start-tag',
-        'v0.9.0',
-        'dist/app.zip',
-      ], ctx);
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        [
+          "release",
+          "create",
+          "v1.0.0",
+          "--notes-file",
+          "notes.md",
+          "--discussion-category",
+          "Announcements",
+          "--notes-start-tag",
+          "v0.9.0",
+          "dist/app.zip",
+        ],
+        ctx,
+      );
     });
 
-    it('forwards latest equals-form values', async () => {
-      await releaseCommand(['create', 'v1.0.0', '--latest=false'], ctx);
+    it("forwards latest equals-form values", async () => {
+      await releaseCommand(["create", "v1.0.0", "--latest=false"], ctx);
 
-      expect(mockedGhExec).toHaveBeenCalledWith([
-        'release',
-        'create',
-        'v1.0.0',
-        '--latest=false',
-      ], ctx);
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["release", "create", "v1.0.0", "--latest=false"],
+        ctx,
+      );
     });
 
-    it('threads repo context through create', async () => {
-      await releaseCommand(['create', 'v1.0.0', '--target', 'main'], ctx);
+    it("threads repo context through create", async () => {
+      await releaseCommand(["create", "v1.0.0", "--target", "main"], ctx);
 
       expect(mockedGhExec).toHaveBeenCalledWith(expect.any(Array), ctx);
     });
   });
 
-  describe('repo context threading', () => {
+  describe("repo context threading", () => {
     beforeEach(() => {
       mockedGhJson.mockImplementation(async (args) => {
-        if (args[0] === 'release' && args[1] === 'list') return [];
-        return { tagName: 'v1.0.0' };
+        if (args[0] === "release" && args[1] === "list") return [];
+        return { tagName: "v1.0.0" };
       });
-      mockedGhExec.mockResolvedValue('');
+      mockedGhExec.mockResolvedValue("");
     });
 
     it.each([
-      ['list', ['list']],
-      ['view', ['view', 'v1.0.0']],
-      ['edit', ['edit', 'v1.0.0', '--title', 'New title']],
-      ['delete', ['delete', 'v1.0.0']],
-      ['download', ['download', 'v1.0.0', '--pattern', '*.zip']],
-      ['upload', ['upload', 'v1.0.0', 'dist/app.zip']],
-    ])('passes ctx to gh for release %s', async (_name, args) => {
+      ["list", ["list"]],
+      ["view", ["view", "v1.0.0"]],
+      ["edit", ["edit", "v1.0.0", "--title", "New title"]],
+      ["delete", ["delete", "v1.0.0"]],
+      ["download", ["download", "v1.0.0", "--pattern", "*.zip"]],
+      ["upload", ["upload", "v1.0.0", "dist/app.zip"]],
+    ])("passes ctx to gh for release %s", async (_name, args) => {
       await releaseCommand(args, ctx);
 
       for (const call of mockedGhJson.mock.calls) {

--- a/test/commands/release.test.ts
+++ b/test/commands/release.test.ts
@@ -6,12 +6,13 @@ vi.mock('../../src/gh.js', () => ({
   ghRaw: vi.fn(),
 }));
 
-import { ghJson } from '../../src/gh.js';
+import { ghJson, ghExec } from '../../src/gh.js';
 import { releaseCommand, RELEASE_HELP } from '../../src/commands/release.js';
 import { AxiError } from '../../src/errors.js';
 import type { RepoContext } from '../../src/context.js';
 
 const mockedGhJson = vi.mocked(ghJson);
+const mockedGhExec = vi.mocked(ghExec);
 
 const ctx: RepoContext = { owner: 'octo', name: 'repo', nwo: 'octo/repo', source: 'flag' };
 
@@ -82,6 +83,142 @@ describe('releaseCommand', () => {
       });
       const result = await releaseCommand(['view', 'v1.0.0'], ctx);
       expect(result).not.toMatch(/^help\[/m);
+    });
+  });
+
+  describe('create', () => {
+    beforeEach(() => {
+      mockedGhExec.mockResolvedValue('');
+    });
+
+    it('does not treat space-form valued flag values as asset files', async () => {
+      await releaseCommand([
+        'create',
+        'v1.0.0',
+        '--target',
+        'main',
+        '--title',
+        'HomeMux 0.1.0 (TestFlight)',
+        '--notes',
+        'hello notes',
+      ], ctx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith([
+        'release',
+        'create',
+        'v1.0.0',
+        '--title',
+        'HomeMux 0.1.0 (TestFlight)',
+        '--notes',
+        'hello notes',
+        '--target',
+        'main',
+      ], ctx);
+    });
+
+    it('accepts equals-form valued flags', async () => {
+      await releaseCommand([
+        'create',
+        'v1.0.0',
+        '--target=abc123',
+        '--title=HomeMux 0.1.0 (TestFlight)',
+        '--notes=hello notes',
+      ], ctx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith([
+        'release',
+        'create',
+        'v1.0.0',
+        '--title',
+        'HomeMux 0.1.0 (TestFlight)',
+        '--notes',
+        'hello notes',
+        '--target',
+        'abc123',
+      ], ctx);
+    });
+
+    it('keeps trailing asset files positional after valued flags are consumed', async () => {
+      await releaseCommand([
+        'create',
+        'v1.0.0',
+        '--target',
+        'main',
+        '--title',
+        'Release title',
+        'dist/app.zip',
+      ], ctx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith([
+        'release',
+        'create',
+        'v1.0.0',
+        '--title',
+        'Release title',
+        '--target',
+        'main',
+        'dist/app.zip',
+      ], ctx);
+    });
+
+    it('consumes all supported valued release-create flags before assets', async () => {
+      await releaseCommand([
+        'create',
+        'v1.0.0',
+        '--notes-file',
+        'notes.md',
+        '--discussion-category=Announcements',
+        '--notes-start-tag',
+        'v0.9.0',
+        'dist/app.zip',
+      ], ctx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith([
+        'release',
+        'create',
+        'v1.0.0',
+        '--notes-file',
+        'notes.md',
+        '--discussion-category',
+        'Announcements',
+        '--notes-start-tag',
+        'v0.9.0',
+        'dist/app.zip',
+      ], ctx);
+    });
+
+    it('threads repo context through create', async () => {
+      await releaseCommand(['create', 'v1.0.0', '--target', 'main'], ctx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith(expect.any(Array), ctx);
+    });
+  });
+
+  describe('repo context threading', () => {
+    beforeEach(() => {
+      mockedGhJson.mockImplementation(async (args) => {
+        if (args[0] === 'release' && args[1] === 'list') return [];
+        return { tagName: 'v1.0.0' };
+      });
+      mockedGhExec.mockResolvedValue('');
+    });
+
+    it.each([
+      ['list', ['list']],
+      ['view', ['view', 'v1.0.0']],
+      ['edit', ['edit', 'v1.0.0', '--title', 'New title']],
+      ['delete', ['delete', 'v1.0.0']],
+      ['download', ['download', 'v1.0.0', '--pattern', '*.zip']],
+      ['upload', ['upload', 'v1.0.0', 'dist/app.zip']],
+    ])('passes ctx to gh for release %s', async (_name, args) => {
+      await releaseCommand(args, ctx);
+
+      for (const call of mockedGhJson.mock.calls) {
+        expect(call[1]).toBe(ctx);
+      }
+      for (const call of mockedGhExec.mock.calls) {
+        expect(call[1]).toBe(ctx);
+      }
     });
   });
 });

--- a/test/commands/search.test.ts
+++ b/test/commands/search.test.ts
@@ -75,6 +75,32 @@ describe("searchCommand", () => {
       expect(result).toContain("Bug");
       expect(result).toContain("Feature");
     });
+
+    it("keeps query after equals-form filters", async () => {
+      mockedGhJson.mockResolvedValue([]);
+
+      await searchCommand(["issues", "--repo=owner/repo", "bug"]);
+
+      expect(mockedGhJson).toHaveBeenCalledWith([
+        "search",
+        "issues",
+        "bug",
+        "--json",
+        "number,title,repository,state,author,labels,createdAt",
+        "--limit",
+        "1000",
+        "--repo",
+        "owner/repo",
+      ]);
+    });
+
+    it("keeps query after boolean filters", async () => {
+      mockedGhJson.mockResolvedValue([]);
+
+      await searchCommand(["prs", "--draft", "bug"]);
+
+      expect(mockedGhJson).toHaveBeenCalledWith(expect.arrayContaining(["bug"]));
+    });
   });
 
   describe("searchRepos", () => {

--- a/test/commands/search.test.ts
+++ b/test/commands/search.test.ts
@@ -99,7 +99,9 @@ describe("searchCommand", () => {
 
       await searchCommand(["prs", "--draft", "bug"]);
 
-      expect(mockedGhJson).toHaveBeenCalledWith(expect.arrayContaining(["bug"]));
+      expect(mockedGhJson).toHaveBeenCalledWith(
+        expect.arrayContaining(["bug"]),
+      );
     });
   });
 

--- a/test/gh.test.ts
+++ b/test/gh.test.ts
@@ -152,6 +152,25 @@ describe("ghExec", () => {
       expect((e as AxiError).code).toBe("GH_NOT_INSTALLED");
     }
   });
+
+  it("appends --repo for non-git sources", async () => {
+    mockExecFileResult(null, "output", "");
+    const ctx: RepoContext = {
+      owner: "cli",
+      name: "cli",
+      nwo: "cli/cli",
+      source: "flag",
+    };
+    await ghExec(["release", "create", "v1.0.0"], ctx);
+    const callArgs = mockedExecFile.mock.calls[0][1] as string[];
+    expect(callArgs).toEqual([
+      "release",
+      "create",
+      "v1.0.0",
+      "--repo",
+      "cli/cli",
+    ]);
+  });
 });
 
 describe("ghRaw", () => {


### PR DESCRIPTION
## Intent

Fix real gh-axi argument forwarding bugs hit during live use. Ensure release create honors --repo in both --repo value and --repo=value forms so releases cannot silently target the cwd repo. Ensure release create parses known valued flags such as --target, --title, --notes, --notes-file, --discussion-category, and --notes-start-tag before treating remaining arguments as positional assets, supporting both space and equals forms while preserving trailing asset files. Ensure pr merge shorthand flags --squash, --merge, and --rebase work like the documented examples while keeping --method working. Add regression coverage for the parsed gh argv, repo context threading across release subcommands, valued flag parsing, assets, and merge shorthand mapping, and run the existing test suite.

## What Changed

- Fixed `gh-axi` argument parsing so release commands preserve `--repo`, known valued release flags, `--latest=false`, search query terms after equals-form flags, and trailing release asset files.
- Updated PR merge handling so documented shorthand strategy flags like `--squash`, `--merge`, and `--rebase` map correctly while preserving `--method` support.
- Added regression coverage, E2E evidence, and documentation updates for the corrected argument forwarding behavior.

## Risk Assessment

✅ Low: The changes are narrowly scoped to argument parsing and forwarding, include targeted regression coverage, and I did not identify material correctness or behavioral regressions in the reviewed diff.

## Testing

Exercised the real gh-axi entrypoint against a fake gh binary to prove release create preserves --repo in space and equals forms, consumes valued release flags before assets, preserves trailing assets, and maps pr merge --squash while threading repo context; then ran the targeted regression tests and full test suite successfully, with only intentional evidence files left in the worktree.

<details>
<summary>Evidence: End-to-end CLI transcript showing user-facing output and forwarded gh argv</summary>

Source: [End-to-end CLI transcript showing user-facing output and forwarded gh argv](https://github.com/kunchenguid/gh-axi/blob/6efa414ffab797a9a7993c3ca0c1e489f0ecab72/.no-mistakes/evidence/fm/gh-axi-argfix-r3/cli-e2e-transcript.txt)

```text
Shows release create with --repo and --repo= forms, valued release flags, asset preservation, and pr merge --squash forwarding to gh with the expected --repo target.
```
</details>
<details>
<summary>Evidence: Captured gh argv JSONL</summary>

Source: [Captured gh argv JSONL](https://github.com/kunchenguid/gh-axi/blob/6efa414ffab797a9a7993c3ca0c1e489f0ecab72/.no-mistakes/evidence/fm/gh-axi-argfix-r3/gh-argv.jsonl)

```text
Recorded argv includes release create arguments ending in --repo octo/release-target and --repo octo/equals-target, plus pr merge 42 --squash --delete-branch --repo octo/pr-target.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `src/commands/release.ts:148` - `--latest=false` is a documented `gh release create` form, but this treats `--latest` as a pure boolean and drops equals-form values, so an explicit request not to mark a release as latest is silently omitted. Forward `--latest=false` (and any value form) instead of only appending bare `--latest`.
- ⚠️ `src/commands/search.ts:120` - Equals-form search filters are now recognized here, but `extractQuery` still skips the token after any `--flag=value`; `gh-axi search issues --repo=owner/repo bug` therefore drops `bug` from the search query. Update query extraction to skip only the flag token for equals-form flags.

🔧 Fix: Preserve release latest and search query flags
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `.no-mistakes/evidence/fm/gh-axi-argfix-r3/run-e2e.sh`
- `pnpm exec vitest run test/args.test.ts test/cli.test.ts test/gh.test.ts test/commands/release.test.ts test/commands/pr.test.ts`
- `pnpm test`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
