### PR TITLE
feat: add gh-axi push command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ gh-axi pr view 42               # view pull request #42
 gh-axi run list -R owner/repo   # list workflow runs for a specific repo
 gh-axi run view 123456 --job 789012       # inspect a single job within a run
 gh-axi run view --job 789012 --log-failed # show failed log lines for one job
+gh-axi push --dry-run           # preview publishing the current branch
+gh-axi push                     # publish the current branch with upstream tracking
 gh-axi setup hooks              # install optional agent session hooks
 ```
 
@@ -109,6 +111,7 @@ When truncation happens, gh-axi best-effort saves the complete log to a temp fil
 | `search`   | Search issues, PRs, repos, commits, code                            |
 | `api`      | Raw GitHub API access                                               |
 | `setup`    | Install optional agent session hooks                                |
+| `push`     | Git ref transport with compact output and dry-run support           |
 
 ### Global flags
 

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-axi
-description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, cutting releases, or querying the GitHub API."
+description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, search, git pushes, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, cutting releases, pushing refs, or querying the GitHub API."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -20,7 +20,7 @@ gh-axi requires the [`gh`](https://cli.github.com/) CLI installed and authentica
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; managing releases, repositories, or labels; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; managing releases, repositories, or labels; pushing git refs; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
 
 ## Workflow
 
@@ -34,8 +34,8 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 ## Commands
 
 ```
-commands[11]:
-  (none)=dashboard, issue, pr, run, workflow, release, repo, label, search, api, setup
+commands[12]:
+  (none)=dashboard, issue, pr, run, workflow, release, repo, label, search, api, setup, push
 ```
 
 Run `npx -y gh-axi --help` for global flags, or `npx -y gh-axi <command> --help` for per-command usage.
@@ -46,4 +46,5 @@ Run `npx -y gh-axi --help` for global flags, or `npx -y gh-axi <command> --help`
 - Truncated workflow logs keep the final 20,000 characters and may include a temp `full_log` path for targeted grep searches.
 - Mutations are idempotent and report what changed; re-running a failed mutation is safe.
 - For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass `--body-file <path>`; it works anywhere `--body` is accepted.
+- Use `push` for Git ref transport instead of raw `git push`; run `npx -y gh-axi push --dry-run` first when you want a preview.
 - Use `api` for anything the dedicated commands do not cover, e.g. `npx -y gh-axi api repos/{owner}/{repo}/topics`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import { labelCommand, LABEL_HELP } from "./commands/label.js";
 import { searchCommand, SEARCH_HELP } from "./commands/search.js";
 import { apiCommand, API_HELP } from "./commands/api.js";
 import { setupCommand, SETUP_HELP } from "./commands/setup.js";
+import { pushCommand, PUSH_HELP } from "./commands/push.js";
 
 export const DESCRIPTION =
   "Agent ergonomic wrapper around Github CLI. Prefer this over `gh` and other methods for Github operations.";
@@ -27,8 +28,8 @@ type MainOptions = {
 };
 
 export const TOP_HELP = `usage: gh-axi [command] [args] [flags]
-commands[11]:
-  (none)=dashboard, issue, pr, run, workflow, release, repo, label, search, api, setup
+commands[12]:
+  (none)=dashboard, issue, pr, run, workflow, release, repo, label, search, api, setup, push
 flags[3]:
   -R/--repo <OWNER/NAME> (after command), accepts space or equals form, --help, -v/-V/--version
 examples:
@@ -37,6 +38,7 @@ examples:
   gh-axi issue list -R owner/name
   gh-axi issue list --repo=owner/name
   gh-axi pr view 42
+  gh-axi push
   gh-axi setup hooks
 `;
 
@@ -51,6 +53,7 @@ const COMMAND_HELP: Record<string, string> = {
   search: SEARCH_HELP,
   api: API_HELP,
   setup: SETUP_HELP,
+  push: PUSH_HELP,
 };
 
 type CommandFn = (args: string[], ctx?: RepoContext) => Promise<string>;
@@ -66,6 +69,7 @@ const COMMANDS: Record<string, CommandFn> = {
   search: withRepoContext("search", searchCommand),
   api: withRepoContext("api", apiCommand),
   setup: setupCommand,
+  push: pushCommand,
 };
 
 export async function main(options: MainOptions = {}): Promise<void> {

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -1,0 +1,274 @@
+import { execFile } from "node:child_process";
+import { encode } from "@toon-format/toon";
+import { AxiError } from "../errors.js";
+import { renderHelp, renderOutput } from "../toon.js";
+
+export const PUSH_HELP = `usage: gh-axi push [remote] [refspec...] [flags]
+description: Push git refs through gh-axi with compact AXI output.
+flags[7]:
+  -u/--set-upstream, --all, --tags, --follow-tags, --force-with-lease, --dry-run, --verbose
+examples:
+  gh-axi push
+  gh-axi push origin main:main
+  gh-axi push origin main:main codex/feature:codex/feature --follow-tags`;
+
+const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+const ALLOWED_FLAGS = new Set([
+  "-u",
+  "--set-upstream",
+  "--all",
+  "--tags",
+  "--follow-tags",
+  "--force-with-lease",
+  "--dry-run",
+  "--verbose",
+]);
+
+type GitResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+type PushFlags = {
+  setUpstream: boolean;
+  all: boolean;
+  tags: boolean;
+  followTags: boolean;
+  forceWithLease: boolean;
+  dryRun: boolean;
+  verbose: boolean;
+};
+
+type PushPlan = {
+  flags: PushFlags;
+  remote: string;
+  refspecs: string[];
+  mode: "current-branch" | "explicit" | "all" | "all+tags" | "tags";
+  branch?: string;
+  pushes: string[][];
+};
+
+function runGit(args: string[]): Promise<GitResult> {
+  return new Promise((resolve) => {
+    execFile(
+      "git",
+      args,
+      { maxBuffer: MAX_BUFFER_BYTES },
+      (error, stdout, stderr) => {
+        if (error && "code" in error && error.code === "ENOENT") {
+          resolve({ stdout: "", stderr: "ENOENT", exitCode: 127 });
+          return;
+        }
+        const code = error && "code" in error ? error.code : 0;
+        resolve({
+          stdout: stdout ?? "",
+          stderr: stderr ?? "",
+          exitCode: typeof code === "number" ? code : error ? 1 : 0,
+        });
+      },
+    );
+  });
+}
+
+function firstLine(text: string): string {
+  return text.trim().split(/\r?\n/).find(Boolean) ?? "";
+}
+
+async function currentBranch(): Promise<string> {
+  const result = await runGit(["branch", "--show-current"]);
+  if (result.stderr === "ENOENT") {
+    throw new AxiError("git is not installed", "GIT_NOT_INSTALLED");
+  }
+  if (result.exitCode !== 0) {
+    throw new AxiError(
+      firstLine(result.stderr) || "Could not determine current branch",
+      "GIT_ERROR",
+    );
+  }
+  return result.stdout.trim();
+}
+
+function compactOutput(
+  stdout: string,
+  stderr: string,
+  verbose: boolean,
+): string[] {
+  const combined = `${stdout}\n${stderr}`
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => verbose || !line.startsWith("remote:"));
+  const interesting = combined.filter(
+    (line) =>
+      verbose ||
+      line.startsWith("To ") ||
+      line.startsWith("* ") ||
+      line.startsWith("= ") ||
+      line.startsWith("! ") ||
+      line.startsWith("- ") ||
+      line.startsWith("branch "),
+  );
+  const lines = interesting.length > 0 ? interesting : combined;
+  return lines
+    .slice(-20)
+    .map((line) => (line.length > 240 ? `${line.slice(0, 237)}...` : line));
+}
+
+function parseArgs(args: string[]): {
+  flags: PushFlags;
+  positionals: string[];
+} {
+  const flags: PushFlags = {
+    setUpstream: false,
+    all: false,
+    tags: false,
+    followTags: false,
+    forceWithLease: false,
+    dryRun: false,
+    verbose: false,
+  };
+  const positionals: string[] = [];
+
+  for (const arg of args) {
+    if (arg.startsWith("-")) {
+      if (!ALLOWED_FLAGS.has(arg)) {
+        throw new AxiError(`Unknown push flag: ${arg}`, "VALIDATION_ERROR", [
+          "Run `gh-axi push --help` for supported flags",
+        ]);
+      }
+      if (arg === "-u" || arg === "--set-upstream") flags.setUpstream = true;
+      if (arg === "--all") flags.all = true;
+      if (arg === "--tags") flags.tags = true;
+      if (arg === "--follow-tags") flags.followTags = true;
+      if (arg === "--force-with-lease") flags.forceWithLease = true;
+      if (arg === "--dry-run") flags.dryRun = true;
+      if (arg === "--verbose") flags.verbose = true;
+      continue;
+    }
+
+    positionals.push(arg);
+  }
+
+  return { flags, positionals };
+}
+
+async function buildPushPlan(args: string[]): Promise<PushPlan> {
+  const { flags, positionals } = parseArgs(args);
+  const remote = positionals[0] ?? "origin";
+  const explicitRefspecs = positionals.slice(positionals.length > 0 ? 1 : 0);
+
+  if (flags.all && explicitRefspecs.length > 0) {
+    throw new AxiError(
+      "--all cannot be combined with explicit refspecs",
+      "VALIDATION_ERROR",
+    );
+  }
+  if (flags.tags && explicitRefspecs.length > 0) {
+    throw new AxiError(
+      "--tags cannot be combined with explicit refspecs",
+      "VALIDATION_ERROR",
+    );
+  }
+
+  const common = ["push"];
+  if (flags.dryRun) common.push("--dry-run");
+  if (flags.forceWithLease) common.push("--force-with-lease");
+  if (flags.followTags && !flags.tags) common.push("--follow-tags");
+
+  if (flags.all) {
+    const pushes = [[...common, "--all", remote]];
+    if (flags.tags) pushes.push([...common, "--tags", remote]);
+    return {
+      flags,
+      remote,
+      refspecs: [],
+      mode: flags.tags ? "all+tags" : "all",
+      pushes,
+    };
+  }
+
+  if (flags.tags) {
+    return {
+      flags,
+      remote,
+      refspecs: [],
+      mode: "tags",
+      pushes: [[...common, "--tags", remote]],
+    };
+  }
+
+  const branch =
+    explicitRefspecs.length === 0 ? await currentBranch() : undefined;
+  if (explicitRefspecs.length === 0 && !branch) {
+    throw new AxiError(
+      "No current branch; pass an explicit refspec",
+      "VALIDATION_ERROR",
+      ["Run `gh-axi push origin HEAD:<branch>`"],
+    );
+  }
+
+  const refspecs =
+    explicitRefspecs.length > 0 ? explicitRefspecs : [`HEAD:${branch}`];
+  const push = [...common];
+  if (flags.setUpstream || explicitRefspecs.length === 0)
+    push.push("--set-upstream");
+  push.push(remote, ...refspecs);
+
+  return {
+    flags,
+    remote,
+    refspecs,
+    mode: explicitRefspecs.length === 0 ? "current-branch" : "explicit",
+    ...(branch ? { branch } : {}),
+    pushes: [push],
+  };
+}
+
+export async function pushCommand(args: string[]): Promise<string> {
+  if (args[0] === "--help" || (args.length > 0 && args[0] === "help"))
+    return PUSH_HELP;
+
+  const plan = await buildPushPlan(args);
+  const output: string[] = [];
+
+  for (const gitArgs of plan.pushes) {
+    const result = await runGit(gitArgs);
+    if (result.stderr === "ENOENT") {
+      throw new AxiError("git is not installed", "GIT_NOT_INSTALLED");
+    }
+    output.push(
+      ...compactOutput(result.stdout, result.stderr, plan.flags.verbose),
+    );
+    if (result.exitCode !== 0) {
+      throw new AxiError(
+        firstLine(result.stderr) || `git exited with code ${result.exitCode}`,
+        "GIT_PUSH_FAILED",
+        ["Run `gh-axi push --dry-run` to preview the push"],
+      );
+    }
+  }
+
+  const summary: Record<string, unknown> = {
+    status: plan.flags.dryRun ? "dry-run-ok" : "ok",
+    remote: plan.remote,
+    mode: plan.mode,
+    refs: plan.refspecs.length,
+    refspecs: plan.refspecs,
+  };
+  if (plan.branch) summary.branch = plan.branch;
+  if (plan.flags.forceWithLease) summary.force = "with-lease";
+  if (plan.flags.followTags) summary.tags = "follow";
+
+  const help = plan.flags.dryRun
+    ? ["Run the same `gh-axi push` command without --dry-run to publish refs"]
+    : [
+        "Run `gh-axi repo view` to verify the default branch and repository summary",
+      ];
+
+  return renderOutput([
+    encode({ push: summary }),
+    output.length > 0 ? encode({ git: output }) : "",
+    renderHelp(help),
+  ]);
+}

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -4,9 +4,9 @@ import { DESCRIPTION, TOP_HELP } from "./cli.js";
 // Kept terse and outcome-focused so it fires on "needs GitHub" intents.
 export const SKILL_DESCRIPTION =
   "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, " +
-  "releases, repositories, labels, search, and raw API access. Use whenever a task touches " +
+  "releases, repositories, labels, search, git pushes, and raw API access. Use whenever a task touches " +
   "GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, cutting " +
-  "releases, or querying the GitHub API.";
+  "releases, pushing refs, or querying the GitHub API.";
 
 export const SKILL_AUTHOR = "Kun Chen (kunchenguid)";
 
@@ -63,7 +63,7 @@ gh-axi requires the [\`gh\`](https://cli.github.com/) CLI installed and authenti
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; managing releases, repositories, or labels; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; managing releases, repositories, or labels; pushing git refs; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
 
 ## Workflow
 
@@ -88,6 +88,7 @@ Run \`npx -y gh-axi --help\` for global flags, or \`npx -y gh-axi <command> --he
 - Truncated workflow logs keep the final 20,000 characters and may include a temp \`full_log\` path for targeted grep searches.
 - Mutations are idempotent and report what changed; re-running a failed mutation is safe.
 - For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass \`--body-file <path>\`; it works anywhere \`--body\` is accepted.
+- Use \`push\` for Git ref transport instead of raw \`git push\`; run \`npx -y gh-axi push --dry-run\` first when you want a preview.
 - Use \`api\` for anything the dedicated commands do not cover, e.g. \`npx -y gh-axi api repos/{owner}/{repo}/topics\`.
 `;
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -55,6 +55,10 @@ vi.mock("../src/commands/api.js", () => ({
   apiCommand: vi.fn().mockResolvedValue("api output"),
   API_HELP: "api help",
 }));
+vi.mock("../src/commands/push.js", () => ({
+  pushCommand: vi.fn().mockResolvedValue("push output"),
+  PUSH_HELP: "push help",
+}));
 
 vi.mock("../src/context.js", () => ({
   resolveRepo: vi.fn().mockReturnValue({
@@ -69,6 +73,7 @@ import { main, TOP_HELP } from "../src/cli.js";
 import { homeCommand } from "../src/commands/home.js";
 import { issueCommand } from "../src/commands/issue.js";
 import { releaseCommand } from "../src/commands/release.js";
+import { pushCommand } from "../src/commands/push.js";
 import { resolveRepo } from "../src/context.js";
 
 const packageVersion = JSON.parse(
@@ -84,6 +89,7 @@ describe("main CLI", () => {
     vi.mocked(homeCommand).mockResolvedValue("home output");
     vi.mocked(issueCommand).mockResolvedValue("issue output");
     vi.mocked(releaseCommand).mockResolvedValue("release output");
+    vi.mocked(pushCommand).mockResolvedValue("push output");
     vi.mocked(resolveRepo).mockReturnValue({
       owner: "octo",
       name: "repo",
@@ -106,6 +112,8 @@ describe("main CLI", () => {
 
   it("documents explicit hook setup in help output", () => {
     expect(TOP_HELP).toContain("setup");
+    expect(TOP_HELP).toContain("push");
+    expect(TOP_HELP).toContain("gh-axi push");
     expect(TOP_HELP).toContain("gh-axi setup hooks");
   });
 
@@ -321,6 +329,28 @@ describe("main CLI", () => {
     );
     expect(vi.mocked(issueCommand)).toHaveBeenCalledWith(
       ["transfer", "123", "--to-repo", "dest/repo"],
+      ctx,
+    );
+  });
+
+  it("runs push without repo-context rewriting", async () => {
+    await main();
+
+    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+    const ctx = {
+      owner: "octo",
+      name: "repo",
+      nwo: "octo/repo",
+      source: "flag",
+    };
+
+    await options.commands.push(
+      ["origin", "main:main", "-R", "other/repo"],
+      ctx,
+    );
+
+    expect(vi.mocked(pushCommand)).toHaveBeenCalledWith(
+      ["origin", "main:main", "-R", "other/repo"],
       ctx,
     );
   });

--- a/test/commands/push.test.ts
+++ b/test/commands/push.test.ts
@@ -1,0 +1,149 @@
+import { execFile } from "node:child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AxiError } from "../../src/errors.js";
+import { pushCommand, PUSH_HELP } from "../../src/commands/push.js";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+const mockedExecFile = vi.mocked(execFile);
+
+type ExecFileCallback = (
+  error: (Error & { code?: string | number }) | null,
+  stdout: string,
+  stderr: string,
+) => void;
+
+function mockGitResults(
+  results: Array<{
+    error?: (Error & { code?: string | number }) | null;
+    stdout?: string;
+    stderr?: string;
+  }>,
+) {
+  mockedExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+    const result = results.shift() ?? {};
+    (callback as ExecFileCallback)(
+      result.error ?? null,
+      result.stdout ?? "",
+      result.stderr ?? "",
+    );
+    return {} as ReturnType<typeof execFile>;
+  });
+}
+
+describe("pushCommand", () => {
+  beforeEach(() => {
+    mockedExecFile.mockReset();
+  });
+
+  it("returns command help", async () => {
+    await expect(pushCommand(["--help"])).resolves.toBe(PUSH_HELP);
+  });
+
+  it("pushes the current branch by default", async () => {
+    mockGitResults([
+      { stdout: "feature/push\n" },
+      {
+        stderr:
+          "To https://github.com/octo/repo.git\n" +
+          " * [new branch]      HEAD -> feature/push\n" +
+          "branch 'feature/push' set up to track 'origin/feature/push'.\n",
+      },
+    ]);
+
+    const output = await pushCommand([]);
+
+    expect(mockedExecFile).toHaveBeenNthCalledWith(
+      1,
+      "git",
+      ["branch", "--show-current"],
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(mockedExecFile).toHaveBeenNthCalledWith(
+      2,
+      "git",
+      ["push", "--set-upstream", "origin", "HEAD:feature/push"],
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(output).toContain("status: ok");
+    expect(output).toContain("mode: current-branch");
+    expect(output).toContain("branch: feature/push");
+    expect(output).toContain("[new branch]");
+  });
+
+  it("pushes explicit refspecs with dry-run and follow-tags", async () => {
+    mockGitResults([
+      {
+        stderr:
+          "To https://github.com/octo/repo.git\n" +
+          " * [new branch]      main -> main\n",
+      },
+    ]);
+
+    const output = await pushCommand([
+      "origin",
+      "main:main",
+      "--dry-run",
+      "--follow-tags",
+    ]);
+
+    expect(mockedExecFile).toHaveBeenCalledWith(
+      "git",
+      ["push", "--dry-run", "--follow-tags", "origin", "main:main"],
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(output).toContain("status: dry-run-ok");
+    expect(output).toContain("mode: explicit");
+    expect(output).toContain("tags: follow");
+  });
+
+  it("splits all-branches plus tags into two git pushes", async () => {
+    mockGitResults([
+      {
+        stderr:
+          "To https://github.com/octo/repo.git\n = [up to date]      main -> main\n",
+      },
+      {
+        stderr:
+          "To https://github.com/octo/repo.git\n * [new tag]         v1.0.0 -> v1.0.0\n",
+      },
+    ]);
+
+    const output = await pushCommand(["upstream", "--all", "--tags"]);
+
+    expect(mockedExecFile).toHaveBeenNthCalledWith(
+      1,
+      "git",
+      ["push", "--all", "upstream"],
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(mockedExecFile).toHaveBeenNthCalledWith(
+      2,
+      "git",
+      ["push", "--tags", "upstream"],
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(output).toContain("mode: all+tags");
+  });
+
+  it("maps git push failures to structured errors", async () => {
+    const error = new Error("exit 1") as Error & { code: number };
+    error.code = 1;
+    mockGitResults([{ error, stderr: "fatal: unable to access repository\n" }]);
+
+    try {
+      await pushCommand(["origin", "main:main"]);
+      throw new Error("Expected pushCommand to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(AxiError);
+      expect((e as AxiError).code).toBe("GIT_PUSH_FAILED");
+    }
+  });
+});

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -561,14 +561,17 @@ describe("runCommand", () => {
 
       const fullLogPath = result.match(/^\s*full_log: "?([^"\n]+)"?$/m)?.[1];
       expect(fullLogPath).toBeDefined();
-      expect(fullLogPath).toContain(join(tmpdir(), "gh-axi-logs-"));
-      expect(fullLogPath).toContain("100-job-555-log-failed.log");
-      expect(result).toContain(`full_log: ${fullLogPath}`);
+      const normalizedFullLogPath = fullLogPath.replace(/\\\\/g, "\\");
+      expect(normalizedFullLogPath).toContain(join(tmpdir(), "gh-axi-logs-"));
+      expect(normalizedFullLogPath).toContain("100-job-555-log-failed.log");
+      expect(result).toContain("full_log:");
       expect(result).toContain("help[1]:");
       expect(result).toContain("Output shows the last 20000 of");
       await expect(readFile(fullLogPath!, "utf8")).resolves.toBe(output);
-      expect((await stat(dirname(fullLogPath!))).mode & 0o777).toBe(0o700);
-      expect((await stat(fullLogPath!)).mode & 0o777).toBe(0o600);
+      if (process.platform !== "win32") {
+        expect((await stat(dirname(fullLogPath!))).mode & 0o777).toBe(0o700);
+        expect((await stat(fullLogPath!)).mode & 0o777).toBe(0o600);
+      }
     });
 
     it("does not save a log file when output fits within the limit", async () => {

--- a/test/help-examples.test.ts
+++ b/test/help-examples.test.ts
@@ -8,6 +8,7 @@ import { REPO_HELP } from "../src/commands/repo.js";
 import { LABEL_HELP } from "../src/commands/label.js";
 import { SEARCH_HELP } from "../src/commands/search.js";
 import { API_HELP } from "../src/commands/api.js";
+import { PUSH_HELP } from "../src/commands/push.js";
 import { TOP_HELP } from "../src/cli.js";
 
 /**
@@ -51,6 +52,7 @@ describe("Help output includes examples for every command family", () => {
   assertHelpHasExamples("LABEL_HELP", LABEL_HELP);
   assertHelpHasExamples("SEARCH_HELP", SEARCH_HELP);
   assertHelpHasExamples("API_HELP", API_HELP);
+  assertHelpHasExamples("PUSH_HELP", PUSH_HELP);
 });
 
 describe("--body-file discoverability", () => {


### PR DESCRIPTION
﻿## Summary
- Add `gh-axi push` for Git ref transport with compact TOON output.
- Support current-branch default push, explicit refspecs, `--dry-run`, `--follow-tags`, `--force-with-lease`, and `--all --tags` split pushes.
- Regenerate the gh-axi skill/docs and make existing run-log tests pass on Windows path/permission semantics.

## Verification
- `corepack pnpm run build`
- `corepack pnpm test` (449 passed)
