### PR TITLE
fix(run): cross-reference workflow dispatch command

### DIFF
--- a/.no-mistakes/evidence/fm/ghaxi-run-help-xref-h3/run-help.txt
+++ b/.no-mistakes/evidence/fm/ghaxi-run-help-xref-h3/run-help.txt
@@ -1,0 +1,18 @@
+usage: gh-axi run <subcommand> [flags]
+subcommands[7]:
+  list, view <id>, watch <id>, rerun <id>, cancel <id>, delete <id>, download <id>
+note:
+  manages existing runs; to trigger (dispatch) a workflow, use `gh-axi workflow run <name> --ref <ref>`
+flags{list}:
+  --workflow, --branch, --status, --event, --user, --commit, --limit (default 10), --fields <a,b,c>
+flags{view}:
+  --job <job-id>, --log, --log-failed, --conclusion <success|failure|cancelled|skipped> (filter jobs by conclusion)
+  long --log/--log-failed output keeps the tail and may include full_log for grep searches
+flags{rerun}:
+  --failed, --debug, --job
+flags{download}:
+  --name, --dir
+examples:
+  gh-axi run list --workflow ci.yml --status failure
+  gh-axi run view 123456 --log-failed
+  gh-axi run rerun 123456 --failed

--- a/.no-mistakes/evidence/fm/ghaxi-run-help-xref-h3/workflow-help.txt
+++ b/.no-mistakes/evidence/fm/ghaxi-run-help-xref-h3/workflow-help.txt
@@ -1,0 +1,11 @@
+usage: gh-axi workflow <subcommand> [flags]
+subcommands[5]:
+  list, view <id|name>, run <id|name>, enable <id|name>, disable <id|name>
+flags{list}:
+  --limit <n> (default 20), --all
+flags{run}:
+  --ref <git-ref>, --field <key=val> (repeatable)
+examples:
+  gh-axi workflow list
+  gh-axi workflow run ci.yml --ref main
+  gh-axi workflow disable 12345

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ gh-axi pr view 42               # view pull request #42
 gh-axi run list -R owner/repo   # list workflow runs for a specific repo
 gh-axi run view 123456 --job 789012       # inspect a single job within a run
 gh-axi run view --job 789012 --log-failed # show failed log lines for one job
+gh-axi workflow run ci.yml --ref main     # trigger a workflow
 gh-axi setup hooks              # install optional agent session hooks
 gh-axi update --check           # check whether a newer release exists
 gh-axi update                   # upgrade a global install
@@ -97,22 +98,23 @@ For releases, `--body` and `--body-file` are aliases for release notes, alongsid
 
 Long `run view --log` and `run view --log-failed` output shows the last 20,000 characters so CI failures stay visible.
 When truncation happens, gh-axi best-effort saves the complete log to a temp file, includes it as `full_log`, and prints a `help:` hint telling agents to grep that file for earlier context.
+`gh-axi run` manages existing workflow runs; use `gh-axi workflow run <name> --ref <ref>` to trigger (dispatch) a workflow.
 
 ### Commands
 
-| Command    | Description                                                         |
-| ---------- | ------------------------------------------------------------------- |
-| `issue`    | Issues — list, view, create, edit, close, reopen, comment, subissue |
-| `pr`       | Pull requests — list, view, create, merge, review, checks           |
-| `run`      | Workflow runs — list, view, rerun, cancel, watch                    |
-| `workflow` | Workflows — list, view, run, enable, disable                        |
-| `release`  | Releases — list, view, create, edit, delete                         |
-| `repo`     | Repositories — list, view, create, edit, clone, fork                |
-| `label`    | Labels — list, create, edit, delete                                 |
-| `search`   | Search issues, PRs, repos, commits, code                            |
-| `api`      | Raw GitHub API access                                               |
-| `setup`    | Install optional agent session hooks                                |
-| `update`   | Built-in self-update command inherited from `axi-sdk-js`            |
+| Command    | Description                                                                 |
+| ---------- | --------------------------------------------------------------------------- |
+| `issue`    | Issues — list, view, create, edit, close, reopen, comment, subissue         |
+| `pr`       | Pull requests — list, view, create, merge, review, checks                   |
+| `run`      | Existing workflow runs - list, view, watch, rerun, cancel, delete, download |
+| `workflow` | Workflows - list, view, run (trigger), enable, disable                      |
+| `release`  | Releases — list, view, create, edit, delete                                 |
+| `repo`     | Repositories — list, view, create, edit, clone, fork                        |
+| `label`    | Labels — list, create, edit, delete                                         |
+| `search`   | Search issues, PRs, repos, commits, code                                    |
+| `api`      | Raw GitHub API access                                                       |
+| `setup`    | Install optional agent session hooks                                        |
+| `update`   | Built-in self-update command inherited from `axi-sdk-js`                    |
 
 ### Global flags
 

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-axi
-description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, cutting releases, or querying the GitHub API."
+description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, or querying the GitHub API."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -20,16 +20,17 @@ gh-axi requires the [`gh`](https://cli.github.com/) CLI installed and authentica
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; managing releases, repositories, or labels; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
 
 ## Workflow
 
 1. Run `npx -y gh-axi` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: `issue list`, `issue view <n>`, `pr view <n>`, `pr checks <n>`, `run view <id>`, and so on.
 3. Target another repository by placing `-R owner/name`, `-R=owner/name`, `--repo owner/name`, or `--repo=owner/name` AFTER the command, e.g. `npx -y gh-axi issue list --repo=owner/name` - the flag is not accepted before the command.
-4. Debug CI with `run list`, then `run view <id> --job <job-id>` or `run view --job <job-id> --log-failed` for failing log lines.
+4. Trigger (dispatch) a workflow with `workflow run <name> --ref <ref>`; `run` manages existing workflow runs.
+5. Debug CI with `run list`, then `run view <id> --job <job-id>` or `run view --job <job-id> --log-failed` for failing log lines.
    Long `--log` and `--log-failed` output keeps the tail in context; when `full_log` appears, grep that file for earlier context.
-5. Every response ends with contextual next-step hints under `help:` - follow them.
+6. Every response ends with contextual next-step hints under `help:` - follow them.
 
 ## Commands
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -24,6 +24,8 @@ import { getSuggestions } from "../suggestions.js";
 export const RUN_HELP = `usage: gh-axi run <subcommand> [flags]
 subcommands[7]:
   list, view <id>, watch <id>, rerun <id>, cancel <id>, delete <id>, download <id>
+note:
+  manages existing runs; to trigger (dispatch) a workflow, use \`gh-axi workflow run <name> --ref <ref>\`
 flags{list}:
   --workflow, --branch, --status, --event, --user, --commit, --limit (default 10), --fields <a,b,c>
 flags{view}:

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -5,8 +5,8 @@ import { DESCRIPTION, TOP_HELP } from "./cli.js";
 export const SKILL_DESCRIPTION =
   "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, " +
   "releases, repositories, labels, search, and raw API access. Use whenever a task touches " +
-  "GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, cutting " +
-  "releases, or querying the GitHub API.";
+  "GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering " +
+  "workflows, cutting releases, or querying the GitHub API.";
 
 export const SKILL_AUTHOR = "Kun Chen (kunchenguid)";
 
@@ -63,16 +63,17 @@ gh-axi requires the [\`gh\`](https://cli.github.com/) CLI installed and authenti
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; managing releases, repositories, or labels; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
 
 ## Workflow
 
 1. Run \`npx -y gh-axi\` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: \`issue list\`, \`issue view <n>\`, \`pr view <n>\`, \`pr checks <n>\`, \`run view <id>\`, and so on.
 3. Target another repository by placing \`-R owner/name\`, \`-R=owner/name\`, \`--repo owner/name\`, or \`--repo=owner/name\` AFTER the command, e.g. \`npx -y gh-axi issue list --repo=owner/name\` - the flag is not accepted before the command.
-4. Debug CI with \`run list\`, then \`run view <id> --job <job-id>\` or \`run view --job <job-id> --log-failed\` for failing log lines.
+4. Trigger (dispatch) a workflow with \`workflow run <name> --ref <ref>\`; \`run\` manages existing workflow runs.
+5. Debug CI with \`run list\`, then \`run view <id> --job <job-id>\` or \`run view --job <job-id> --log-failed\` for failing log lines.
    Long \`--log\` and \`--log-failed\` output keeps the tail in context; when \`full_log\` appears, grep that file for earlier context.
-5. Every response ends with contextual next-step hints under \`help:\` - follow them.
+6. Every response ends with contextual next-step hints under \`help:\` - follow them.
 
 ## Commands
 


### PR DESCRIPTION
## Intent

Small discoverability improvement to gh-axi: make it obvious that triggering (dispatching) a workflow is done via 'gh-axi workflow run', not 'gh-axi run'. Background: 'gh-axi run' only manages existing workflow runs (list/view/watch/rerun/cancel/delete/download), but it is the natural place an agent looks first for 'run a workflow'. Finding no dispatch subcommand there, agents fall back to raw 'gh workflow run', defeating the wrapper (observed in real use). Change: added a single concise 'note:' cross-reference line to the RUN_HELP constant in src/commands/run.ts: 'manages existing runs; to trigger (dispatch) a workflow, use `gh-axi workflow run <name> --ref <ref>`'. Decisions/tradeoffs: (1) placed the note immediately after the subcommands block and before flags/examples - so an agent sees what run does, then where dispatch lives, and so it stays outside the 'examples:' section that help-examples.test.ts slices and indentation-checks; (2) matched the file's existing labeled-section help style (lowercase label, 2-space indented content, backticked command reference, no trailing period to match sibling help lines); (3) help/usage text only - no command behavior, flags, or output schema changed. Verified end-to-end via 'tsx bin/gh-axi.ts run --help', full test suite (440 passing), eslint clean, tsc build clean, and 'build:skill' regeneration produced no diff (SKILL.md does not depend on RUN_HELP).

## What Changed

- Added a `gh-axi run --help` note clarifying that `run` manages existing workflow runs and workflow dispatch belongs under `gh-axi workflow run <name> --ref <ref>`.
- Updated the README command examples/table and generated gh-axi skill guidance so agents see workflow triggering as part of the supported gh-axi workflow path.
- Committed no-mistakes evidence snapshots for the rendered `run --help` and `workflow --help` output.

## Risk Assessment

✅ Low: The branch only adds a static help-text cross-reference, and it matches the existing `workflow run` command surface without changing behavior.

## Testing

After a frozen dependency install, focused Vitest coverage for run/workflow help routing and help-example placement passed. The captured CLI transcripts show `gh-axi run --help` includes the new dispatch note immediately after the subcommands block and before flags/examples, and `gh-axi workflow --help` exposes the referenced `workflow run` command; lint, formatting, and build checks were not run because the prompt forbade linters/static analysis.

- Evidence: [run help output](https://github.com/kunchenguid/gh-axi/blob/841863d019c6965f98350ef090b6df458f922356/.no-mistakes/evidence/fm/ghaxi-run-help-xref-h3/run-help.txt)
- Evidence: [workflow help output](https://github.com/kunchenguid/gh-axi/blob/841863d019c6965f98350ef090b6df458f922356/.no-mistakes/evidence/fm/ghaxi-run-help-xref-h3/workflow-help.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run test/commands/run.test.ts test/commands/workflow.test.ts test/help-examples.test.ts test/cli.test.ts test/cli-entrypoint.test.ts`
- `pnpm exec tsx bin/gh-axi.ts run --help | tee .no-mistakes/evidence/fm/ghaxi-run-help-xref-h3/run-help.txt`
- `pnpm exec tsx bin/gh-axi.ts workflow --help | tee .no-mistakes/evidence/fm/ghaxi-run-help-xref-h3/workflow-help.txt`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
