### PR TITLE
fix(commands): apply all repeated --label flags on issue and pr create

### DIFF
--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -5,6 +5,7 @@ import { getSuggestions } from "../suggestions.js";
 import {
   hasFlag,
   getFlag,
+  getAllFlags,
   getPositional,
   requireNumber,
   takeFlag,
@@ -62,7 +63,7 @@ flags{list}:
 flags{view}:
   --comments, --full (show complete body without truncation)
 flags{create}:
-  --title <text> (required), --body <text> or --body-file <path>, --assignee <login>, --label <name>, --milestone <name>, --type <name>
+  --title <text> (required), --body <text> or --body-file <path>, --assignee <login>, --label <name> (repeatable), --milestone <name>, --type <name>
 flags{edit}:
   --title, --body <text> or --body-file <path>, --add-label, --remove-label, --add-assignee, --remove-assignee, --milestone, --type <name>, --no-type
 flags{close}:
@@ -473,7 +474,7 @@ async function createIssue(args: string[], ctx?: RepoContext): Promise<string> {
 
   const body = takeBody(args);
   const assignee = getFlag(args, "--assignee");
-  const label = getFlag(args, "--label");
+  const labels = getAllFlags(args, "--label");
   const milestone = getFlag(args, "--milestone");
   const project = getFlag(args, "--project");
   const typeName = getOptionalRequiredFlag(args, "--type");
@@ -487,7 +488,7 @@ async function createIssue(args: string[], ctx?: RepoContext): Promise<string> {
   const ghArgs = ["issue", "create", "--title", title];
   if (body !== undefined) ghArgs.push("--body", body);
   if (assignee) ghArgs.push("--assignee", assignee);
-  if (label) ghArgs.push("--label", label);
+  for (const l of labels) ghArgs.push("--label", l);
   if (milestone) ghArgs.push("--milestone", milestone);
   if (project) ghArgs.push("--project", project);
 

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -5,7 +5,7 @@ import { AxiError } from "../errors.js";
 import { takeBody, truncateBody } from "../body.js";
 import { formatCountLine } from "../format.js";
 import { getSuggestions } from "../suggestions.js";
-import { takeFlag, takeBoolFlag, takeNumber } from "../args.js";
+import { takeFlag, takeBoolFlag, takeNumber, getAllFlags } from "../args.js";
 import { parseFields, type ExtraFieldSpec } from "../fields.js";
 import {
   field,
@@ -432,7 +432,7 @@ async function prCreate(args: string[], ctx?: RepoContext): Promise<string> {
   const draft = takeBoolFlag(args, "--draft");
   const assignee = takeFlag(args, "--assignee");
   const reviewer = takeFlag(args, "--reviewer");
-  const label = takeFlag(args, "--label");
+  const labels = getAllFlags(args, "--label");
   const milestone = takeFlag(args, "--milestone");
   const project = takeFlag(args, "--project");
 
@@ -443,7 +443,7 @@ async function prCreate(args: string[], ctx?: RepoContext): Promise<string> {
   if (draft) ghArgs.push("--draft");
   if (assignee) ghArgs.push("--assignee", assignee);
   if (reviewer) ghArgs.push("--reviewer", reviewer);
-  if (label) ghArgs.push("--label", label);
+  for (const l of labels) ghArgs.push("--label", l);
   if (milestone) ghArgs.push("--milestone", milestone);
   if (project) ghArgs.push("--project", project);
 

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -227,7 +227,7 @@ flags{list}:
 flags{view}:
   --comments, --reviews (show review submissions and inline review comments), --full (show complete body without truncation)
 flags{create}:
-  --title <text> (required), --body <text> or --body-file <path>, --base, --head, --draft, --assignee, --reviewer, --label, --milestone
+  --title <text> (required), --body <text> or --body-file <path>, --base, --head, --draft, --assignee, --reviewer, --label <name> (repeatable), --milestone
 flags{edit}:
   --title <text>, --body <text> or --body-file <path>, --add-label, --remove-label, --add-assignee, --remove-assignee, --add-reviewer, --remove-reviewer, --milestone
 flags{merge}:

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -392,6 +392,90 @@ describe("issueCommand", () => {
       ).rejects.toThrow(AxiError);
       expect(mockedGhExec).not.toHaveBeenCalled();
     });
+
+    it("passes all repeated --label flags to gh issue create (two labels)", async () => {
+      mockedGhExec.mockResolvedValue(
+        "https://github.com/octo/repo/issues/99\n",
+      );
+      mockedGhJson.mockResolvedValue({
+        number: 99,
+        title: "Multi-label issue",
+        state: "OPEN",
+        url: "https://github.com/octo/repo/issues/99",
+      });
+
+      await issueCommand(
+        [
+          "create",
+          "--title",
+          "Multi-label issue",
+          "--label",
+          "enhancement",
+          "--label",
+          "ready-for-agent",
+        ],
+        ctx,
+      );
+
+      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
+      expect(callArgs.filter((a) => a === "--label")).toHaveLength(2);
+      expect(callArgs).toContain("enhancement");
+      expect(callArgs).toContain("ready-for-agent");
+    });
+
+    it("passes all repeated --label flags to gh issue create (three labels)", async () => {
+      mockedGhExec.mockResolvedValue(
+        "https://github.com/octo/repo/issues/100\n",
+      );
+      mockedGhJson.mockResolvedValue({
+        number: 100,
+        title: "Triple-label issue",
+        state: "OPEN",
+        url: "https://github.com/octo/repo/issues/100",
+      });
+
+      await issueCommand(
+        [
+          "create",
+          "--title",
+          "Triple-label issue",
+          "--label",
+          "bug",
+          "--label",
+          "enhancement",
+          "--label",
+          "good first issue",
+        ],
+        ctx,
+      );
+
+      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
+      expect(callArgs.filter((a) => a === "--label")).toHaveLength(3);
+      expect(callArgs).toContain("bug");
+      expect(callArgs).toContain("enhancement");
+      expect(callArgs).toContain("good first issue");
+    });
+
+    it("still passes a single --label flag correctly (no regression)", async () => {
+      mockedGhExec.mockResolvedValue(
+        "https://github.com/octo/repo/issues/101\n",
+      );
+      mockedGhJson.mockResolvedValue({
+        number: 101,
+        title: "Single-label issue",
+        state: "OPEN",
+        url: "https://github.com/octo/repo/issues/101",
+      });
+
+      await issueCommand(
+        ["create", "--title", "Single-label issue", "--label", "bug"],
+        ctx,
+      );
+
+      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
+      expect(callArgs.filter((a) => a === "--label")).toHaveLength(1);
+      expect(callArgs).toContain("bug");
+    });
   });
 
   describe("edit with --type", () => {


### PR DESCRIPTION
## What Changed

- `issue create` and `pr create` now collect every repeated `--label` flag via `getAllFlags` and forward each one to `gh`, instead of reading a single value and silently dropping all but the first label.
- Updated the `flags{create}` help text for both commands to annotate `--label` as `(repeatable)`.
- Added regression tests for `issue create` covering two-label, three-label, and single-label cases.

## Risk Assessment

✅ Low: A small, well-bounded change that mirrors an existing pattern, updates both help strings, and adds regression tests for the issue path with no functional risks to the gh argument construction.

## Testing

Ran the issue/pr command unit suites (78 passing, including the newly added multi-label and single-label regression tests) and then exercised the actual CLI surface end-to-end by running the built `gh-axi issue create` and `pr create` commands with multiple `--label` flags through a fake `gh` shim that records the exact argv it receives. The recorded calls confirm all three labels (enhancement, ready-for-agent, bug) reach `gh issue create` and both labels reach `gh pr create`, directly demonstrating the user intent from issue #55; no failures, working tree left clean.

<details>
<summary>Evidence: CLI transcript: gh-axi forwards every --label to gh (issue + pr create)</summary>

```text
$ gh-axi issue create --title 'Multi-label issue' --label enhancement --label ready-for-agent --label bug --repo octo/repo
issue:
number: 99
title: Multi-label issue
state: open
url: "https://github.com/octo/repo/issues/99"

$ gh-axi pr create --title 'Multi-label PR' --label enhancement --label needs-review --repo octo/repo
created:
number: 42
url: "https://github.com/octo/repo/pull/42"

--- exact argv gh-axi handed to gh (recorded by shim) ---
gh issue create --title Multi-label issue --label enhancement --label ready-for-agent --label bug --repo octo/repo
gh issue view 99 --json number,title,state,url,id --repo octo/repo
gh pr create --title Multi-label PR --label enhancement --label needs-review --repo octo/repo
```
</details>
<details>
<summary>Evidence: Recorded gh call log</summary>

```text
gh issue create --title Multi-label issue --label enhancement --label ready-for-agent --label bug --repo octo/repo
gh issue view 99 --json number,title,state,url,id --repo octo/repo
gh pr create --title Multi-label PR --label enhancement --label needs-review --repo octo/repo
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `src/commands/pr.ts:230` - The pr.ts change makes `pr create --label` repeatable (mirroring the issue.ts fix), but its help text at this line still lists `--label` without the `(repeatable)` annotation that was added to issue.ts&#39;s `flags{create}` help. The new multi-label capability is therefore undocumented for pr create, hurting discoverability and leaving the two parallel commands inconsistent.

🔧 Fix: docs(pr): annotate pr create --label as repeatable
1 info still open:
- ℹ️ `src/commands/pr.ts:446` - The `pr create` multi-label fix is identical to the `issue create` fix but, unlike issue.ts (which gained three regression tests), has no test exercising repeated `--label` flags. Since these two commands are maintained in parallel, a future refactor could silently regress pr create&#39;s multi-label behavior with nothing to catch it.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm vitest run test/commands/issue.test.ts test/commands/pr.test.ts` (78 pass, incl. new two/three-label and single-label-regression cases)</code>
- <code>End-to-end CLI: `tsx bin/gh-axi.ts issue create --title &#39;Multi-label issue&#39; --label enhancement --label ready-for-agent --label bug --repo octo/repo` against a fake `gh` shim that records argv</code>
- <code>End-to-end CLI: `tsx bin/gh-axi.ts pr create --title &#39;Multi-label PR&#39; --label enhancement --label needs-review --repo octo/repo` against the same shim</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
