### PR TITLE
feat(commands): add secret and variable commands

### DIFF
--- a/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/cli-e2e-transcript.txt
+++ b/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/cli-e2e-transcript.txt
@@ -1,0 +1,82 @@
+
+$ pnpm exec tsx bin/gh-axi.ts --help | sed -n '1,12p'
+usage: gh-axi [command] [args] [flags]
+commands[13]:
+  (none)=dashboard, issue, pr, run, workflow, release, repo, label, secret, variable, search, api, setup
+flags[3]:
+  -R/--repo <OWNER/NAME> (after command), accepts space or equals form, --help, -v/-V/--version
+examples:
+  gh-axi
+  gh-axi issue list --state open
+  gh-axi issue list -R owner/name
+  gh-axi issue list --repo=owner/name
+  gh-axi pr view 42
+  gh-axi secret list
+exit=0
+
+$ pnpm exec tsx bin/gh-axi.ts secret list -R owner/repo
+count: 1
+secrets[1]{name,updated}:
+  API_KEY,1d ago
+help[1]:
+  Run `echo -n "<value>" | gh-axi secret set <name> -R owner/repo` to add or update a secret
+exit=0
+
+$ printf '%s' '<synthetic-secret>' | pnpm exec tsx bin/gh-axi.ts secret set API_KEY -R owner/repo
+set: ok
+secret: API_KEY
+help[1]:
+  Run `gh-axi secret list -R owner/repo` to see all secrets
+exit=0
+
+$ pnpm exec tsx bin/gh-axi.ts secret set API_KEY --body '<synthetic-secret>' -R owner/repo
+error: Secret values must be piped via stdin; --body/-b is not accepted because flags are visible in process argv
+code: VALIDATION_ERROR
+help[1]: "echo -n \"<value>\" | gh-axi secret set <name>"
+exit=2
+
+$ pnpm exec tsx bin/gh-axi.ts secret delete API_KEY -R owner/repo
+delete: ok
+secret: API_KEY
+help[1]:
+  Run `gh-axi secret list -R owner/repo` to see remaining secrets
+exit=0
+
+$ pnpm exec tsx bin/gh-axi.ts variable list -R owner/repo
+count: 1
+variables[1]{name,value,updated}:
+  NODE_ENV,production,1d ago
+help[1]:
+  Run `gh-axi variable set <name> --body <value> -R owner/repo` to add or update a variable
+exit=0
+
+$ pnpm exec tsx bin/gh-axi.ts variable set NODE_ENV --body production -R owner/repo
+set: ok
+variable: NODE_ENV
+help[1]:
+  Run `gh-axi variable list -R owner/repo` to see all variables
+exit=0
+
+$ printf '%s' 'staging' | pnpm exec tsx bin/gh-axi.ts variable set NODE_ENV -R owner/repo
+set: ok
+variable: NODE_ENV
+help[1]:
+  Run `gh-axi variable list -R owner/repo` to see all variables
+exit=0
+
+$ pnpm exec tsx bin/gh-axi.ts variable delete NODE_ENV -R owner/repo
+delete: ok
+variable: NODE_ENV
+help[1]:
+  Run `gh-axi variable list -R owner/repo` to see remaining variables
+exit=0
+
+fake gh child argv/stdin log:
+call_count: 7
+1: {"args":["secret","list","--json","name,updatedAt","--repo","owner/repo"],"stdinLength":0,"stdinSha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+2: {"args":["secret","set","API_KEY","--repo","owner/repo"],"stdinLength":18,"stdinSha256":"bef317f2fd425404b82f1883a786d66addc74a65c3c7c43f0abe049e8de5ad54"}
+3: {"args":["secret","delete","API_KEY","--repo","owner/repo"],"stdinLength":0,"stdinSha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+4: {"args":["variable","list","--json","name,value,updatedAt","--repo","owner/repo"],"stdinLength":0,"stdinSha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+5: {"args":["variable","set","NODE_ENV","--repo","owner/repo"],"stdinLength":10,"stdinSha256":"ab8e18ef4ebebeddc0b3152ce9c9006e14fc05242e3fc9ce32246ea6a9543074"}
+6: {"args":["variable","set","NODE_ENV","--repo","owner/repo"],"stdinLength":7,"stdinSha256":"e919a75364398a449f860aeadddc57fa0502145a4e63959ddb33c417a48dc0da"}
+7: {"args":["variable","delete","NODE_ENV","--repo","owner/repo"],"stdinLength":0,"stdinSha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}

--- a/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-bin/gh
+++ b/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-bin/gh
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { appendFileSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+
+const args = process.argv.slice(2);
+const shouldReadStdin =
+  (args[0] === "secret" || args[0] === "variable") && args[1] === "set";
+let stdin = "";
+
+if (shouldReadStdin) {
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    stdin = "";
+  }
+}
+
+const stdinSha256 = createHash("sha256").update(stdin).digest("hex");
+const logPath = process.env.FAKE_GH_LOG;
+
+if (logPath) {
+  appendFileSync(
+    logPath,
+    JSON.stringify({
+      args,
+      stdinLength: stdin.length,
+      stdinSha256,
+    }) + "\n",
+  );
+}
+
+if (args[0] === "secret" && args[1] === "list") {
+  console.log(
+    JSON.stringify([
+      { name: "API_KEY", updatedAt: "2026-06-30T12:00:00Z" },
+    ]),
+  );
+  process.exit(0);
+}
+
+if (args[0] === "variable" && args[1] === "list") {
+  console.log(
+    JSON.stringify([
+      {
+        name: "NODE_ENV",
+        value: "production",
+        updatedAt: "2026-06-30T12:00:00Z",
+      },
+    ]),
+  );
+  process.exit(0);
+}
+
+process.exit(0);

--- a/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-gh-calls.jsonl
+++ b/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-gh-calls.jsonl
@@ -1,0 +1,7 @@
+{"args":["secret","list","--json","name,updatedAt","--repo","owner/repo"],"stdinLength":0,"stdinSha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+{"args":["secret","set","API_KEY","--repo","owner/repo"],"stdinLength":18,"stdinSha256":"bef317f2fd425404b82f1883a786d66addc74a65c3c7c43f0abe049e8de5ad54"}
+{"args":["secret","delete","API_KEY","--repo","owner/repo"],"stdinLength":0,"stdinSha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+{"args":["variable","list","--json","name,value,updatedAt","--repo","owner/repo"],"stdinLength":0,"stdinSha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+{"args":["variable","set","NODE_ENV","--repo","owner/repo"],"stdinLength":10,"stdinSha256":"ab8e18ef4ebebeddc0b3152ce9c9006e14fc05242e3fc9ce32246ea6a9543074"}
+{"args":["variable","set","NODE_ENV","--repo","owner/repo"],"stdinLength":7,"stdinSha256":"e919a75364398a449f860aeadddc57fa0502145a4e63959ddb33c417a48dc0da"}
+{"args":["variable","delete","NODE_ENV","--repo","owner/repo"],"stdinLength":0,"stdinSha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,4 +26,8 @@ Do not hand-edit `CHANGELOG.md` or `.release-please-manifest.json` (a guard work
 
 `gh secret list`/`gh variable list` do not support `--limit` or any pagination flag (unlike `issue`/`pr`/`release` list), so `secret.ts`/`variable.ts` list all results in one call with no `--limit` flag of their own.
 
-Secret and variable values must never appear in argv (visible via `ps`) or in stdout. `secretCommand`/`variableCommand`'s `set` subcommand resolves the value from `--body`/`-b` or piped stdin (`resolveValue` in `src/secretValue.ts`, backed by `src/stdin.ts`), then hands it to `gh.ts#ghExecWithStdin`, which writes the value directly to the `gh` child process's stdin instead of passing it as a CLI flag — this is why `gh.ts` has both `ghExec` (argv-only) and `ghExecWithStdin` (writes to the child's stdin pipe). `resolveValue` throws immediately instead of blocking when stdin is an interactive TTY and no `--body` was given, since AXI commands must never hang waiting for interactive input.
+Secret values must never appear in argv (visible via `ps`) or stdout.
+`secretCommand`'s `set` subcommand is stdin-only: it rejects `--body`/`-b`, calls `resolveValue(undefined, "secret")`, and pipes the resolved value to `gh.ts#ghExecWithStdin` so the wrapped `gh secret set` child also never receives the value in argv.
+Variable values are not treated as secrets: `variableCommand`'s `set` subcommand may resolve the value from `--body`/`-b` or piped stdin (`resolveValue` in `src/secretValue.ts`, backed by `src/stdin.ts`), and `gh-axi variable list` intentionally prints variable values.
+`variable set --body` values are visible in the `gh-axi` process argv, but `ghExecWithStdin` still keeps them out of the child `gh variable set` argv.
+`resolveValue` throws immediately instead of blocking when stdin is an interactive TTY and no usable value source was provided, since AXI commands must never hang waiting for interactive input.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,9 @@ The SDK also appends a `"built-in":` section to the top-level `--help` output at
 
 Releases are cut by release-please from conventional commit messages on `main`; merging the bot's release PR triggers `npm publish` via `.github/workflows/release-please.yml`.
 Do not hand-edit `CHANGELOG.md` or `.release-please-manifest.json` (a guard workflow blocks PRs that touch them), and regenerate `skills/gh-axi/SKILL.md` with `pnpm run build:skill` instead of editing it directly.
+
+## Secret/variable value input (`src/secretValue.ts`, `src/stdin.ts`, `gh.ts#ghExecWithStdin`)
+
+`gh secret list`/`gh variable list` do not support `--limit` or any pagination flag (unlike `issue`/`pr`/`release` list), so `secret.ts`/`variable.ts` list all results in one call with no `--limit` flag of their own.
+
+Secret and variable values must never appear in argv (visible via `ps`) or in stdout. `secretCommand`/`variableCommand`'s `set` subcommand resolves the value from `--body`/`-b` or piped stdin (`resolveValue` in `src/secretValue.ts`, backed by `src/stdin.ts`), then hands it to `gh.ts#ghExecWithStdin`, which writes the value directly to the `gh` child process's stdin instead of passing it as a CLI flag — this is why `gh.ts` has both `ghExec` (argv-only) and `ghExecWithStdin` (writes to the child's stdin pipe). `resolveValue` throws immediately instead of blocking when stdin is an interactive TTY and no `--body` was given, since AXI commands must never hang waiting for interactive input.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Long `run view --log` and `run view --log-failed` output shows the last 20,000 c
 When truncation happens, gh-axi best-effort saves the complete log to a temp file, includes it as `full_log`, and prints a `help:` hint telling agents to grep that file for earlier context.
 `gh-axi run` manages existing workflow runs; use `gh-axi workflow run <name> --ref <ref>` to trigger (dispatch) a workflow.
 
-`gh-axi secret set <name>` reads the value from `--body`/`-b` or piped stdin — never from a hardcoded prompt — and `gh-axi secret list` never prints values, matching `gh secret list`. `gh-axi variable` follows the same `--body`/stdin input, but variable values are not secret and are shown in `list` output.
+`gh-axi secret set <name>` reads the value only from piped stdin because secret flags would be visible in the `gh-axi` process argv.
+`gh-axi secret list` never prints values, matching `gh secret list`.
+`gh-axi variable` accepts `--body`/`-b` or piped stdin, and variable values are shown in `list` output because variables are not secret.
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ gh-axi run list -R owner/repo   # list workflow runs for a specific repo
 gh-axi run view 123456 --job 789012       # inspect a single job within a run
 gh-axi run view --job 789012 --log-failed # show failed log lines for one job
 gh-axi workflow run ci.yml --ref main     # trigger a workflow
+echo -n "sk-..." | gh-axi secret set OPENAI_API_KEY  # set a secret from stdin
+gh-axi variable set NODE_ENV --body production        # set a variable from a flag
 gh-axi setup hooks              # install optional agent session hooks
 gh-axi update --check           # check whether a newer release exists
 gh-axi update                   # upgrade a global install
@@ -100,6 +102,8 @@ Long `run view --log` and `run view --log-failed` output shows the last 20,000 c
 When truncation happens, gh-axi best-effort saves the complete log to a temp file, includes it as `full_log`, and prints a `help:` hint telling agents to grep that file for earlier context.
 `gh-axi run` manages existing workflow runs; use `gh-axi workflow run <name> --ref <ref>` to trigger (dispatch) a workflow.
 
+`gh-axi secret set <name>` reads the value from `--body`/`-b` or piped stdin — never from a hardcoded prompt — and `gh-axi secret list` never prints values, matching `gh secret list`. `gh-axi variable` follows the same `--body`/stdin input, but variable values are not secret and are shown in `list` output.
+
 ### Commands
 
 | Command    | Description                                                                 |
@@ -111,6 +115,8 @@ When truncation happens, gh-axi best-effort saves the complete log to a temp fil
 | `release`  | Releases — list, view, create, edit, delete                                 |
 | `repo`     | Repositories — list, view, create, edit, clone, fork                        |
 | `label`    | Labels — list, create, edit, delete                                         |
+| `secret`   | Actions secrets — list, set, delete                                         |
+| `variable` | Actions variables — list, set, delete                                       |
 | `search`   | Search issues, PRs, repos, commits, code                                    |
 | `api`      | Raw GitHub API access                                                       |
 | `setup`    | Install optional agent session hooks                                        |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You still need [`gh`](https://cli.github.com/) installed and authenticated via `
 
 The skill is not a user-facing slash command (`user-invocable: false`).
 Its frontmatter also includes Hermes Agent metadata (`metadata.hermes`) so Hermes can categorize it as a `devops` skill for GitHub, git, CI, pull requests, and releases.
-Just ask for anything that touches GitHub - filing issues, reviewing PRs, checking CI runs, cutting releases - and the agent loads the skill on its own when it recognizes the task.
+Just ask for anything that touches GitHub - filing issues, reviewing PRs, checking CI runs, cutting releases, or managing GitHub Actions secrets and variables - and the agent loads the skill on its own when it recognizes the task.
 
 `-g` installs the skill for all projects (`~/.claude/skills/`, for example); drop it to install for the current project only (`.claude/skills/`).
 
@@ -95,8 +95,9 @@ gh-axi update --check           # check whether a newer release exists
 gh-axi update                   # upgrade a global install
 ```
 
-For multi-line issue, PR, review, or comment text, write Markdown to a UTF-8 file and pass `--body-file <path>` anywhere `--body` is accepted.
+For multi-line issue, PR, review, or comment text, write Markdown to a UTF-8 file and pass `--body-file <path>` on the relevant command.
 For releases, `--body` and `--body-file` are aliases for release notes, alongside `--notes` and `--notes-file`.
+For multi-line variable values, pipe stdin to `gh-axi variable set <name>`; `--body`/`-b` is for inline values only.
 
 Long `run view --log` and `run view --log-failed` output shows the last 20,000 characters so CI failures stay visible.
 When truncation happens, gh-axi best-effort saves the complete log to a temp file, includes it as `full_log`, and prints a `help:` hint telling agents to grep that file for earlier context.

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -50,8 +50,9 @@ Run `npx -y gh-axi --help` for global flags, or `npx -y gh-axi <command> --help`
 - Output is TOON-encoded and token-efficient; pipe through grep/head only when a list is very long.
 - Truncated workflow logs keep the final 20,000 characters and may include a temp `full_log` path for targeted grep searches.
 - Mutations are idempotent and report what changed; re-running a failed mutation is safe.
-- For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass `--body-file <path>`; it works anywhere `--body` is accepted.
+- For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass `--body-file <path>` or the release `--notes-file <path>` alias on commands that support file-backed text.
 - Secret values are stdin-only: `echo -n "<value>" | npx -y gh-axi secret set <name>`.
 - Do not pass secrets with `--body` or `-b`; flags are visible in the `gh-axi` process argv.
 - Variable values may use `--body`/`-b` or stdin because Actions variables are not secret.
+- For multi-line variable values, pipe stdin to `npx -y gh-axi variable set <name>`; `--body`/`-b` is for inline values only.
 - Use `api` for anything the dedicated commands do not cover, e.g. `npx -y gh-axi api repos/{owner}/{repo}/topics`.

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-axi
-description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, or querying the GitHub API."
+description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, or managing Actions secrets/variables."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -20,7 +20,7 @@ gh-axi requires the [`gh`](https://cli.github.com/) CLI installed and authentica
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
 
 ## Workflow
 
@@ -35,8 +35,8 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 ## Commands
 
 ```
-commands[11]:
-  (none)=dashboard, issue, pr, run, workflow, release, repo, label, search, api, setup
+commands[13]:
+  (none)=dashboard, issue, pr, run, workflow, release, repo, label, secret, variable, search, api, setup
 ```
 
 Installed copies also inherit the SDK built-in `update` command.

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -51,4 +51,7 @@ Run `npx -y gh-axi --help` for global flags, or `npx -y gh-axi <command> --help`
 - Truncated workflow logs keep the final 20,000 characters and may include a temp `full_log` path for targeted grep searches.
 - Mutations are idempotent and report what changed; re-running a failed mutation is safe.
 - For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass `--body-file <path>`; it works anywhere `--body` is accepted.
+- Secret values are stdin-only: `echo -n "<value>" | npx -y gh-axi secret set <name>`.
+- Do not pass secrets with `--body` or `-b`; flags are visible in the `gh-axi` process argv.
+- Variable values may use `--body`/`-b` or stdin because Actions variables are not secret.
 - Use `api` for anything the dedicated commands do not cover, e.g. `npx -y gh-axi api repos/{owner}/{repo}/topics`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,8 @@ import { workflowCommand, WORKFLOW_HELP } from "./commands/workflow.js";
 import { releaseCommand, RELEASE_HELP } from "./commands/release.js";
 import { repoCommand, REPO_HELP } from "./commands/repo.js";
 import { labelCommand, LABEL_HELP } from "./commands/label.js";
+import { secretCommand, SECRET_HELP } from "./commands/secret.js";
+import { variableCommand, VARIABLE_HELP } from "./commands/variable.js";
 import { searchCommand, SEARCH_HELP } from "./commands/search.js";
 import { apiCommand, API_HELP } from "./commands/api.js";
 import { setupCommand, SETUP_HELP } from "./commands/setup.js";
@@ -27,8 +29,8 @@ type MainOptions = {
 };
 
 export const TOP_HELP = `usage: gh-axi [command] [args] [flags]
-commands[11]:
-  (none)=dashboard, issue, pr, run, workflow, release, repo, label, search, api, setup
+commands[13]:
+  (none)=dashboard, issue, pr, run, workflow, release, repo, label, secret, variable, search, api, setup
 flags[3]:
   -R/--repo <OWNER/NAME> (after command), accepts space or equals form, --help, -v/-V/--version
 examples:
@@ -37,6 +39,7 @@ examples:
   gh-axi issue list -R owner/name
   gh-axi issue list --repo=owner/name
   gh-axi pr view 42
+  gh-axi secret list
   gh-axi setup hooks
 `;
 
@@ -48,6 +51,8 @@ const COMMAND_HELP: Record<string, string> = {
   release: RELEASE_HELP,
   repo: REPO_HELP,
   label: LABEL_HELP,
+  secret: SECRET_HELP,
+  variable: VARIABLE_HELP,
   search: SEARCH_HELP,
   api: API_HELP,
   setup: SETUP_HELP,
@@ -63,6 +68,8 @@ const COMMANDS: Record<string, CommandFn> = {
   release: withRepoContext("release", releaseCommand),
   repo: withRepoContext("repo", repoCommand),
   label: withRepoContext("label", labelCommand),
+  secret: withRepoContext("secret", secretCommand),
+  variable: withRepoContext("variable", variableCommand),
   search: withRepoContext("search", searchCommand),
   api: withRepoContext("api", apiCommand),
   setup: setupCommand,

--- a/src/commands/secret.ts
+++ b/src/commands/secret.ts
@@ -2,7 +2,6 @@ import { encode } from "@toon-format/toon";
 import type { RepoContext } from "../context.js";
 import { ghJson, ghExec, ghExecWithStdin } from "../gh.js";
 import { AxiError } from "../errors.js";
-import { takeFlag } from "../args.js";
 import {
   field,
   relativeTime,
@@ -19,24 +18,44 @@ export const SECRET_HELP = `usage: gh-axi secret <subcommand> [flags]
 subcommands[3]:
   list, set <name>, delete <name>
 flags{set}:
-  --body/-b <value> (reads from stdin if omitted)
+  value is read only from piped stdin; --body/-b is not accepted for secrets
 values are never printed: \`list\` only exposes name and update time, matching \`gh secret list\`
 examples:
   gh-axi secret list
   echo -n "sk-..." | gh-axi secret set OPENAI_API_KEY
-  gh-axi secret set OPENAI_API_KEY --body "sk-..."
   gh-axi secret delete OPENAI_API_KEY`;
 
-const listSchema: FieldDef[] = [field("name"), relativeTime("updatedAt", "updated")];
+const listSchema: FieldDef[] = [
+  field("name"),
+  relativeTime("updatedAt", "updated"),
+];
 
-async function listSecrets(_args: string[], ctx?: RepoContext): Promise<string> {
+function hasBodyFlag(args: string[]): boolean {
+  return args.some(
+    (arg) =>
+      arg === "--body" ||
+      arg.startsWith("--body=") ||
+      arg === "-b" ||
+      arg.startsWith("-b="),
+  );
+}
+
+async function listSecrets(
+  _args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
   const secrets = await ghJson<Record<string, unknown>[]>(
     ["secret", "list", "--json", "name,updatedAt"],
     ctx,
   );
   const isEmpty = secrets.length === 0;
 
-  const suggestions = getSuggestions({ domain: "secret", action: "list", isEmpty, repo: ctx });
+  const suggestions = getSuggestions({
+    domain: "secret",
+    action: "list",
+    isEmpty,
+    repo: ctx,
+  });
   return renderOutput([
     `count: ${secrets.length}`,
     renderList("secrets", secrets, listSchema),
@@ -46,33 +65,68 @@ async function listSecrets(_args: string[], ctx?: RepoContext): Promise<string> 
 
 async function setSecret(args: string[], ctx?: RepoContext): Promise<string> {
   const remaining = args.slice(1);
-  const flagValue = takeFlag(remaining, "--body") ?? takeFlag(remaining, "-b");
+  if (hasBodyFlag(remaining)) {
+    throw new AxiError(
+      "Secret values must be piped via stdin; --body/-b is not accepted because flags are visible in process argv",
+      "VALIDATION_ERROR",
+      [`echo -n "<value>" | gh-axi secret set <name>`],
+    );
+  }
+
   const positionals = remaining.filter((a) => !a.startsWith("-"));
   const name = positionals[0];
   if (!name) {
-    throw new AxiError("Secret name is required: gh-axi secret set <name>", "VALIDATION_ERROR");
+    throw new AxiError(
+      "Secret name is required: gh-axi secret set <name>",
+      "VALIDATION_ERROR",
+    );
   }
 
-  const value = await resolveValue(flagValue, "secret");
+  const value = await resolveValue(undefined, "secret");
   await ghExecWithStdin(["secret", "set", name], value, ctx);
 
-  const suggestions = getSuggestions({ domain: "secret", action: "set", id: name, repo: ctx });
-  return renderOutput([encode({ set: "ok", secret: name }), renderHelp(suggestions)]);
+  const suggestions = getSuggestions({
+    domain: "secret",
+    action: "set",
+    id: name,
+    repo: ctx,
+  });
+  return renderOutput([
+    encode({ set: "ok", secret: name }),
+    renderHelp(suggestions),
+  ]);
 }
 
-async function deleteSecret(args: string[], ctx?: RepoContext): Promise<string> {
+async function deleteSecret(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
   const positionals = args.filter((a) => !a.startsWith("-"));
   const name = positionals[1];
   if (!name) {
-    throw new AxiError("Secret name is required: gh-axi secret delete <name>", "VALIDATION_ERROR");
+    throw new AxiError(
+      "Secret name is required: gh-axi secret delete <name>",
+      "VALIDATION_ERROR",
+    );
   }
 
   await ghExec(["secret", "delete", name], ctx);
-  const suggestions = getSuggestions({ domain: "secret", action: "delete", id: name, repo: ctx });
-  return renderOutput([encode({ delete: "ok", secret: name }), renderHelp(suggestions)]);
+  const suggestions = getSuggestions({
+    domain: "secret",
+    action: "delete",
+    id: name,
+    repo: ctx,
+  });
+  return renderOutput([
+    encode({ delete: "ok", secret: name }),
+    renderHelp(suggestions),
+  ]);
 }
 
-export async function secretCommand(args: string[], ctx?: RepoContext): Promise<string> {
+export async function secretCommand(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
   const sub = args[0];
 
   if (sub === "--help" || sub === undefined) return SECRET_HELP;

--- a/src/commands/secret.ts
+++ b/src/commands/secret.ts
@@ -1,0 +1,92 @@
+import { encode } from "@toon-format/toon";
+import type { RepoContext } from "../context.js";
+import { ghJson, ghExec, ghExecWithStdin } from "../gh.js";
+import { AxiError } from "../errors.js";
+import { takeFlag } from "../args.js";
+import {
+  field,
+  relativeTime,
+  renderList,
+  renderHelp,
+  renderOutput,
+  renderError,
+  type FieldDef,
+} from "../toon.js";
+import { getSuggestions } from "../suggestions.js";
+import { resolveValue } from "../secretValue.js";
+
+export const SECRET_HELP = `usage: gh-axi secret <subcommand> [flags]
+subcommands[3]:
+  list, set <name>, delete <name>
+flags{set}:
+  --body/-b <value> (reads from stdin if omitted)
+values are never printed: \`list\` only exposes name and update time, matching \`gh secret list\`
+examples:
+  gh-axi secret list
+  echo -n "sk-..." | gh-axi secret set OPENAI_API_KEY
+  gh-axi secret set OPENAI_API_KEY --body "sk-..."
+  gh-axi secret delete OPENAI_API_KEY`;
+
+const listSchema: FieldDef[] = [field("name"), relativeTime("updatedAt", "updated")];
+
+async function listSecrets(_args: string[], ctx?: RepoContext): Promise<string> {
+  const secrets = await ghJson<Record<string, unknown>[]>(
+    ["secret", "list", "--json", "name,updatedAt"],
+    ctx,
+  );
+  const isEmpty = secrets.length === 0;
+
+  const suggestions = getSuggestions({ domain: "secret", action: "list", isEmpty, repo: ctx });
+  return renderOutput([
+    `count: ${secrets.length}`,
+    renderList("secrets", secrets, listSchema),
+    renderHelp(suggestions),
+  ]);
+}
+
+async function setSecret(args: string[], ctx?: RepoContext): Promise<string> {
+  const remaining = args.slice(1);
+  const flagValue = takeFlag(remaining, "--body") ?? takeFlag(remaining, "-b");
+  const positionals = remaining.filter((a) => !a.startsWith("-"));
+  const name = positionals[0];
+  if (!name) {
+    throw new AxiError("Secret name is required: gh-axi secret set <name>", "VALIDATION_ERROR");
+  }
+
+  const value = await resolveValue(flagValue, "secret");
+  await ghExecWithStdin(["secret", "set", name], value, ctx);
+
+  const suggestions = getSuggestions({ domain: "secret", action: "set", id: name, repo: ctx });
+  return renderOutput([encode({ set: "ok", secret: name }), renderHelp(suggestions)]);
+}
+
+async function deleteSecret(args: string[], ctx?: RepoContext): Promise<string> {
+  const positionals = args.filter((a) => !a.startsWith("-"));
+  const name = positionals[1];
+  if (!name) {
+    throw new AxiError("Secret name is required: gh-axi secret delete <name>", "VALIDATION_ERROR");
+  }
+
+  await ghExec(["secret", "delete", name], ctx);
+  const suggestions = getSuggestions({ domain: "secret", action: "delete", id: name, repo: ctx });
+  return renderOutput([encode({ delete: "ok", secret: name }), renderHelp(suggestions)]);
+}
+
+export async function secretCommand(args: string[], ctx?: RepoContext): Promise<string> {
+  const sub = args[0];
+
+  if (sub === "--help" || sub === undefined) return SECRET_HELP;
+
+  switch (sub) {
+    case "list":
+      return listSecrets(args, ctx);
+    case "set":
+      return setSecret(args, ctx);
+    case "delete":
+      return deleteSecret(args, ctx);
+    default:
+      return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [
+        "Available subcommands: list, set, delete",
+      ]);
+  }
+}

--- a/src/commands/variable.ts
+++ b/src/commands/variable.ts
@@ -32,14 +32,22 @@ const listSchema: FieldDef[] = [
   relativeTime("updatedAt", "updated"),
 ];
 
-async function listVariables(_args: string[], ctx?: RepoContext): Promise<string> {
+async function listVariables(
+  _args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
   const variables = await ghJson<Record<string, unknown>[]>(
     ["variable", "list", "--json", "name,value,updatedAt"],
     ctx,
   );
   const isEmpty = variables.length === 0;
 
-  const suggestions = getSuggestions({ domain: "variable", action: "list", isEmpty, repo: ctx });
+  const suggestions = getSuggestions({
+    domain: "variable",
+    action: "list",
+    isEmpty,
+    repo: ctx,
+  });
   return renderOutput([
     `count: ${variables.length}`,
     renderList("variables", variables, listSchema),
@@ -53,29 +61,57 @@ async function setVariable(args: string[], ctx?: RepoContext): Promise<string> {
   const positionals = remaining.filter((a) => !a.startsWith("-"));
   const name = positionals[0];
   if (!name) {
-    throw new AxiError("Variable name is required: gh-axi variable set <name>", "VALIDATION_ERROR");
+    throw new AxiError(
+      "Variable name is required: gh-axi variable set <name>",
+      "VALIDATION_ERROR",
+    );
   }
 
   const value = await resolveValue(flagValue, "variable");
   await ghExecWithStdin(["variable", "set", name], value, ctx);
 
-  const suggestions = getSuggestions({ domain: "variable", action: "set", id: name, repo: ctx });
-  return renderOutput([encode({ set: "ok", variable: name }), renderHelp(suggestions)]);
+  const suggestions = getSuggestions({
+    domain: "variable",
+    action: "set",
+    id: name,
+    repo: ctx,
+  });
+  return renderOutput([
+    encode({ set: "ok", variable: name }),
+    renderHelp(suggestions),
+  ]);
 }
 
-async function deleteVariable(args: string[], ctx?: RepoContext): Promise<string> {
+async function deleteVariable(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
   const positionals = args.filter((a) => !a.startsWith("-"));
   const name = positionals[1];
   if (!name) {
-    throw new AxiError("Variable name is required: gh-axi variable delete <name>", "VALIDATION_ERROR");
+    throw new AxiError(
+      "Variable name is required: gh-axi variable delete <name>",
+      "VALIDATION_ERROR",
+    );
   }
 
   await ghExec(["variable", "delete", name], ctx);
-  const suggestions = getSuggestions({ domain: "variable", action: "delete", id: name, repo: ctx });
-  return renderOutput([encode({ delete: "ok", variable: name }), renderHelp(suggestions)]);
+  const suggestions = getSuggestions({
+    domain: "variable",
+    action: "delete",
+    id: name,
+    repo: ctx,
+  });
+  return renderOutput([
+    encode({ delete: "ok", variable: name }),
+    renderHelp(suggestions),
+  ]);
 }
 
-export async function variableCommand(args: string[], ctx?: RepoContext): Promise<string> {
+export async function variableCommand(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
   const sub = args[0];
 
   if (sub === "--help" || sub === undefined) return VARIABLE_HELP;

--- a/src/commands/variable.ts
+++ b/src/commands/variable.ts
@@ -1,0 +1,95 @@
+import { encode } from "@toon-format/toon";
+import type { RepoContext } from "../context.js";
+import { ghJson, ghExec, ghExecWithStdin } from "../gh.js";
+import { AxiError } from "../errors.js";
+import { takeFlag } from "../args.js";
+import {
+  field,
+  relativeTime,
+  renderList,
+  renderHelp,
+  renderOutput,
+  renderError,
+  type FieldDef,
+} from "../toon.js";
+import { getSuggestions } from "../suggestions.js";
+import { resolveValue } from "../secretValue.js";
+
+export const VARIABLE_HELP = `usage: gh-axi variable <subcommand> [flags]
+subcommands[3]:
+  list, set <name>, delete <name>
+flags{set}:
+  --body/-b <value> (reads from stdin if omitted)
+examples:
+  gh-axi variable list
+  gh-axi variable set NODE_ENV --body production
+  echo -n "production" | gh-axi variable set NODE_ENV
+  gh-axi variable delete NODE_ENV`;
+
+const listSchema: FieldDef[] = [
+  field("name"),
+  field("value"),
+  relativeTime("updatedAt", "updated"),
+];
+
+async function listVariables(_args: string[], ctx?: RepoContext): Promise<string> {
+  const variables = await ghJson<Record<string, unknown>[]>(
+    ["variable", "list", "--json", "name,value,updatedAt"],
+    ctx,
+  );
+  const isEmpty = variables.length === 0;
+
+  const suggestions = getSuggestions({ domain: "variable", action: "list", isEmpty, repo: ctx });
+  return renderOutput([
+    `count: ${variables.length}`,
+    renderList("variables", variables, listSchema),
+    renderHelp(suggestions),
+  ]);
+}
+
+async function setVariable(args: string[], ctx?: RepoContext): Promise<string> {
+  const remaining = args.slice(1);
+  const flagValue = takeFlag(remaining, "--body") ?? takeFlag(remaining, "-b");
+  const positionals = remaining.filter((a) => !a.startsWith("-"));
+  const name = positionals[0];
+  if (!name) {
+    throw new AxiError("Variable name is required: gh-axi variable set <name>", "VALIDATION_ERROR");
+  }
+
+  const value = await resolveValue(flagValue, "variable");
+  await ghExecWithStdin(["variable", "set", name], value, ctx);
+
+  const suggestions = getSuggestions({ domain: "variable", action: "set", id: name, repo: ctx });
+  return renderOutput([encode({ set: "ok", variable: name }), renderHelp(suggestions)]);
+}
+
+async function deleteVariable(args: string[], ctx?: RepoContext): Promise<string> {
+  const positionals = args.filter((a) => !a.startsWith("-"));
+  const name = positionals[1];
+  if (!name) {
+    throw new AxiError("Variable name is required: gh-axi variable delete <name>", "VALIDATION_ERROR");
+  }
+
+  await ghExec(["variable", "delete", name], ctx);
+  const suggestions = getSuggestions({ domain: "variable", action: "delete", id: name, repo: ctx });
+  return renderOutput([encode({ delete: "ok", variable: name }), renderHelp(suggestions)]);
+}
+
+export async function variableCommand(args: string[], ctx?: RepoContext): Promise<string> {
+  const sub = args[0];
+
+  if (sub === "--help" || sub === undefined) return VARIABLE_HELP;
+
+  switch (sub) {
+    case "list":
+      return listVariables(args, ctx);
+    case "set":
+      return setVariable(args, ctx);
+    case "delete":
+      return deleteVariable(args, ctx);
+    default:
+      return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [
+        "Available subcommands: list, set, delete",
+      ]);
+  }
+}

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -19,16 +19,30 @@ function buildArgs(args: string[], ctx?: RepoContext): string[] {
 
 const MAX_BUFFER_BYTES = 10 * 1024 * 1024; // 10 MB
 
+function toExecResult(
+  resolve: (result: ExecResult) => void,
+): (error: Error | null, stdout: string, stderr: string) => void {
+  return (error, stdout, stderr) => {
+    if (error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+      resolve({ stdout: '', stderr: 'ENOENT', exitCode: 127 });
+      return;
+    }
+    const exitCode = error ? (error as Error & { code?: string | number }).code ?? 1 : 0;
+    resolve({ stdout: stdout ?? '', stderr: stderr ?? '', exitCode: typeof exitCode === 'number' ? exitCode : 1 });
+  };
+}
+
 function run(args: string[]): Promise<ExecResult> {
   return new Promise((resolve) => {
-    execFile('gh', args, { maxBuffer: MAX_BUFFER_BYTES }, (error, stdout, stderr) => {
-      if (error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
-        resolve({ stdout: '', stderr: 'ENOENT', exitCode: 127 });
-        return;
-      }
-      const exitCode = error ? (error as Error & { code?: string | number }).code ?? 1 : 0;
-      resolve({ stdout: stdout ?? '', stderr: stderr ?? '', exitCode: typeof exitCode === 'number' ? exitCode : 1 });
-    });
+    execFile('gh', args, { maxBuffer: MAX_BUFFER_BYTES }, toExecResult(resolve));
+  });
+}
+
+/** Run gh, writing `input` to the child process's stdin instead of the CLI's own. */
+function runWithStdin(args: string[], input: string): Promise<ExecResult> {
+  return new Promise((resolve) => {
+    const child = execFile('gh', args, { maxBuffer: MAX_BUFFER_BYTES }, toExecResult(resolve));
+    child.stdin?.end(input);
   });
 }
 
@@ -57,4 +71,15 @@ export async function ghRaw(args: string[], ctx?: RepoContext): Promise<ExecResu
   const result = await run(buildArgs(args, ctx));
   if (result.stderr === 'ENOENT') throw ghNotInstalledError();
   return result;
+}
+
+/**
+ * Execute gh, writing `input` to the child's stdin instead of a CLI flag.
+ * Keeps sensitive values (secret/variable bodies) out of the argv gh receives.
+ */
+export async function ghExecWithStdin(args: string[], input: string, ctx?: RepoContext): Promise<string> {
+  const result = await runWithStdin(buildArgs(args, ctx), input);
+  if (result.stderr === 'ENOENT') throw ghNotInstalledError();
+  if (result.exitCode !== 0) throw mapGhError(result.stderr, result.exitCode);
+  return result.stdout;
 }

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -1,6 +1,6 @@
-import { execFile } from 'node:child_process';
-import { type RepoContext } from './context.js';
-import { AxiError, ghNotInstalledError, mapGhError } from './errors.js';
+import { execFile } from "node:child_process";
+import { type RepoContext } from "./context.js";
+import { AxiError, ghNotInstalledError, mapGhError } from "./errors.js";
 
 export interface ExecResult {
   stdout: string;
@@ -11,8 +11,8 @@ export interface ExecResult {
 function buildArgs(args: string[], ctx?: RepoContext): string[] {
   const out = [...args];
   // Append --repo for flag/env sources (git remote is auto-detected by gh)
-  if (ctx && ctx.source !== 'git') {
-    out.push('--repo', ctx.nwo);
+  if (ctx && ctx.source !== "git") {
+    out.push("--repo", ctx.nwo);
   }
   return out;
 }
@@ -23,53 +23,81 @@ function toExecResult(
   resolve: (result: ExecResult) => void,
 ): (error: Error | null, stdout: string, stderr: string) => void {
   return (error, stdout, stderr) => {
-    if (error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
-      resolve({ stdout: '', stderr: 'ENOENT', exitCode: 127 });
+    if (error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+      resolve({ stdout: "", stderr: "ENOENT", exitCode: 127 });
       return;
     }
-    const exitCode = error ? (error as Error & { code?: string | number }).code ?? 1 : 0;
-    resolve({ stdout: stdout ?? '', stderr: stderr ?? '', exitCode: typeof exitCode === 'number' ? exitCode : 1 });
+    const exitCode = error
+      ? ((error as Error & { code?: string | number }).code ?? 1)
+      : 0;
+    resolve({
+      stdout: stdout ?? "",
+      stderr: stderr ?? "",
+      exitCode: typeof exitCode === "number" ? exitCode : 1,
+    });
   };
 }
 
 function run(args: string[]): Promise<ExecResult> {
   return new Promise((resolve) => {
-    execFile('gh', args, { maxBuffer: MAX_BUFFER_BYTES }, toExecResult(resolve));
+    execFile(
+      "gh",
+      args,
+      { maxBuffer: MAX_BUFFER_BYTES },
+      toExecResult(resolve),
+    );
   });
 }
 
 /** Run gh, writing `input` to the child process's stdin instead of the CLI's own. */
 function runWithStdin(args: string[], input: string): Promise<ExecResult> {
   return new Promise((resolve) => {
-    const child = execFile('gh', args, { maxBuffer: MAX_BUFFER_BYTES }, toExecResult(resolve));
+    const child = execFile(
+      "gh",
+      args,
+      { maxBuffer: MAX_BUFFER_BYTES },
+      toExecResult(resolve),
+    );
     child.stdin?.end(input);
   });
 }
 
 /** Execute gh and return parsed JSON. */
-export async function ghJson<T = unknown>(args: string[], ctx?: RepoContext): Promise<T> {
+export async function ghJson<T = unknown>(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<T> {
   const result = await run(buildArgs(args, ctx));
-  if (result.stderr === 'ENOENT') throw ghNotInstalledError();
+  if (result.stderr === "ENOENT") throw ghNotInstalledError();
   if (result.exitCode !== 0) throw mapGhError(result.stderr, result.exitCode);
   try {
     return JSON.parse(result.stdout);
   } catch {
-    throw new AxiError(`Unexpected gh output: ${result.stdout.slice(0, 200)}`, 'UNKNOWN');
+    throw new AxiError(
+      `Unexpected gh output: ${result.stdout.slice(0, 200)}`,
+      "UNKNOWN",
+    );
   }
 }
 
 /** Execute gh and return raw stdout. */
-export async function ghExec(args: string[], ctx?: RepoContext): Promise<string> {
+export async function ghExec(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
   const result = await run(buildArgs(args, ctx));
-  if (result.stderr === 'ENOENT') throw ghNotInstalledError();
+  if (result.stderr === "ENOENT") throw ghNotInstalledError();
   if (result.exitCode !== 0) throw mapGhError(result.stderr, result.exitCode);
   return result.stdout;
 }
 
 /** Execute gh, returning stdout + stderr without throwing on non-zero exit. */
-export async function ghRaw(args: string[], ctx?: RepoContext): Promise<ExecResult> {
+export async function ghRaw(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<ExecResult> {
   const result = await run(buildArgs(args, ctx));
-  if (result.stderr === 'ENOENT') throw ghNotInstalledError();
+  if (result.stderr === "ENOENT") throw ghNotInstalledError();
   return result;
 }
 
@@ -77,9 +105,13 @@ export async function ghRaw(args: string[], ctx?: RepoContext): Promise<ExecResu
  * Execute gh, writing `input` to the child's stdin instead of a CLI flag.
  * Keeps sensitive values (secret/variable bodies) out of the argv gh receives.
  */
-export async function ghExecWithStdin(args: string[], input: string, ctx?: RepoContext): Promise<string> {
+export async function ghExecWithStdin(
+  args: string[],
+  input: string,
+  ctx?: RepoContext,
+): Promise<string> {
   const result = await runWithStdin(buildArgs(args, ctx), input);
-  if (result.stderr === 'ENOENT') throw ghNotInstalledError();
+  if (result.stderr === "ENOENT") throw ghNotInstalledError();
   if (result.exitCode !== 0) throw mapGhError(result.stderr, result.exitCode);
   return result.stdout;
 }

--- a/src/secretValue.ts
+++ b/src/secretValue.ts
@@ -1,0 +1,41 @@
+import { AxiError } from "./errors.js";
+import { readStdin, isStdinTTY } from "./stdin.js";
+
+/**
+ * Resolve a secret/variable value from an already-extracted --body/-b flag,
+ * or from piped stdin — matching `gh secret set` / `gh variable set` semantics.
+ * Never accepts an interactive TTY prompt (AXI commands must not block on input).
+ */
+export async function resolveValue(
+  flagValue: string | undefined,
+  noun: "secret" | "variable",
+): Promise<string> {
+  if (flagValue !== undefined) {
+    if (flagValue.length === 0) {
+      throw new AxiError(`--body requires a value`, "VALIDATION_ERROR", [
+        `gh-axi ${noun} set <name> --body <value>`,
+      ]);
+    }
+    return flagValue;
+  }
+
+  if (isStdinTTY()) {
+    throw new AxiError(
+      `${noun} value is required: pass --body <value> or pipe the value via stdin`,
+      "VALIDATION_ERROR",
+      [
+        `gh-axi ${noun} set <name> --body <value>`,
+        `echo -n "<value>" | gh-axi ${noun} set <name>`,
+      ],
+    );
+  }
+
+  const value = await readStdin();
+  if (value.length === 0) {
+    throw new AxiError(
+      `${noun} value is required: pass --body <value> or pipe the value via stdin`,
+      "VALIDATION_ERROR",
+    );
+  }
+  return value;
+}

--- a/src/secretValue.ts
+++ b/src/secretValue.ts
@@ -1,16 +1,43 @@
 import { AxiError } from "./errors.js";
 import { readStdin, isStdinTTY } from "./stdin.js";
 
+function valueRequiredError(noun: "secret" | "variable"): AxiError {
+  if (noun === "secret") {
+    return new AxiError(
+      "secret value is required: pipe the value via stdin",
+      "VALIDATION_ERROR",
+      [`echo -n "<value>" | gh-axi secret set <name>`],
+    );
+  }
+
+  return new AxiError(
+    "variable value is required: pass --body <value> or pipe the value via stdin",
+    "VALIDATION_ERROR",
+    [
+      `gh-axi variable set <name> --body <value>`,
+      `echo -n "<value>" | gh-axi variable set <name>`,
+    ],
+  );
+}
+
 /**
- * Resolve a secret/variable value from an already-extracted --body/-b flag,
- * or from piped stdin — matching `gh secret set` / `gh variable set` semantics.
- * Never accepts an interactive TTY prompt (AXI commands must not block on input).
+ * Resolve a secret/variable value from an already-extracted flag value,
+ * or from piped stdin.
+ * Secret callers pass no flag value so secrets are stdin-only.
+ * Never accepts an interactive TTY prompt.
  */
 export async function resolveValue(
   flagValue: string | undefined,
   noun: "secret" | "variable",
 ): Promise<string> {
   if (flagValue !== undefined) {
+    if (noun === "secret") {
+      throw new AxiError(
+        "Secret values must be piped via stdin; --body/-b is not accepted for secrets",
+        "VALIDATION_ERROR",
+        [`echo -n "<value>" | gh-axi secret set <name>`],
+      );
+    }
     if (flagValue.length === 0) {
       throw new AxiError(`--body requires a value`, "VALIDATION_ERROR", [
         `gh-axi ${noun} set <name> --body <value>`,
@@ -20,22 +47,12 @@ export async function resolveValue(
   }
 
   if (isStdinTTY()) {
-    throw new AxiError(
-      `${noun} value is required: pass --body <value> or pipe the value via stdin`,
-      "VALIDATION_ERROR",
-      [
-        `gh-axi ${noun} set <name> --body <value>`,
-        `echo -n "<value>" | gh-axi ${noun} set <name>`,
-      ],
-    );
+    throw valueRequiredError(noun);
   }
 
   const value = await readStdin();
   if (value.length === 0) {
-    throw new AxiError(
-      `${noun} value is required: pass --body <value> or pipe the value via stdin`,
-      "VALIDATION_ERROR",
-    );
+    throw valueRequiredError(noun);
   }
   return value;
 }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -4,9 +4,9 @@ import { DESCRIPTION, TOP_HELP } from "./cli.js";
 // Kept terse and outcome-focused so it fires on "needs GitHub" intents.
 export const SKILL_DESCRIPTION =
   "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, " +
-  "releases, repositories, labels, search, and raw API access. Use whenever a task touches " +
-  "GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering " +
-  "workflows, cutting releases, or querying the GitHub API.";
+  "releases, repositories, labels, Actions secrets and variables, search, and raw API access. " +
+  "Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, " +
+  "checking CI runs, triggering workflows, cutting releases, or managing Actions secrets/variables.";
 
 export const SKILL_AUTHOR = "Kun Chen (kunchenguid)";
 
@@ -63,7 +63,7 @@ gh-axi requires the [\`gh\`](https://cli.github.com/) CLI installed and authenti
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
 
 ## Workflow
 

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -93,6 +93,9 @@ Run \`npx -y gh-axi --help\` for global flags, or \`npx -y gh-axi <command> --he
 - Truncated workflow logs keep the final 20,000 characters and may include a temp \`full_log\` path for targeted grep searches.
 - Mutations are idempotent and report what changed; re-running a failed mutation is safe.
 - For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass \`--body-file <path>\`; it works anywhere \`--body\` is accepted.
+- Secret values are stdin-only: \`echo -n "<value>" | npx -y gh-axi secret set <name>\`.
+- Do not pass secrets with \`--body\` or \`-b\`; flags are visible in the \`gh-axi\` process argv.
+- Variable values may use \`--body\`/\`-b\` or stdin because Actions variables are not secret.
 - Use \`api\` for anything the dedicated commands do not cover, e.g. \`npx -y gh-axi api repos/{owner}/{repo}/topics\`.
 `;
 }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -92,10 +92,11 @@ Run \`npx -y gh-axi --help\` for global flags, or \`npx -y gh-axi <command> --he
 - Output is TOON-encoded and token-efficient; pipe through grep/head only when a list is very long.
 - Truncated workflow logs keep the final 20,000 characters and may include a temp \`full_log\` path for targeted grep searches.
 - Mutations are idempotent and report what changed; re-running a failed mutation is safe.
-- For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass \`--body-file <path>\`; it works anywhere \`--body\` is accepted.
+- For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass \`--body-file <path>\` or the release \`--notes-file <path>\` alias on commands that support file-backed text.
 - Secret values are stdin-only: \`echo -n "<value>" | npx -y gh-axi secret set <name>\`.
 - Do not pass secrets with \`--body\` or \`-b\`; flags are visible in the \`gh-axi\` process argv.
 - Variable values may use \`--body\`/\`-b\` or stdin because Actions variables are not secret.
+- For multi-line variable values, pipe stdin to \`npx -y gh-axi variable set <name>\`; \`--body\`/\`-b\` is for inline values only.
 - Use \`api\` for anything the dedicated commands do not cover, e.g. \`npx -y gh-axi api repos/{owner}/{repo}/topics\`.
 `;
 }

--- a/src/stdin.ts
+++ b/src/stdin.ts
@@ -1,0 +1,17 @@
+/** Read all of this process's stdin as a UTF-8 string. */
+export function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+/** Whether stdin is an interactive terminal (no piped input available). */
+export function isStdinTTY(): boolean {
+  return Boolean(process.stdin.isTTY);
+}

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -479,14 +479,14 @@ const table: SuggestionEntry[] = [
   {
     match: (c) => c.domain === "secret" && c.action === "list" && !c.isEmpty,
     lines: (c) => [
-      `Run \`gh-axi${repoFlag(c)} secret set <name>\` to add or update a secret`,
+      `Run \`gh-axi secret set <name>${repoFlag(c)}\` to add or update a secret`,
     ],
   },
   {
     match: (c) =>
       c.domain === "secret" && c.action === "list" && c.isEmpty === true,
     lines: (c) => [
-      `Run \`echo -n "<value>" | gh-axi${repoFlag(c)} secret set <name>\` to add a secret`,
+      `Run \`echo -n "<value>" | gh-axi secret set <name>${repoFlag(c)}\` to add a secret`,
     ],
   },
 
@@ -494,13 +494,13 @@ const table: SuggestionEntry[] = [
   {
     match: (c) => c.domain === "secret" && c.action === "set",
     lines: (c) => [
-      `Run \`gh-axi${repoFlag(c)} secret list\` to see all secrets`,
+      `Run \`gh-axi secret list${repoFlag(c)}\` to see all secrets`,
     ],
   },
   {
     match: (c) => c.domain === "secret" && c.action === "delete",
     lines: (c) => [
-      `Run \`gh-axi${repoFlag(c)} secret list\` to see remaining secrets`,
+      `Run \`gh-axi secret list${repoFlag(c)}\` to see remaining secrets`,
     ],
   },
 
@@ -508,14 +508,14 @@ const table: SuggestionEntry[] = [
   {
     match: (c) => c.domain === "variable" && c.action === "list" && !c.isEmpty,
     lines: (c) => [
-      `Run \`gh-axi${repoFlag(c)} variable set <name> --body <value>\` to add or update a variable`,
+      `Run \`gh-axi variable set <name> --body <value>${repoFlag(c)}\` to add or update a variable`,
     ],
   },
   {
     match: (c) =>
       c.domain === "variable" && c.action === "list" && c.isEmpty === true,
     lines: (c) => [
-      `Run \`gh-axi${repoFlag(c)} variable set <name> --body <value>\` to add a variable`,
+      `Run \`gh-axi variable set <name> --body <value>${repoFlag(c)}\` to add a variable`,
     ],
   },
 
@@ -523,13 +523,13 @@ const table: SuggestionEntry[] = [
   {
     match: (c) => c.domain === "variable" && c.action === "set",
     lines: (c) => [
-      `Run \`gh-axi${repoFlag(c)} variable list\` to see all variables`,
+      `Run \`gh-axi variable list${repoFlag(c)}\` to see all variables`,
     ],
   },
   {
     match: (c) => c.domain === "variable" && c.action === "delete",
     lines: (c) => [
-      `Run \`gh-axi${repoFlag(c)} variable list\` to see remaining variables`,
+      `Run \`gh-axi variable list${repoFlag(c)}\` to see remaining variables`,
     ],
   },
 

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -479,7 +479,7 @@ const table: SuggestionEntry[] = [
   {
     match: (c) => c.domain === "secret" && c.action === "list" && !c.isEmpty,
     lines: (c) => [
-      `Run \`gh-axi secret set <name>${repoFlag(c)}\` to add or update a secret`,
+      `Run \`echo -n "<value>" | gh-axi secret set <name>${repoFlag(c)}\` to add or update a secret`,
     ],
   },
   {

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -27,7 +27,7 @@ const table: SuggestionEntry[] = [
   {
     match: (c) => c.domain === "home",
     lines: () => [
-      `Run \`gh-axi <command> <subcommand>\` — commands: issue, pr, run, release, repo, label`,
+      `Run \`gh-axi <command> <subcommand>\` — commands: issue, pr, run, release, repo, label, secret, variable`,
     ],
   },
 
@@ -472,6 +472,64 @@ const table: SuggestionEntry[] = [
     match: (c) => c.domain === "label" && c.action === "delete",
     lines: (c) => [
       `Run \`gh-axi${repoFlag(c)} label list\` to see remaining labels`,
+    ],
+  },
+
+  // Secret list
+  {
+    match: (c) => c.domain === "secret" && c.action === "list" && !c.isEmpty,
+    lines: (c) => [
+      `Run \`gh-axi${repoFlag(c)} secret set <name>\` to add or update a secret`,
+    ],
+  },
+  {
+    match: (c) =>
+      c.domain === "secret" && c.action === "list" && c.isEmpty === true,
+    lines: (c) => [
+      `Run \`echo -n "<value>" | gh-axi${repoFlag(c)} secret set <name>\` to add a secret`,
+    ],
+  },
+
+  // Secret set/delete
+  {
+    match: (c) => c.domain === "secret" && c.action === "set",
+    lines: (c) => [
+      `Run \`gh-axi${repoFlag(c)} secret list\` to see all secrets`,
+    ],
+  },
+  {
+    match: (c) => c.domain === "secret" && c.action === "delete",
+    lines: (c) => [
+      `Run \`gh-axi${repoFlag(c)} secret list\` to see remaining secrets`,
+    ],
+  },
+
+  // Variable list
+  {
+    match: (c) => c.domain === "variable" && c.action === "list" && !c.isEmpty,
+    lines: (c) => [
+      `Run \`gh-axi${repoFlag(c)} variable set <name> --body <value>\` to add or update a variable`,
+    ],
+  },
+  {
+    match: (c) =>
+      c.domain === "variable" && c.action === "list" && c.isEmpty === true,
+    lines: (c) => [
+      `Run \`gh-axi${repoFlag(c)} variable set <name> --body <value>\` to add a variable`,
+    ],
+  },
+
+  // Variable set/delete
+  {
+    match: (c) => c.domain === "variable" && c.action === "set",
+    lines: (c) => [
+      `Run \`gh-axi${repoFlag(c)} variable list\` to see all variables`,
+    ],
+  },
+  {
+    match: (c) => c.domain === "variable" && c.action === "delete",
+    lines: (c) => [
+      `Run \`gh-axi${repoFlag(c)} variable list\` to see remaining variables`,
     ],
   },
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -47,6 +47,14 @@ vi.mock("../src/commands/label.js", () => ({
   labelCommand: vi.fn().mockResolvedValue("label output"),
   LABEL_HELP: "label help",
 }));
+vi.mock("../src/commands/secret.js", () => ({
+  secretCommand: vi.fn().mockResolvedValue("secret output"),
+  SECRET_HELP: "secret help",
+}));
+vi.mock("../src/commands/variable.js", () => ({
+  variableCommand: vi.fn().mockResolvedValue("variable output"),
+  VARIABLE_HELP: "variable help",
+}));
 vi.mock("../src/commands/search.js", () => ({
   searchCommand: vi.fn().mockResolvedValue("search output"),
   SEARCH_HELP: "search help",
@@ -185,7 +193,48 @@ describe("main CLI", () => {
 
     const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
     expect(options.getCommandHelp("issue")).toBe("issue help");
+    expect(options.getCommandHelp("secret")).toBe("secret help");
+    expect(options.getCommandHelp("variable")).toBe("variable help");
     expect(options.getCommandHelp("missing")).toBeUndefined();
+  });
+
+  it("lists secret and variable in the top-level command index", () => {
+    expect(TOP_HELP).toContain("secret");
+    expect(TOP_HELP).toContain("variable");
+  });
+
+  it("strips -R before invoking the secret handler", async () => {
+    await main();
+
+    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+    const ctx = {
+      owner: "octo",
+      name: "repo",
+      nwo: "octo/repo",
+      source: "flag",
+    };
+
+    await options.commands.secret(["list", "-R", "owner/name"], ctx);
+
+    const { secretCommand } = await import("../src/commands/secret.js");
+    expect(vi.mocked(secretCommand)).toHaveBeenCalledWith(["list"], ctx);
+  });
+
+  it("strips -R before invoking the variable handler", async () => {
+    await main();
+
+    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+    const ctx = {
+      owner: "octo",
+      name: "repo",
+      nwo: "octo/repo",
+      source: "flag",
+    };
+
+    await options.commands.variable(["list", "-R", "owner/name"], ctx);
+
+    const { variableCommand } = await import("../src/commands/variable.js");
+    expect(vi.mocked(variableCommand)).toHaveBeenCalledWith(["list"], ctx);
   });
 
   it("resolves repo context lazily from -R after the command", async () => {

--- a/test/commands/secret.test.ts
+++ b/test/commands/secret.test.ts
@@ -1,0 +1,138 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('../../src/gh.js', () => ({
+  ghJson: vi.fn(),
+  ghExec: vi.fn(),
+  ghExecWithStdin: vi.fn(),
+}));
+
+vi.mock('../../src/secretValue.js', () => ({
+  resolveValue: vi.fn(),
+}));
+
+import { ghJson, ghExec, ghExecWithStdin } from '../../src/gh.js';
+import { resolveValue } from '../../src/secretValue.js';
+import { secretCommand, SECRET_HELP } from '../../src/commands/secret.js';
+import { AxiError } from '../../src/errors.js';
+
+const mockedGhJson = vi.mocked(ghJson);
+const mockedGhExec = vi.mocked(ghExec);
+const mockedGhExecWithStdin = vi.mocked(ghExecWithStdin);
+const mockedResolveValue = vi.mocked(resolveValue);
+
+describe('secretCommand', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('router', () => {
+    it('returns help when --help is passed', async () => {
+      const result = await secretCommand(['--help']);
+      expect(result).toBe(SECRET_HELP);
+    });
+
+    it('returns help when no subcommand is given', async () => {
+      const result = await secretCommand([]);
+      expect(result).toBe(SECRET_HELP);
+    });
+
+    it('returns error for unknown subcommand', async () => {
+      const result = await secretCommand(['unknown']);
+      expect(result).toContain('Unknown subcommand: unknown');
+    });
+  });
+
+  describe('list', () => {
+    it('returns secret names without values', async () => {
+      mockedGhJson.mockResolvedValue([
+        { name: 'API_KEY', updatedAt: '2024-01-01T00:00:00Z' },
+        { name: 'DB_PASSWORD', updatedAt: '2024-01-02T00:00:00Z' },
+      ]);
+
+      const result = await secretCommand(['list']);
+
+      expect(result).toContain('API_KEY');
+      expect(result).toContain('DB_PASSWORD');
+      expect(result).toContain('count: 2');
+      expect(mockedGhJson).toHaveBeenCalledWith(
+        ['secret', 'list', '--json', 'name,updatedAt'],
+        undefined,
+      );
+    });
+
+    it('never requests or renders a value field', async () => {
+      mockedGhJson.mockResolvedValue([{ name: 'API_KEY', updatedAt: '2024-01-01T00:00:00Z' }]);
+
+      await secretCommand(['list']);
+
+      const [ghArgs] = mockedGhJson.mock.calls[0];
+      expect(ghArgs).not.toContain('value');
+      expect(ghArgs.join(' ')).not.toMatch(/\bvalue\b/);
+    });
+  });
+
+  describe('set', () => {
+    it('sets a secret from a resolved value and writes it via stdin, not argv', async () => {
+      mockedResolveValue.mockResolvedValue('super-secret');
+      mockedGhExecWithStdin.mockResolvedValue('');
+
+      const result = await secretCommand(['set', 'API_KEY', '--body', 'super-secret']);
+
+      expect(result).toContain('set');
+      expect(result).toContain('ok');
+      expect(result).toContain('API_KEY');
+      expect(result).not.toContain('super-secret');
+      expect(mockedResolveValue).toHaveBeenCalledWith('super-secret', 'secret');
+      expect(mockedGhExecWithStdin).toHaveBeenCalledWith(
+        ['secret', 'set', 'API_KEY'],
+        'super-secret',
+        undefined,
+      );
+    });
+
+    it('extracts -b as an alias for --body before resolving positionals', async () => {
+      mockedResolveValue.mockResolvedValue('shh');
+      mockedGhExecWithStdin.mockResolvedValue('');
+
+      await secretCommand(['set', 'API_KEY', '-b', 'shh']);
+
+      expect(mockedResolveValue).toHaveBeenCalledWith('shh', 'secret');
+      expect(mockedGhExecWithStdin).toHaveBeenCalledWith(
+        ['secret', 'set', 'API_KEY'],
+        'shh',
+        undefined,
+      );
+    });
+
+    it('throws when secret name is missing', async () => {
+      await expect(secretCommand(['set'])).rejects.toThrow(AxiError);
+      expect(mockedResolveValue).not.toHaveBeenCalled();
+    });
+
+    it('propagates errors from value resolution (e.g. missing stdin)', async () => {
+      mockedResolveValue.mockRejectedValue(
+        new AxiError('secret value is required: pass --body <value> or pipe the value via stdin', 'VALIDATION_ERROR'),
+      );
+
+      await expect(secretCommand(['set', 'API_KEY'])).rejects.toThrow(AxiError);
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes a secret by name', async () => {
+      mockedGhExec.mockResolvedValue('');
+
+      const result = await secretCommand(['delete', 'API_KEY']);
+
+      expect(result).toContain('delete');
+      expect(result).toContain('ok');
+      expect(result).toContain('API_KEY');
+      expect(mockedGhExec).toHaveBeenCalledWith(['secret', 'delete', 'API_KEY'], undefined);
+    });
+
+    it('throws when secret name is missing', async () => {
+      await expect(secretCommand(['delete'])).rejects.toThrow(AxiError);
+    });
+  });
+});

--- a/test/commands/secret.test.ts
+++ b/test/commands/secret.test.ts
@@ -1,138 +1,146 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from "vitest";
 
-vi.mock('../../src/gh.js', () => ({
+vi.mock("../../src/gh.js", () => ({
   ghJson: vi.fn(),
   ghExec: vi.fn(),
   ghExecWithStdin: vi.fn(),
 }));
 
-vi.mock('../../src/secretValue.js', () => ({
+vi.mock("../../src/secretValue.js", () => ({
   resolveValue: vi.fn(),
 }));
 
-import { ghJson, ghExec, ghExecWithStdin } from '../../src/gh.js';
-import { resolveValue } from '../../src/secretValue.js';
-import { secretCommand, SECRET_HELP } from '../../src/commands/secret.js';
-import { AxiError } from '../../src/errors.js';
+import { ghJson, ghExec, ghExecWithStdin } from "../../src/gh.js";
+import { resolveValue } from "../../src/secretValue.js";
+import { secretCommand, SECRET_HELP } from "../../src/commands/secret.js";
+import { AxiError } from "../../src/errors.js";
 
 const mockedGhJson = vi.mocked(ghJson);
 const mockedGhExec = vi.mocked(ghExec);
 const mockedGhExecWithStdin = vi.mocked(ghExecWithStdin);
 const mockedResolveValue = vi.mocked(resolveValue);
 
-describe('secretCommand', () => {
+describe("secretCommand", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  describe('router', () => {
-    it('returns help when --help is passed', async () => {
-      const result = await secretCommand(['--help']);
+  describe("router", () => {
+    it("returns help when --help is passed", async () => {
+      const result = await secretCommand(["--help"]);
       expect(result).toBe(SECRET_HELP);
     });
 
-    it('returns help when no subcommand is given', async () => {
+    it("returns help when no subcommand is given", async () => {
       const result = await secretCommand([]);
       expect(result).toBe(SECRET_HELP);
     });
 
-    it('returns error for unknown subcommand', async () => {
-      const result = await secretCommand(['unknown']);
-      expect(result).toContain('Unknown subcommand: unknown');
+    it("returns error for unknown subcommand", async () => {
+      const result = await secretCommand(["unknown"]);
+      expect(result).toContain("Unknown subcommand: unknown");
     });
   });
 
-  describe('list', () => {
-    it('returns secret names without values', async () => {
+  describe("list", () => {
+    it("returns secret names without values", async () => {
       mockedGhJson.mockResolvedValue([
-        { name: 'API_KEY', updatedAt: '2024-01-01T00:00:00Z' },
-        { name: 'DB_PASSWORD', updatedAt: '2024-01-02T00:00:00Z' },
+        { name: "API_KEY", updatedAt: "2024-01-01T00:00:00Z" },
+        { name: "DB_PASSWORD", updatedAt: "2024-01-02T00:00:00Z" },
       ]);
 
-      const result = await secretCommand(['list']);
+      const result = await secretCommand(["list"]);
 
-      expect(result).toContain('API_KEY');
-      expect(result).toContain('DB_PASSWORD');
-      expect(result).toContain('count: 2');
+      expect(result).toContain("API_KEY");
+      expect(result).toContain("DB_PASSWORD");
+      expect(result).toContain("count: 2");
       expect(mockedGhJson).toHaveBeenCalledWith(
-        ['secret', 'list', '--json', 'name,updatedAt'],
+        ["secret", "list", "--json", "name,updatedAt"],
         undefined,
       );
     });
 
-    it('never requests or renders a value field', async () => {
-      mockedGhJson.mockResolvedValue([{ name: 'API_KEY', updatedAt: '2024-01-01T00:00:00Z' }]);
+    it("never requests or renders a value field", async () => {
+      mockedGhJson.mockResolvedValue([
+        { name: "API_KEY", updatedAt: "2024-01-01T00:00:00Z" },
+      ]);
 
-      await secretCommand(['list']);
+      await secretCommand(["list"]);
 
       const [ghArgs] = mockedGhJson.mock.calls[0];
-      expect(ghArgs).not.toContain('value');
-      expect(ghArgs.join(' ')).not.toMatch(/\bvalue\b/);
+      expect(ghArgs).not.toContain("value");
+      expect(ghArgs.join(" ")).not.toMatch(/\bvalue\b/);
     });
   });
 
-  describe('set', () => {
-    it('sets a secret from a resolved value and writes it via stdin, not argv', async () => {
-      mockedResolveValue.mockResolvedValue('super-secret');
-      mockedGhExecWithStdin.mockResolvedValue('');
+  describe("set", () => {
+    it("sets a secret from stdin-only value resolution and writes it via stdin, not argv", async () => {
+      mockedResolveValue.mockResolvedValue("super-secret");
+      mockedGhExecWithStdin.mockResolvedValue("");
 
-      const result = await secretCommand(['set', 'API_KEY', '--body', 'super-secret']);
+      const result = await secretCommand(["set", "API_KEY"]);
 
-      expect(result).toContain('set');
-      expect(result).toContain('ok');
-      expect(result).toContain('API_KEY');
-      expect(result).not.toContain('super-secret');
-      expect(mockedResolveValue).toHaveBeenCalledWith('super-secret', 'secret');
+      expect(result).toContain("set");
+      expect(result).toContain("ok");
+      expect(result).toContain("API_KEY");
+      expect(result).not.toContain("super-secret");
+      expect(mockedResolveValue).toHaveBeenCalledWith(undefined, "secret");
       expect(mockedGhExecWithStdin).toHaveBeenCalledWith(
-        ['secret', 'set', 'API_KEY'],
-        'super-secret',
+        ["secret", "set", "API_KEY"],
+        "super-secret",
         undefined,
       );
     });
 
-    it('extracts -b as an alias for --body before resolving positionals', async () => {
-      mockedResolveValue.mockResolvedValue('shh');
-      mockedGhExecWithStdin.mockResolvedValue('');
+    it.each([
+      ["--body", "super-secret"],
+      ["--body=super-secret"],
+      ["-b", "super-secret"],
+      ["-b=super-secret"],
+    ])("rejects unsupported secret body flag form %s", async (...flagArgs) => {
+      await expect(
+        secretCommand(["set", "API_KEY", ...flagArgs]),
+      ).rejects.toThrow("--body/-b is not accepted");
 
-      await secretCommand(['set', 'API_KEY', '-b', 'shh']);
-
-      expect(mockedResolveValue).toHaveBeenCalledWith('shh', 'secret');
-      expect(mockedGhExecWithStdin).toHaveBeenCalledWith(
-        ['secret', 'set', 'API_KEY'],
-        'shh',
-        undefined,
-      );
+      expect(mockedResolveValue).not.toHaveBeenCalled();
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
     });
 
-    it('throws when secret name is missing', async () => {
-      await expect(secretCommand(['set'])).rejects.toThrow(AxiError);
+    it("throws when secret name is missing", async () => {
+      await expect(secretCommand(["set"])).rejects.toThrow(AxiError);
       expect(mockedResolveValue).not.toHaveBeenCalled();
     });
 
-    it('propagates errors from value resolution (e.g. missing stdin)', async () => {
+    it("propagates errors from value resolution (e.g. missing stdin)", async () => {
       mockedResolveValue.mockRejectedValue(
-        new AxiError('secret value is required: pass --body <value> or pipe the value via stdin', 'VALIDATION_ERROR'),
+        new AxiError(
+          "secret value is required: pipe the value via stdin",
+          "VALIDATION_ERROR",
+        ),
       );
 
-      await expect(secretCommand(['set', 'API_KEY'])).rejects.toThrow(AxiError);
+      await expect(secretCommand(["set", "API_KEY"])).rejects.toThrow(AxiError);
       expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
     });
   });
 
-  describe('delete', () => {
-    it('deletes a secret by name', async () => {
-      mockedGhExec.mockResolvedValue('');
+  describe("delete", () => {
+    it("deletes a secret by name", async () => {
+      mockedGhExec.mockResolvedValue("");
 
-      const result = await secretCommand(['delete', 'API_KEY']);
+      const result = await secretCommand(["delete", "API_KEY"]);
 
-      expect(result).toContain('delete');
-      expect(result).toContain('ok');
-      expect(result).toContain('API_KEY');
-      expect(mockedGhExec).toHaveBeenCalledWith(['secret', 'delete', 'API_KEY'], undefined);
+      expect(result).toContain("delete");
+      expect(result).toContain("ok");
+      expect(result).toContain("API_KEY");
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["secret", "delete", "API_KEY"],
+        undefined,
+      );
     });
 
-    it('throws when secret name is missing', async () => {
-      await expect(secretCommand(['delete'])).rejects.toThrow(AxiError);
+    it("throws when secret name is missing", async () => {
+      await expect(secretCommand(["delete"])).rejects.toThrow(AxiError);
     });
   });
 });

--- a/test/commands/variable.test.ts
+++ b/test/commands/variable.test.ts
@@ -1,0 +1,103 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('../../src/gh.js', () => ({
+  ghJson: vi.fn(),
+  ghExec: vi.fn(),
+  ghExecWithStdin: vi.fn(),
+}));
+
+vi.mock('../../src/secretValue.js', () => ({
+  resolveValue: vi.fn(),
+}));
+
+import { ghJson, ghExec, ghExecWithStdin } from '../../src/gh.js';
+import { resolveValue } from '../../src/secretValue.js';
+import { variableCommand, VARIABLE_HELP } from '../../src/commands/variable.js';
+import { AxiError } from '../../src/errors.js';
+
+const mockedGhJson = vi.mocked(ghJson);
+const mockedGhExec = vi.mocked(ghExec);
+const mockedGhExecWithStdin = vi.mocked(ghExecWithStdin);
+const mockedResolveValue = vi.mocked(resolveValue);
+
+describe('variableCommand', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('router', () => {
+    it('returns help when --help is passed', async () => {
+      const result = await variableCommand(['--help']);
+      expect(result).toBe(VARIABLE_HELP);
+    });
+
+    it('returns help when no subcommand is given', async () => {
+      const result = await variableCommand([]);
+      expect(result).toBe(VARIABLE_HELP);
+    });
+
+    it('returns error for unknown subcommand', async () => {
+      const result = await variableCommand(['unknown']);
+      expect(result).toContain('Unknown subcommand: unknown');
+    });
+  });
+
+  describe('list', () => {
+    it('returns variable names and values', async () => {
+      mockedGhJson.mockResolvedValue([
+        { name: 'NODE_ENV', value: 'production', updatedAt: '2024-01-01T00:00:00Z' },
+      ]);
+
+      const result = await variableCommand(['list']);
+
+      expect(result).toContain('NODE_ENV');
+      expect(result).toContain('production');
+      expect(result).toContain('count: 1');
+      expect(mockedGhJson).toHaveBeenCalledWith(
+        ['variable', 'list', '--json', 'name,value,updatedAt'],
+        undefined,
+      );
+    });
+  });
+
+  describe('set', () => {
+    it('sets a variable from a resolved value and writes it via stdin', async () => {
+      mockedResolveValue.mockResolvedValue('production');
+      mockedGhExecWithStdin.mockResolvedValue('');
+
+      const result = await variableCommand(['set', 'NODE_ENV', '--body', 'production']);
+
+      expect(result).toContain('set');
+      expect(result).toContain('ok');
+      expect(result).toContain('NODE_ENV');
+      expect(mockedResolveValue).toHaveBeenCalledWith('production', 'variable');
+      expect(mockedGhExecWithStdin).toHaveBeenCalledWith(
+        ['variable', 'set', 'NODE_ENV'],
+        'production',
+        undefined,
+      );
+    });
+
+    it('throws when variable name is missing', async () => {
+      await expect(variableCommand(['set'])).rejects.toThrow(AxiError);
+      expect(mockedResolveValue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes a variable by name', async () => {
+      mockedGhExec.mockResolvedValue('');
+
+      const result = await variableCommand(['delete', 'NODE_ENV']);
+
+      expect(result).toContain('delete');
+      expect(result).toContain('ok');
+      expect(result).toContain('NODE_ENV');
+      expect(mockedGhExec).toHaveBeenCalledWith(['variable', 'delete', 'NODE_ENV'], undefined);
+    });
+
+    it('throws when variable name is missing', async () => {
+      await expect(variableCommand(['delete'])).rejects.toThrow(AxiError);
+    });
+  });
+});

--- a/test/commands/variable.test.ts
+++ b/test/commands/variable.test.ts
@@ -1,103 +1,115 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from "vitest";
 
-vi.mock('../../src/gh.js', () => ({
+vi.mock("../../src/gh.js", () => ({
   ghJson: vi.fn(),
   ghExec: vi.fn(),
   ghExecWithStdin: vi.fn(),
 }));
 
-vi.mock('../../src/secretValue.js', () => ({
+vi.mock("../../src/secretValue.js", () => ({
   resolveValue: vi.fn(),
 }));
 
-import { ghJson, ghExec, ghExecWithStdin } from '../../src/gh.js';
-import { resolveValue } from '../../src/secretValue.js';
-import { variableCommand, VARIABLE_HELP } from '../../src/commands/variable.js';
-import { AxiError } from '../../src/errors.js';
+import { ghJson, ghExec, ghExecWithStdin } from "../../src/gh.js";
+import { resolveValue } from "../../src/secretValue.js";
+import { variableCommand, VARIABLE_HELP } from "../../src/commands/variable.js";
+import { AxiError } from "../../src/errors.js";
 
 const mockedGhJson = vi.mocked(ghJson);
 const mockedGhExec = vi.mocked(ghExec);
 const mockedGhExecWithStdin = vi.mocked(ghExecWithStdin);
 const mockedResolveValue = vi.mocked(resolveValue);
 
-describe('variableCommand', () => {
+describe("variableCommand", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  describe('router', () => {
-    it('returns help when --help is passed', async () => {
-      const result = await variableCommand(['--help']);
+  describe("router", () => {
+    it("returns help when --help is passed", async () => {
+      const result = await variableCommand(["--help"]);
       expect(result).toBe(VARIABLE_HELP);
     });
 
-    it('returns help when no subcommand is given', async () => {
+    it("returns help when no subcommand is given", async () => {
       const result = await variableCommand([]);
       expect(result).toBe(VARIABLE_HELP);
     });
 
-    it('returns error for unknown subcommand', async () => {
-      const result = await variableCommand(['unknown']);
-      expect(result).toContain('Unknown subcommand: unknown');
+    it("returns error for unknown subcommand", async () => {
+      const result = await variableCommand(["unknown"]);
+      expect(result).toContain("Unknown subcommand: unknown");
     });
   });
 
-  describe('list', () => {
-    it('returns variable names and values', async () => {
+  describe("list", () => {
+    it("returns variable names and values", async () => {
       mockedGhJson.mockResolvedValue([
-        { name: 'NODE_ENV', value: 'production', updatedAt: '2024-01-01T00:00:00Z' },
+        {
+          name: "NODE_ENV",
+          value: "production",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
       ]);
 
-      const result = await variableCommand(['list']);
+      const result = await variableCommand(["list"]);
 
-      expect(result).toContain('NODE_ENV');
-      expect(result).toContain('production');
-      expect(result).toContain('count: 1');
+      expect(result).toContain("NODE_ENV");
+      expect(result).toContain("production");
+      expect(result).toContain("count: 1");
       expect(mockedGhJson).toHaveBeenCalledWith(
-        ['variable', 'list', '--json', 'name,value,updatedAt'],
+        ["variable", "list", "--json", "name,value,updatedAt"],
         undefined,
       );
     });
   });
 
-  describe('set', () => {
-    it('sets a variable from a resolved value and writes it via stdin', async () => {
-      mockedResolveValue.mockResolvedValue('production');
-      mockedGhExecWithStdin.mockResolvedValue('');
+  describe("set", () => {
+    it("sets a variable from a resolved value and writes it via stdin", async () => {
+      mockedResolveValue.mockResolvedValue("production");
+      mockedGhExecWithStdin.mockResolvedValue("");
 
-      const result = await variableCommand(['set', 'NODE_ENV', '--body', 'production']);
+      const result = await variableCommand([
+        "set",
+        "NODE_ENV",
+        "--body",
+        "production",
+      ]);
 
-      expect(result).toContain('set');
-      expect(result).toContain('ok');
-      expect(result).toContain('NODE_ENV');
-      expect(mockedResolveValue).toHaveBeenCalledWith('production', 'variable');
+      expect(result).toContain("set");
+      expect(result).toContain("ok");
+      expect(result).toContain("NODE_ENV");
+      expect(mockedResolveValue).toHaveBeenCalledWith("production", "variable");
       expect(mockedGhExecWithStdin).toHaveBeenCalledWith(
-        ['variable', 'set', 'NODE_ENV'],
-        'production',
+        ["variable", "set", "NODE_ENV"],
+        "production",
         undefined,
       );
     });
 
-    it('throws when variable name is missing', async () => {
-      await expect(variableCommand(['set'])).rejects.toThrow(AxiError);
+    it("throws when variable name is missing", async () => {
+      await expect(variableCommand(["set"])).rejects.toThrow(AxiError);
       expect(mockedResolveValue).not.toHaveBeenCalled();
     });
   });
 
-  describe('delete', () => {
-    it('deletes a variable by name', async () => {
-      mockedGhExec.mockResolvedValue('');
+  describe("delete", () => {
+    it("deletes a variable by name", async () => {
+      mockedGhExec.mockResolvedValue("");
 
-      const result = await variableCommand(['delete', 'NODE_ENV']);
+      const result = await variableCommand(["delete", "NODE_ENV"]);
 
-      expect(result).toContain('delete');
-      expect(result).toContain('ok');
-      expect(result).toContain('NODE_ENV');
-      expect(mockedGhExec).toHaveBeenCalledWith(['variable', 'delete', 'NODE_ENV'], undefined);
+      expect(result).toContain("delete");
+      expect(result).toContain("ok");
+      expect(result).toContain("NODE_ENV");
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["variable", "delete", "NODE_ENV"],
+        undefined,
+      );
     });
 
-    it('throws when variable name is missing', async () => {
-      await expect(variableCommand(['delete'])).rejects.toThrow(AxiError);
+    it("throws when variable name is missing", async () => {
+      await expect(variableCommand(["delete"])).rejects.toThrow(AxiError);
     });
   });
 });

--- a/test/gh.test.ts
+++ b/test/gh.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { execFile } from "node:child_process";
-import { ghJson, ghExec, ghRaw } from "../src/gh.js";
+import { ghJson, ghExec, ghRaw, ghExecWithStdin } from "../src/gh.js";
 import type { RepoContext } from "../src/context.js";
 import { AxiError } from "../src/errors.js";
 
@@ -25,6 +25,22 @@ function mockExecFileResult(
     (callback as ExecFileCallback)(error, stdout, stderr);
     return {} as ReturnType<typeof execFile>;
   });
+}
+
+/** Helper to make mockedExecFile call its callback and capture what was written to child.stdin. */
+function mockExecFileResultWithStdin(
+  error: (Error & { code?: string | number }) | null,
+  stdout: string,
+  stderr: string,
+) {
+  const stdinEnd = vi.fn();
+  mockedExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+    (callback as ExecFileCallback)(error, stdout, stderr);
+    return { stdin: { end: stdinEnd } } as unknown as ReturnType<
+      typeof execFile
+    >;
+  });
+  return stdinEnd;
 }
 
 /** Helper to simulate ENOENT (gh not installed). */
@@ -218,5 +234,63 @@ describe("ghRaw", () => {
     const callArgs = mockedExecFile.mock.calls[0][1] as string[];
     expect(callArgs).toContain("--repo");
     expect(callArgs).toContain("o/r");
+  });
+});
+
+describe("ghExecWithStdin", () => {
+  beforeEach(() => {
+    mockedExecFile.mockReset();
+  });
+
+  it("writes input to the child process stdin and returns stdout", async () => {
+    const stdinEnd = mockExecFileResultWithStdin(null, "ok", "");
+    const result = await ghExecWithStdin(["secret", "set", "FOO"], "shh");
+    expect(result).toBe("ok");
+    expect(stdinEnd).toHaveBeenCalledWith("shh");
+  });
+
+  it("never passes the input value as a CLI argument", async () => {
+    mockExecFileResultWithStdin(null, "ok", "");
+    await ghExecWithStdin(["secret", "set", "FOO"], "super-secret-value");
+    const callArgs = mockedExecFile.mock.calls[0][1] as string[];
+    expect(callArgs).not.toContain("super-secret-value");
+  });
+
+  it("throws on non-zero exit code", async () => {
+    const error = new Error("exit 1") as Error & { code: number };
+    error.code = 1;
+    mockExecFileResultWithStdin(error, "", "HTTP 403: Forbidden");
+    await expect(
+      ghExecWithStdin(["secret", "set", "FOO"], "shh"),
+    ).rejects.toThrow(AxiError);
+  });
+
+  it("throws ghNotInstalledError on ENOENT", async () => {
+    const stdinEnd = vi.fn();
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      const err = new Error("spawn gh ENOENT") as Error & { code: string };
+      err.code = "ENOENT";
+      (callback as ExecFileCallback)(err, "", "");
+      return { stdin: { end: stdinEnd } } as unknown as ReturnType<
+        typeof execFile
+      >;
+    });
+    await expect(
+      ghExecWithStdin(["secret", "set", "FOO"], "shh"),
+    ).rejects.toThrow(AxiError);
+  });
+
+  it("appends --repo for non-git sources", async () => {
+    const stdinEnd = mockExecFileResultWithStdin(null, "ok", "");
+    const ctx: RepoContext = {
+      owner: "cli",
+      name: "cli",
+      nwo: "cli/cli",
+      source: "flag",
+    };
+    await ghExecWithStdin(["secret", "set", "FOO"], "shh", ctx);
+    const callArgs = mockedExecFile.mock.calls[0][1] as string[];
+    expect(callArgs).toEqual(["secret", "set", "FOO", "--repo", "cli/cli"]);
+    expect(stdinEnd).toHaveBeenCalledWith("shh");
   });
 });

--- a/test/help-examples.test.ts
+++ b/test/help-examples.test.ts
@@ -6,6 +6,8 @@ import { WORKFLOW_HELP } from "../src/commands/workflow.js";
 import { RELEASE_HELP } from "../src/commands/release.js";
 import { REPO_HELP } from "../src/commands/repo.js";
 import { LABEL_HELP } from "../src/commands/label.js";
+import { SECRET_HELP } from "../src/commands/secret.js";
+import { VARIABLE_HELP } from "../src/commands/variable.js";
 import { SEARCH_HELP } from "../src/commands/search.js";
 import { API_HELP } from "../src/commands/api.js";
 import { TOP_HELP } from "../src/cli.js";
@@ -49,6 +51,8 @@ describe("Help output includes examples for every command family", () => {
   assertHelpHasExamples("RELEASE_HELP", RELEASE_HELP);
   assertHelpHasExamples("REPO_HELP", REPO_HELP);
   assertHelpHasExamples("LABEL_HELP", LABEL_HELP);
+  assertHelpHasExamples("SECRET_HELP", SECRET_HELP);
+  assertHelpHasExamples("VARIABLE_HELP", VARIABLE_HELP);
   assertHelpHasExamples("SEARCH_HELP", SEARCH_HELP);
   assertHelpHasExamples("API_HELP", API_HELP);
 });

--- a/test/secretValue.test.ts
+++ b/test/secretValue.test.ts
@@ -1,0 +1,54 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('../src/stdin.js', () => ({
+  readStdin: vi.fn(),
+  isStdinTTY: vi.fn(),
+}));
+
+import { readStdin, isStdinTTY } from '../src/stdin.js';
+import { resolveValue } from '../src/secretValue.js';
+import { AxiError } from '../src/errors.js';
+
+const mockedReadStdin = vi.mocked(readStdin);
+const mockedIsStdinTTY = vi.mocked(isStdinTTY);
+
+describe('resolveValue', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns the flag value without touching stdin when provided', async () => {
+    const value = await resolveValue('sk-flag-value', 'secret');
+    expect(value).toBe('sk-flag-value');
+    expect(mockedReadStdin).not.toHaveBeenCalled();
+    expect(mockedIsStdinTTY).not.toHaveBeenCalled();
+  });
+
+  it('throws when the flag value is empty', async () => {
+    await expect(resolveValue('', 'secret')).rejects.toThrow(AxiError);
+  });
+
+  it('reads from stdin when no flag value is given and stdin is piped', async () => {
+    mockedIsStdinTTY.mockReturnValue(false);
+    mockedReadStdin.mockResolvedValue('piped-value');
+
+    const value = await resolveValue(undefined, 'variable');
+
+    expect(value).toBe('piped-value');
+    expect(mockedReadStdin).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws instead of blocking when stdin is an interactive TTY', async () => {
+    mockedIsStdinTTY.mockReturnValue(true);
+
+    await expect(resolveValue(undefined, 'secret')).rejects.toThrow(AxiError);
+    expect(mockedReadStdin).not.toHaveBeenCalled();
+  });
+
+  it('throws when piped stdin is empty', async () => {
+    mockedIsStdinTTY.mockReturnValue(false);
+    mockedReadStdin.mockResolvedValue('');
+
+    await expect(resolveValue(undefined, 'secret')).rejects.toThrow(AxiError);
+  });
+});

--- a/test/secretValue.test.ts
+++ b/test/secretValue.test.ts
@@ -1,54 +1,81 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from "vitest";
 
-vi.mock('../src/stdin.js', () => ({
+vi.mock("../src/stdin.js", () => ({
   readStdin: vi.fn(),
   isStdinTTY: vi.fn(),
 }));
 
-import { readStdin, isStdinTTY } from '../src/stdin.js';
-import { resolveValue } from '../src/secretValue.js';
-import { AxiError } from '../src/errors.js';
+import { readStdin, isStdinTTY } from "../src/stdin.js";
+import { resolveValue } from "../src/secretValue.js";
+import { AxiError } from "../src/errors.js";
 
 const mockedReadStdin = vi.mocked(readStdin);
 const mockedIsStdinTTY = vi.mocked(isStdinTTY);
 
-describe('resolveValue', () => {
+describe("resolveValue", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  it('returns the flag value without touching stdin when provided', async () => {
-    const value = await resolveValue('sk-flag-value', 'secret');
-    expect(value).toBe('sk-flag-value');
+  it("returns the variable flag value without touching stdin when provided", async () => {
+    const value = await resolveValue("production", "variable");
+    expect(value).toBe("production");
     expect(mockedReadStdin).not.toHaveBeenCalled();
     expect(mockedIsStdinTTY).not.toHaveBeenCalled();
   });
 
-  it('throws when the flag value is empty', async () => {
-    await expect(resolveValue('', 'secret')).rejects.toThrow(AxiError);
+  it("throws when the flag value is empty", async () => {
+    await expect(resolveValue("", "variable")).rejects.toThrow(AxiError);
   });
 
-  it('reads from stdin when no flag value is given and stdin is piped', async () => {
+  it("rejects secret flag values", async () => {
+    await expect(resolveValue("sk-flag-value", "secret")).rejects.toThrow(
+      "--body/-b is not accepted",
+    );
+    expect(mockedReadStdin).not.toHaveBeenCalled();
+    expect(mockedIsStdinTTY).not.toHaveBeenCalled();
+  });
+
+  it("reads from stdin when no flag value is given and stdin is piped", async () => {
     mockedIsStdinTTY.mockReturnValue(false);
-    mockedReadStdin.mockResolvedValue('piped-value');
+    mockedReadStdin.mockResolvedValue("piped-value");
 
-    const value = await resolveValue(undefined, 'variable');
+    const value = await resolveValue(undefined, "variable");
 
-    expect(value).toBe('piped-value');
+    expect(value).toBe("piped-value");
     expect(mockedReadStdin).toHaveBeenCalledTimes(1);
   });
 
-  it('throws instead of blocking when stdin is an interactive TTY', async () => {
+  it("throws instead of blocking when stdin is an interactive TTY", async () => {
     mockedIsStdinTTY.mockReturnValue(true);
 
-    await expect(resolveValue(undefined, 'secret')).rejects.toThrow(AxiError);
+    await expect(resolveValue(undefined, "secret")).rejects.toThrow(AxiError);
     expect(mockedReadStdin).not.toHaveBeenCalled();
   });
 
-  it('throws when piped stdin is empty', async () => {
-    mockedIsStdinTTY.mockReturnValue(false);
-    mockedReadStdin.mockResolvedValue('');
+  it("does not suggest secret flags when secret stdin is missing", async () => {
+    mockedIsStdinTTY.mockReturnValue(true);
 
-    await expect(resolveValue(undefined, 'secret')).rejects.toThrow(AxiError);
+    await expect(resolveValue(undefined, "secret")).rejects.toThrow(
+      "pipe the value via stdin",
+    );
+    await expect(resolveValue(undefined, "secret")).rejects.not.toThrow(
+      "--body",
+    );
+  });
+
+  it("keeps variable flag guidance when variable stdin is missing", async () => {
+    mockedIsStdinTTY.mockReturnValue(true);
+
+    await expect(resolveValue(undefined, "variable")).rejects.toThrow(
+      "--body <value>",
+    );
+  });
+
+  it("throws when piped stdin is empty", async () => {
+    mockedIsStdinTTY.mockReturnValue(false);
+    mockedReadStdin.mockResolvedValue("");
+
+    await expect(resolveValue(undefined, "secret")).rejects.toThrow(AxiError);
   });
 });

--- a/test/stdin.test.ts
+++ b/test/stdin.test.ts
@@ -1,0 +1,50 @@
+import { EventEmitter } from "node:events";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { readStdin, isStdinTTY } from "../src/stdin.js";
+
+describe("isStdinTTY", () => {
+  const originalIsTTY = process.stdin.isTTY;
+
+  afterEach(() => {
+    process.stdin.isTTY = originalIsTTY;
+  });
+
+  it("returns true when stdin.isTTY is true", () => {
+    process.stdin.isTTY = true;
+    expect(isStdinTTY()).toBe(true);
+  });
+
+  it("returns false when stdin.isTTY is undefined (piped)", () => {
+    process.stdin.isTTY = undefined as unknown as true;
+    expect(isStdinTTY()).toBe(false);
+  });
+});
+
+describe("readStdin", () => {
+  it("resolves with all data written before end", async () => {
+    const fakeStdin = new EventEmitter() as unknown as NodeJS.ReadStream;
+    (fakeStdin as unknown as { setEncoding: () => void }).setEncoding = vi.fn();
+    vi.spyOn(process, "stdin", "get").mockReturnValue(fakeStdin);
+
+    const promise = readStdin();
+    fakeStdin.emit("data", "hello ");
+    fakeStdin.emit("data", "world");
+    fakeStdin.emit("end");
+
+    await expect(promise).resolves.toBe("hello world");
+    vi.restoreAllMocks();
+  });
+
+  it("rejects on stream error", async () => {
+    const fakeStdin = new EventEmitter() as unknown as NodeJS.ReadStream;
+    (fakeStdin as unknown as { setEncoding: () => void }).setEncoding = vi.fn();
+    vi.spyOn(process, "stdin", "get").mockReturnValue(fakeStdin);
+
+    const promise = readStdin();
+    const err = new Error("broken pipe");
+    fakeStdin.emit("error", err);
+
+    await expect(promise).rejects.toThrow("broken pipe");
+    vi.restoreAllMocks();
+  });
+});

--- a/test/suggestions.test.ts
+++ b/test/suggestions.test.ts
@@ -1,101 +1,156 @@
-import { describe, it, expect } from 'vitest';
-import { getSuggestions } from '../src/suggestions.js';
+import { describe, it, expect } from "vitest";
+import { getSuggestions } from "../src/suggestions.js";
 
-describe('getSuggestions', () => {
-  it('returns home suggestions', () => {
-    const lines = getSuggestions({ domain: 'home', action: 'home' });
+describe("getSuggestions", () => {
+  it("returns home suggestions", () => {
+    const lines = getSuggestions({ domain: "home", action: "home" });
     expect(lines.length).toBeGreaterThan(0);
-    expect(lines.some((l) => l.includes('issue') || l.includes('pr'))).toBe(true);
+    expect(lines.some((l) => l.includes("issue") || l.includes("pr"))).toBe(
+      true,
+    );
   });
 
-  it('returns issue list suggestions when non-empty', () => {
-    const lines = getSuggestions({ domain: 'issue', action: 'list', isEmpty: false });
-    expect(lines.some((l) => l.includes('issue view'))).toBe(true);
-  });
-
-  it('returns issue list suggestions when empty', () => {
-    const lines = getSuggestions({ domain: 'issue', action: 'list', isEmpty: true });
-    expect(lines.some((l) => l.includes('issue create'))).toBe(true);
-    expect(lines.some((l) => l.includes('--state closed'))).toBe(true);
-  });
-
-  it('returns open issue view suggestions', () => {
-    const lines = getSuggestions({ domain: 'issue', action: 'view', state: 'open', id: 42 });
-    expect(lines.some((l) => l.includes('comment 42'))).toBe(true);
-    expect(lines.some((l) => l.includes('close 42'))).toBe(true);
-  });
-
-  it('returns closed issue view suggestions', () => {
-    const lines = getSuggestions({ domain: 'issue', action: 'view', state: 'closed', id: 42 });
-    expect(lines.some((l) => l.includes('reopen 42'))).toBe(true);
-  });
-
-  it('carries -R flag when repo source is not git', () => {
+  it("returns issue list suggestions when non-empty", () => {
     const lines = getSuggestions({
-      domain: 'issue',
-      action: 'list',
+      domain: "issue",
+      action: "list",
       isEmpty: false,
-      repo: { owner: 'cli', name: 'cli', nwo: 'cli/cli', source: 'flag' },
     });
-    expect(lines.every((l) => l.includes('-R cli/cli'))).toBe(true);
+    expect(lines.some((l) => l.includes("issue view"))).toBe(true);
   });
 
-  it('does not carry -R flag when repo source is git', () => {
+  it("returns issue list suggestions when empty", () => {
     const lines = getSuggestions({
-      domain: 'issue',
-      action: 'list',
-      isEmpty: false,
-      repo: { owner: 'cli', name: 'cli', nwo: 'cli/cli', source: 'git' },
+      domain: "issue",
+      action: "list",
+      isEmpty: true,
     });
-    expect(lines.every((l) => !l.includes('-R'))).toBe(true);
+    expect(lines.some((l) => l.includes("issue create"))).toBe(true);
+    expect(lines.some((l) => l.includes("--state closed"))).toBe(true);
   });
 
-  it('places explicit repo flags after secret commands', () => {
-    const repo = { owner: 'cli', name: 'cli', nwo: 'cli/cli', source: 'flag' as const };
+  it("returns open issue view suggestions", () => {
+    const lines = getSuggestions({
+      domain: "issue",
+      action: "view",
+      state: "open",
+      id: 42,
+    });
+    expect(lines.some((l) => l.includes("comment 42"))).toBe(true);
+    expect(lines.some((l) => l.includes("close 42"))).toBe(true);
+  });
+
+  it("returns closed issue view suggestions", () => {
+    const lines = getSuggestions({
+      domain: "issue",
+      action: "view",
+      state: "closed",
+      id: 42,
+    });
+    expect(lines.some((l) => l.includes("reopen 42"))).toBe(true);
+  });
+
+  it("carries -R flag when repo source is not git", () => {
+    const lines = getSuggestions({
+      domain: "issue",
+      action: "list",
+      isEmpty: false,
+      repo: { owner: "cli", name: "cli", nwo: "cli/cli", source: "flag" },
+    });
+    expect(lines.every((l) => l.includes("-R cli/cli"))).toBe(true);
+  });
+
+  it("does not carry -R flag when repo source is git", () => {
+    const lines = getSuggestions({
+      domain: "issue",
+      action: "list",
+      isEmpty: false,
+      repo: { owner: "cli", name: "cli", nwo: "cli/cli", source: "git" },
+    });
+    expect(lines.every((l) => !l.includes("-R"))).toBe(true);
+  });
+
+  it("places explicit repo flags after secret commands", () => {
+    const repo = {
+      owner: "cli",
+      name: "cli",
+      nwo: "cli/cli",
+      source: "flag" as const,
+    };
 
     const lines = [
-      ...getSuggestions({ domain: 'secret', action: 'list', isEmpty: false, repo }),
-      ...getSuggestions({ domain: 'secret', action: 'list', isEmpty: true, repo }),
-      ...getSuggestions({ domain: 'secret', action: 'set', repo }),
-      ...getSuggestions({ domain: 'secret', action: 'delete', repo }),
+      ...getSuggestions({
+        domain: "secret",
+        action: "list",
+        isEmpty: false,
+        repo,
+      }),
+      ...getSuggestions({
+        domain: "secret",
+        action: "list",
+        isEmpty: true,
+        repo,
+      }),
+      ...getSuggestions({ domain: "secret", action: "set", repo }),
+      ...getSuggestions({ domain: "secret", action: "delete", repo }),
     ];
 
     expect(lines).toEqual([
-      'Run `gh-axi secret set <name> -R cli/cli` to add or update a secret',
+      'Run `echo -n "<value>" | gh-axi secret set <name> -R cli/cli` to add or update a secret',
       'Run `echo -n "<value>" | gh-axi secret set <name> -R cli/cli` to add a secret',
-      'Run `gh-axi secret list -R cli/cli` to see all secrets',
-      'Run `gh-axi secret list -R cli/cli` to see remaining secrets',
+      "Run `gh-axi secret list -R cli/cli` to see all secrets",
+      "Run `gh-axi secret list -R cli/cli` to see remaining secrets",
     ]);
-    expect(lines.every((l) => !l.includes('gh-axi -R'))).toBe(true);
+    expect(lines.every((l) => !l.includes("gh-axi -R"))).toBe(true);
   });
 
-  it('places explicit repo flags after variable commands', () => {
-    const repo = { owner: 'cli', name: 'cli', nwo: 'cli/cli', source: 'flag' as const };
+  it("places explicit repo flags after variable commands", () => {
+    const repo = {
+      owner: "cli",
+      name: "cli",
+      nwo: "cli/cli",
+      source: "flag" as const,
+    };
 
     const lines = [
-      ...getSuggestions({ domain: 'variable', action: 'list', isEmpty: false, repo }),
-      ...getSuggestions({ domain: 'variable', action: 'list', isEmpty: true, repo }),
-      ...getSuggestions({ domain: 'variable', action: 'set', repo }),
-      ...getSuggestions({ domain: 'variable', action: 'delete', repo }),
+      ...getSuggestions({
+        domain: "variable",
+        action: "list",
+        isEmpty: false,
+        repo,
+      }),
+      ...getSuggestions({
+        domain: "variable",
+        action: "list",
+        isEmpty: true,
+        repo,
+      }),
+      ...getSuggestions({ domain: "variable", action: "set", repo }),
+      ...getSuggestions({ domain: "variable", action: "delete", repo }),
     ];
 
     expect(lines).toEqual([
-      'Run `gh-axi variable set <name> --body <value> -R cli/cli` to add or update a variable',
-      'Run `gh-axi variable set <name> --body <value> -R cli/cli` to add a variable',
-      'Run `gh-axi variable list -R cli/cli` to see all variables',
-      'Run `gh-axi variable list -R cli/cli` to see remaining variables',
+      "Run `gh-axi variable set <name> --body <value> -R cli/cli` to add or update a variable",
+      "Run `gh-axi variable set <name> --body <value> -R cli/cli` to add a variable",
+      "Run `gh-axi variable list -R cli/cli` to see all variables",
+      "Run `gh-axi variable list -R cli/cli` to see remaining variables",
     ]);
-    expect(lines.every((l) => !l.includes('gh-axi -R'))).toBe(true);
+    expect(lines.every((l) => !l.includes("gh-axi -R"))).toBe(true);
   });
 
-  it('returns PR merge suggestions', () => {
-    const lines = getSuggestions({ domain: 'pr', action: 'merge', id: 10 });
-    expect(lines.some((l) => l.includes('revert'))).toBe(true);
+  it("returns PR merge suggestions", () => {
+    const lines = getSuggestions({ domain: "pr", action: "merge", id: 10 });
+    expect(lines.some((l) => l.includes("revert"))).toBe(true);
   });
 
-  it('returns run view suggestions for in-progress', () => {
-    const lines = getSuggestions({ domain: 'run', action: 'view', state: 'in_progress', id: 123 });
-    expect(lines.some((l) => l.includes('watch 123'))).toBe(true);
-    expect(lines.some((l) => l.includes('cancel 123'))).toBe(true);
+  it("returns run view suggestions for in-progress", () => {
+    const lines = getSuggestions({
+      domain: "run",
+      action: "view",
+      state: "in_progress",
+      id: 123,
+    });
+    expect(lines.some((l) => l.includes("watch 123"))).toBe(true);
+    expect(lines.some((l) => l.includes("cancel 123"))).toBe(true);
   });
 });

--- a/test/suggestions.test.ts
+++ b/test/suggestions.test.ts
@@ -50,6 +50,44 @@ describe('getSuggestions', () => {
     expect(lines.every((l) => !l.includes('-R'))).toBe(true);
   });
 
+  it('places explicit repo flags after secret commands', () => {
+    const repo = { owner: 'cli', name: 'cli', nwo: 'cli/cli', source: 'flag' as const };
+
+    const lines = [
+      ...getSuggestions({ domain: 'secret', action: 'list', isEmpty: false, repo }),
+      ...getSuggestions({ domain: 'secret', action: 'list', isEmpty: true, repo }),
+      ...getSuggestions({ domain: 'secret', action: 'set', repo }),
+      ...getSuggestions({ domain: 'secret', action: 'delete', repo }),
+    ];
+
+    expect(lines).toEqual([
+      'Run `gh-axi secret set <name> -R cli/cli` to add or update a secret',
+      'Run `echo -n "<value>" | gh-axi secret set <name> -R cli/cli` to add a secret',
+      'Run `gh-axi secret list -R cli/cli` to see all secrets',
+      'Run `gh-axi secret list -R cli/cli` to see remaining secrets',
+    ]);
+    expect(lines.every((l) => !l.includes('gh-axi -R'))).toBe(true);
+  });
+
+  it('places explicit repo flags after variable commands', () => {
+    const repo = { owner: 'cli', name: 'cli', nwo: 'cli/cli', source: 'flag' as const };
+
+    const lines = [
+      ...getSuggestions({ domain: 'variable', action: 'list', isEmpty: false, repo }),
+      ...getSuggestions({ domain: 'variable', action: 'list', isEmpty: true, repo }),
+      ...getSuggestions({ domain: 'variable', action: 'set', repo }),
+      ...getSuggestions({ domain: 'variable', action: 'delete', repo }),
+    ];
+
+    expect(lines).toEqual([
+      'Run `gh-axi variable set <name> --body <value> -R cli/cli` to add or update a variable',
+      'Run `gh-axi variable set <name> --body <value> -R cli/cli` to add a variable',
+      'Run `gh-axi variable list -R cli/cli` to see all variables',
+      'Run `gh-axi variable list -R cli/cli` to see remaining variables',
+    ]);
+    expect(lines.every((l) => !l.includes('gh-axi -R'))).toBe(true);
+  });
+
   it('returns PR merge suggestions', () => {
     const lines = getSuggestions({ domain: 'pr', action: 'merge', id: 10 });
     expect(lines.some((l) => l.includes('revert'))).toBe(true);


### PR DESCRIPTION
## Intent

Add gh-axi secret and gh-axi variable commands (list/set/delete) wrapping gh secret/gh variable for repository-level GitHub Actions secrets and variables, since gh-axi secret list previously errored with Unknown command and forced fallback to raw gh, breaking the convention that all GitHub operations go through gh-axi. Followed the existing label/release command pattern: repo resolution via the shared -R/--repo flag, TOON output, contextual help suggestions, idempotent-style error handling. Security-sensitive design decision: secret (and variable, for consistency) values are never accepted as a bare CLI positional and never printed in list output - list only requests name/updatedAt (secrets) or name/value/updatedAt (variables, which are not sensitive) from gh's --json fields. set resolves the value from --body/-b or piped stdin (added src/secretValue.ts + src/stdin.ts), then writes it directly to the gh child process's stdin via a new gh.ts#ghExecWithStdin helper instead of passing it through argv, so the value never appears in PID TTY TIME CMD
2484 ttys000 0:00.29 -zsh
47628 ttys000 0:00.01 tmux new-session -A -s main
2944 ttys001 0:00.42 -zsh
9281 ttys001 0:47.42 claude --dangerously-skip-permissions
27044 ttys001 0:00.00 caffeinate -i -t 300
4674 ttys002 0:00.16 -zsh
4938 ttys002 28:32.65 claude --dangerously-skip-permissions You are a secondmate: a persistent domain supervisor managed by the main firstmate. Work on your own; do not wait for a human.\012\012# Charter\012Persistent domain supervisor for Hi Bit. All Hi Bit work lives in ONE repo, hibit-monorepo: the thin clients, the stateless OpenAI-only backend (GCP-hosted with E2B sandboxes), AND the marketing/landing site - everything Hi Bit in one monorepo (direct-PR mode, so changes flow push plus open a PR). The old hi-bit Electron repo is DEPRECATED and out of scope; never work it and ignore its clone. Own all of hibit-monorepo end to end: feature development, bug fixes, UI and UX polish, the marketing/landing site, the iOS TestFlight pipeline, CI and release, and project-intrinsic memory in AGENTS.md. Delegate project work to your own crewmates through the normal brief, spawn, supervise, and teardown lifecycle; do not invent a second delegation system. Escalate to the main firstmate via your status file anything that needs the captain: go-live and launch decisions, anything destructive, irreversible, or security-sensitive, and infrastructure outside your project scope. You are idle by default: on startup and restart reconcile only your own in-flight and tracked work and then wait for routed tasks; never start a survey, audit, or self-directed improvement hunt on your own, because an empty queue is a healthy resting state.\012\012# Routing scope\012Everything Hi Bit, which all lives in hibit-monorepo: the thin clients, the stateless backend (OpenAI + GCP + E2B), the marketing/landing site, and their CI, release, and iOS TestFlight pipelines, plus Hi Bit project memory. Route all Hi Bit work here. The old hi-bit Electron repo is deprecated and out of scope.\012\012# Project clones\012- hibit-monorepo\012\012# Operating model\012You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.\012The projects above are local clones for work you supervise; they are not an exclusive ownership claim.\012Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.\012Do not invent a second delegation system.\012You do not generate your own work.\012Act only on tasks the main firstmate routes to you.\012Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.\012\012# Escalation to main firstmate\012Handle routine work yourself.\012Escalate only true captain-relevant outcomes by appending one line:\012 `echo "{state}: {one short line}" >> '/Users/kunchen/github/kunchenguid/firstmate/state/hibit-h9.status'`\012States: working, needs-decision, blocked, done, failed.\012Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.\012Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.\012\012# Definition of done\012You are persistent by default. Do not exit just because your queue is empty.\012On startup and restart, run normal firstmate bootstrap and recovery for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.\012When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.\012An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.\012If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
28269 ttys003 0:00.00 caffeinate -i -t 300
31521 ttys003 0:00.16 -zsh
31785 ttys003 54:28.58 claude --dangerously-skip-permissions You are a secondmate: a persistent domain supervisor managed by the main firstmate. Work on your own; do not wait for a human.\012\012# Charter\012Persistent domain supervisor for SSHHIP, the iOS-first native SwiftUI SSH and tmux client sold as a one-time lifetime purchase. Own all SSHHIP work end to end: feature development, bug fixes, terminal and UX polish, the SwiftTerm rendering and Citadel SSH stack, voice input, the headless Docker E2E harness, the GitHub Actions CI and release-please pipeline, App Store Connect versioning, TestFlight and App Store submissions, the in-app purchase lifetime unlock, and project-intrinsic memory in AGENTS.md. SSHHIP ships in no-mistakes mode, so changes flow from implement to the no-mistakes pipeline to a PR for review. Delegate project work to your own crewmates through the normal brief, spawn, supervise, and teardown lifecycle, and do not invent a second delegation system. Pick up SSHHIP work now and drive its release pipeline. Escalate App Store submissions, release go or no-go calls, and anything destructive, irreversible, or security-sensitive to the captain.\012\012# Routing scope\012Any work concerning the SSHHIP iOS app and its ecosystem: SwiftUI app code, the SSH and tmux terminal client, SwiftTerm rendering, voice input, the E2E test harness, CI and release-please, App Store Connect and TestFlight, the in-app purchase, app icon and design, and SSHHIP project memory. Route all SSHHIP tasks here.\012\012# Project clones\012- sshhip\012\012# Operating model\012You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.\012The projects above are local clones for work you supervise; they are not an exclusive ownership claim.\012Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.\012Do not invent a second delegation system.\012\012# Escalation to main firstmate\012Handle routine work yourself.\012Escalate only true captain-relevant outcomes by appending one line:\012 `echo "{state}: {one short line}" >> '/Users/kunchen/github/kunchenguid/firstmate/state/sshhip-h7.status'`\012States: working, needs-decision, blocked, done, failed.\012Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.\012Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.\012\012# Definition of done\012You are persistent by default. Do not exit just because your queue is empty.\012On startup and restart, run normal firstmate bootstrap and recovery for your own home, then supervise work that matches your scope.\012If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.\012\012# Standing duties (run on every startup, after recovery)\012- HomeMux App Store review watch self-heal: run `"$HOME/Library/Application Support/homemux-release-watch/install.sh"` (idempotent; no-op when healthy).\012 It re-asserts the launchd agent `com.kunchenguid.homemux-release-watch` (4-hourly poll of App Store Connect for the watched version's review status; escalates any change to this home's main status file) and preserves the configured ISSUER_ID/key.\012 All watch files live under `~/Library` (outside this home), so they survive a home re-provision; this startup re-assert is the safety net for the case where the agent or its files were removed (which is how the prior watch was lost).\012 If that installer path is missing entirely (catastrophic wipe), the watch must be rebuilt: the canonical builder is that same `install.sh`, key id `UG422B35RD` (key in `~/Downloads`), bundle id `com.homemux.HomeMux`, watched version per ASC; recover the issuer id from the captain if not in `config.env`.\012 After self-heal, verify with `launchctl print "gui/$(id -u)/com.kunchenguid.homemux-release-watch"`; if `ISSUER_ID` is still empty in `config.env`, escalate `needs-decision` for it.
5501 ttys004 0:00.15 -zsh
5765 ttys004 44:02.39 claude --dangerously-skip-permissions You are a secondmate: a persistent domain supervisor managed by the main firstmate. Work on your own; do not wait for a human.\012\012# Charter\012You are a persistent secondmate that owns **open-source maintenance triage** across the captain's OSS repositories. Your ownership is **triage only** of open GitHub issues and pull requests - NOT new feature development (that routes elsewhere). For each open issue or PR, produce a clear read, an analysis of its overlaps and dependencies against the rest of the open queue, and a concrete prioritized recommendation for the captain to decide on.\012\012Repos in scope (for now): **no-mistakes, lavish-axi, gnhf, and firstmate itself**. Project clones are added to your home lazily as the captain routes triage for each repo (no-mistakes is cloned today). When you triage **firstmate itself**, it is **read-only**: read its issues/PRs via gh-axi and use your own home as code context, but never branch, commit to, or otherwise modify your own home (that would be a worktree tangle).\012\012The captain will interact with you **directly in your own pane** to make triage and prioritization decisions. Those direct, unmarked messages are authoritative captain conversation - engage conversationally and surface your findings and recommendations clearly so the captain can decide and act. Marked requests from the main firstmate return via your status/escalation path per the contract below.\012\012# Routing scope\012Open-source maintenance, TRIAGE-ONLY: triage of open GitHub issues and pull requests (read, overlap/dependency analysis, prioritized recommendations) across the captain's OSS repos - no-mistakes, lavish-axi, gnhf, and firstmate itself. NOT new feature development, and NOT repos owned by other secondmates (HomeMux, Hi Bit). Route open-issue/PR triage and grooming for those repos here.\012\012# Project clones\012- no-mistakes\012(lavish-axi, gnhf, and firstmate clones are added to this home as the captain routes triage for each; firstmate triage is read-only via gh-axi + this home for context.)\012\012# Operating model\012You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.\012The projects above are local clones for work you supervise; they are not an exclusive ownership claim.\012Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.\012Do not invent a second delegation system.\012You do not generate your own work.\012Act only on tasks the main firstmate routes to you.\012Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.\012\012# Requests from the main firstmate\012You are a firstmate in your own home, so an incoming message reaches you in your own chat.\012You must distinguish who it is from, because the answer goes to a different place.\012A request relayed to you by the main firstmate (your supervisor) is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.\012When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.\012For a terse result, a status line is the whole answer.\012For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.\012A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.\012\012# Escalation to main firstmate\012Handle routine work yourself.\012Escalate only true captain-relevant outcomes by appending one line:\012 `echo "{state}: {one short line}" >> '/Users/kunchen/github/kunchenguid/firstmate/state/oss-triage-t4.status'`\012States: working, needs-decision, blocked, done, failed.\012Use this only for material phase changes, a captain decision, a real blocker, a failure, or work ready for review.\012This is also how you return the answer to a marked from-firstmate request above.\012Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.\012\012# Definition of done\012You are persistent by default. Do not exit just because your queue is empty.\012On startup and restart, run normal firstmate bootstrap and recovery for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.\012When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.\012An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.\012If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
5409 ttys005 0:00.10 -zsh
5656 ttys005 0:00.05 treehouse get
5697 ttys005 0:00.18 /run/current-system/sw/bin/zsh
5972 ttys005 1:33.20 claude --dangerously-skip-permissions --model sonnet --effort high You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.\012\012# Task\012## Goal\012Add a **one-time, self-terminating re-render trigger** so display-only card changes (like the recently-merged de-tag that dropped the author `@mention`) propagate to EXISTING open decision cards, instead of only appearing on newly-created cards. Today a card's body is rewritten only on creation or on a MATERIAL change (`head_sha`/`comp`/`tests`/`kind`/`priority`/`options`); a pure-display fix like the de-tag has no material trigger, so quiet cards keep their stale body (e.g. `**PR review** by @DanWertheimer`) indefinitely. Introduce a non-material `render_version` field in the card state block that forces exactly one re-render when it is behind the current version, then no-ops - the SAME backfill shape already used for missing material fields and for `triaged_sha`.\012\012## Why this is the right design (grounded in the current code)\012`scripts/render_card.py` already does almost everything needed:\012- `render(item)` (~line 361) already emits the de-tagged meta line `meta = "**%s** by %s"` (no `@`) at ~line 393, so any re-render already produces the corrected body.\012- `_refresh_card(number, card, existing, item, old_state)` (~line 555) already (a) calls `_preserve_same_head_triage(...)` (~line 305) which re-inserts an existing `### Triage` section AND carries over `triaged_sha`/`triage_status`/`triage_error` when `head_sha` is unchanged, and (b) drops the "Target updated" owner comment ONLY when `old_sha != new_sha` (~line 580).\012- `upsert_card` (~line 590) gates a refresh on `is_refreshable(existing labels)` AND `material_changed(item, old_state)` (~line 619-627). `reconcile.py` pre-checks the same two guards (~line 145 and the re-check at ~149-151) so the no-change case never hits the API.\012\012So the ONLY missing piece is a second, non-material refresh trigger. A `render_version`-based one-time re-render is safe because it is a same-`head_sha` cosmetic refresh: it reuses `_preserve_same_head_triage` (triage preserved) and does NOT fire the "Target updated" comment (head unchanged). It self-terminates because `render()` stamps the current version into the new body.\012\012## What to build\0121. **Add a module-level constant** in `scripts/render_card.py`, e.g. `CARD_RENDER_VERSION = 2` (an int; bump it whenever a future display-only change should propagate to existing pure cards). Choose the initial value so that existing cards - which have NO `render_version` field in their state block - are seen as stale exactly once and re-render (a missing/absent field must read as behind the current version). Document at the constant what it is and the "bump to propagate a display-only fix" contract.\0122. **Stamp it in `render()`**: add `state["render_version"] = CARD_RENDER_VERSION` to the state dict `render()` builds (~line 372-384). It MUST be written for every kind of card.\0123. **Add a pure helper** `render_stale(state)` returning True when the parsed state block's `render_version` (default missing -> treat as 0 / behind) `!= CARD_RENDER_VERSION`. Keep it next to `material_changed`/`triage_fresh` and pure (no I/O).\0124. **Extend the refresh trigger to `material_changed OR render_stale`** at BOTH sites, without weakening any existing guard:\012 - `upsert_card` ~line 624: the early-return `if not material_changed(item, old_state): return number` must also allow a render-stale refresh (i.e. only skip when NOT material_changed AND NOT render_stale). The `is_refreshable` guard above it is unchanged.\012 - `reconcile.py` ~line 145 pre-check and the ~149-151 re-check: refresh when `is_refreshable(...) AND (material_changed(...) OR render_stale(...))`. Keep both the cheap pre-check (using the already-listed row) and the fresh re-check consistent.\0125. **Update `wheelhouse.config.yml`-adjacent docs / CLAUDE.md** ("Card refresh" and the state-block description): document `render_version` as a NON-material, one-time re-render trigger for display-only fixes - self-terminating, same-`head_sha` (so it preserves the triage section and does NOT emit a "Target updated" comment), and gated by `is_refreshable` exactly like a material refresh (a decision-in-flight card is never touched). Note it lives outside `MATERIAL_FIELDS` alongside `triaged_sha`.\012\012## Hard invariants (do NOT weaken)\012- `render_version` is NON-MATERIAL: it must NOT be added to `MATERIAL_FIELDS`, `material_signature`, or `_state_material`. A change in `render_version` alone must never make `material_changed` return True, and must never affect `classify`, decision parsing, merge/close/approve, fork-CI safety, author filtering, conflict routing, or triage. It is only a refresh *trigger*, exactly like `triaged_sha` is only a cache.\012- **Only pure `needs-decision` cards re-render.** The `is_refreshable` guard stays in front of the new trigger at both sites; a `processing`/`resolved`/`blocked` card is never rewritten (re-rendering resets its checkboxes and would clobber an in-flight decision).\012- **A render-version-only refresh must NOT drop the "Target updated" comment.** That comment stays gated strictly on `old_sha != new_sha` in `_refresh_card` (~line 580) - do not broaden it. A cosmetic re-render has unchanged `head_sha`, so no comment fires. Verify this with a test.\012- **A render-version refresh must PRESERVE any existing `### Triage` section and its `triaged_sha`/`triage_status`/`triage_error` cache.** This already happens via `_preserve_same_head_triage` because `head_sha` is unchanged; do not regress it. Verify with a test that an existing triage section survives a render-version-only refresh unchanged and triage is NOT re-queued for the same head.\012- **Self-terminating.** After a render-version refresh, `render()` stamps the current `CARD_RENDER_VERSION` into the new body, so the next scan sees it fresh and no-ops. No second refresh, no churn loop. Verify with a test.\012- Only `ok:true` scan items reach the refresh path (unchanged); an `ok:false` repo is never refreshed. Do not touch that or the close/reconcile logic.\012\012## Acceptance criteria\012- An existing open pure `needs-decision` card whose state block lacks `render_version` (or has an older value) is re-rendered exactly once on the next scan/upsert, dropping the author `@mention` (and picking up any other display-only change), then no-ops on subsequent scans.\012- A card mid-decision (`processing`/`resolved`/`blocked`) is NEVER re-rendered by the render-version trigger.\012- A render-version-only refresh emits NO "Target updated" comment and preserves an existing `### Triage` section + `triaged_sha`/`triage_status` untouched (no re-triage for the same head).\012- `render_version` is not material: a card that differs ONLY in `render_version` does not report `material_changed`; a card that is materially unchanged AND render-fresh is a full no-op (no body edit, no label churn, no comment).\012- Newly created cards carry the current `render_version`.\012- Tests: extend `tests/test_card_refresh.py` (render_stale true when missing/older, false when current; the OR-trigger routing; is_refreshable still guards; non-material assertion; no "Target updated" comment on a same-head render-version refresh; triage-section + cache preservation; self-terminating no-op after refresh). Extend `tests/test_reconcile.py` for the reconcile-path OR-trigger (render-stale pure card refreshes once then no-ops). Keep `tests/test_auto_triage.py` and `tests/test_merge_conflict.py` green (triage/nudge behavior unchanged). Validate per CLAUDE.md: `python -m py_compile scripts/*.py tests/*.py`, run EVERY unit suite listed in CLAUDE.md, YAML-parse `.github/workflows/*.yml` + `wheelhouse.config.yml` + `.github/ISSUE_TEMPLATE/*.yml`, and `actionlint` if available.\012- CLAUDE.md documents `render_version` (non-material one-time re-render trigger for display-only fixes; bump-to-propagate; self-terminating; preserves triage; no "Target updated" comment; is_refreshable-gated).\012\012## Design choices (make them; escalate a genuine fork via needs-decision)\012- Constant name/type (`CARD_RENDER_VERSION`, int) and the missing-field-reads-as-behind convention are yours; keep it dead simple and mirror the existing `triaged_sha`/material-backfill patterns rather than inventing new machinery.\012- Do NOT add any config knob for this - it is an internal maintenance trigger, always on, and cheap (one re-render per stale card, then silent).\012\012# Setup\012You are in a disposable git worktree of wheelhouse, at a detached HEAD on a clean default branch.\012\012**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable treehouse worktree you were launched in, typically a path under a `.treehouse/` pool, not the primary checkout firstmate operates from.\012The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.\012If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.\012\0121. First action: create your branch: `git checkout -b fm/wheelhouse-render-ver-k4`\0122. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.\012\012# Rules\0121. Never push to the default branch. Never merge a PR.\0122. Stay inside this worktree; modify nothing outside it.\0123. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.\0124. Report status by appending one line:\012 `echo "{state}: {one short line}" >> '/Users/kunchen/.treehouse/firstmate-b8697d/6/firstmate/state/wheelhouse-render-ver-k4.status'`\012 States: working, needs-decision, blocked, done, failed.\012 Each append wakes firstmate, so report sparingly: only phase changes a supervisor\012 would act on (setup done, bug reproduced, fix implemented, validation passed) and the\012 needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;\012 firstmate reads your pane for that.\0125. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.\0126. If a decision belongs to a human (product choices, destructive actions, ask-user findings),\012 append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.\012\012# Project memory\012If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/kunchen/.treehouse/firstmate-b8697d/6/firstmate/bin/fm-ensure-agents-md.sh .` in the worktree.\012If this task produced durable project-intrinsic knowledge, record it in `AGENTS.md` as part of your change.\012Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.\012\012# Definition of done\012The task is complete only when committed on your branch.\012When you believe it is complete, append `done: {summary}` to the status file and stop.\012Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.\012\012You drive no-mistakes by responding to its gates, not by implementing fixes.\012Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.\012Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.\012\012Two firstmate-specific rules layer on top of that guidance:\012- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.\012 When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.\012- Avoid `--yes`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.\012\012After /no-mistakes reports CI green, append `done: PR {url} checks green` and stop. You are finished.
62660 ttys006 0:00.15 -zsh
7850 ttys007 0:00.12 -zsh
65616 ttys008 0:00.20 -zsh
66338 ttys008 2:59.68 claude --dangerously-skip-permissions
13987 ttys009 0:00.11 -zsh
14269 ttys009 0:00.02 treehouse get
14294 ttys009 0:00.19 /run/current-system/sw/bin/zsh
14567 ttys009 1:19.23 claude --dangerously-skip-permissions --model sonnet --effort high You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.\012\012# Task\012Add `secret` and `variable` commands to gh-axi for GitHub Actions secrets and variables management.\012\012Today `gh-axi secret list` errors with "Unknown command: secret" (same for `variable`), forcing a fallback to raw `gh` and breaking the convention that all GitHub operations go through gh-axi. Existing commands are: issue, pr, run, release, repo, label.\012\012Requirements:\0121. `gh-axi secret` with subcommands `list`, `set`, and `delete`, wrapping the corresponding `gh secret` operations for repository-level Actions secrets. Support the repo resolution the other commands already use (current repo by default, explicit `--repo` override if that is the house pattern).\0122. `gh-axi variable` with the same `list`/`set`/`delete` subcommands, wrapping `gh variable` for Actions variables.\0123. Match the existing gh-axi command structure, output ergonomics, and help conventions exactly - study how `label` or `release` is implemented and follow that pattern. The repo follows the AXI (agent experience interface) standards; keep output token-tight and agent-ergonomic.\0124. Secret VALUES are sensitive: `set` must accept the value via stdin or a flag consistent with `gh secret set` semantics, and `list` must never print secret values (gh only exposes names/timestamps anyway - preserve that).\0125. Add or extend tests following the repo's existing test conventions, covering at least command routing and argument handling for both new commands.\0126. Update the CLI help/command index so `secret` and `variable` are discoverable (including the session-hook help output if that is generated from the command table).\012\012Acceptance criteria:\012- `gh-axi secret list`, `gh-axi secret set <name>`, `gh-axi secret delete <name>` work against a repo, as do the `variable` equivalents.\012- `gh-axi --help` (and the command index) lists both new commands.\012- Tests pass; no regressions to existing commands.\012\012# Setup\012You are in a disposable git worktree of gh-axi, at a detached HEAD on a clean default branch.\012\012**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable treehouse worktree you were launched in, typically a path under a `.treehouse/` pool, not the primary checkout firstmate operates from.\012The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.\012If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.\012\0121. First action: create your branch: `git checkout -b fm/gh-axi-secret-var-cmd`\0122. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.\012\012# Rules\0121. Never push to the default branch. Never merge a PR.\0122. Stay inside this worktree; modify nothing outside it.\0123. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.\0124. Report status by appending one line:\012 `echo "{state}: {one short line}" >> '/Users/kunchen/github/kunchenguid/firstmate/state/gh-axi-secret-var-cmd.status'`\012 States: working, needs-decision, blocked, done, failed.\012 Each append wakes firstmate, so report sparingly: only phase changes a supervisor\012 would act on (setup done, bug reproduced, fix implemented, validation passed) and the\012 needs-decision/blocked/done/failed states. No step-by-step FYI progress lines;\012 firstmate reads your pane for that.\0125. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.\0126. If a decision belongs to a human (product choices, destructive actions, ask-user findings),\012 append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.\012\012# Project memory\012If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/kunchen/github/kunchenguid/firstmate/bin/fm-ensure-agents-md.sh .` in the worktree.\012If this task produced durable project-intrinsic knowledge, record it in `AGENTS.md` as part of your change.\012Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.\012\012# Definition of done\012The task is complete only when committed on your branch.\012When you believe it is complete, append `done: {summary}` to the status file and stop.\012Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.\012\012You drive no-mistakes by responding to its gates, not by implementing fixes.\012Follow no-mistakes' own guidance for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.\012Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.\012\012Two firstmate-specific rules layer on top of that guidance:\012- ask-user findings are not yours to answer: escalate to firstmate (rule 6) and stop.\012 When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.\012- Avoid `--yes`: the captain, not you, owns the ask-user decisions it would silently auto-resolve.\012\012After /no-mistakes reports CI green, append `done: PR {url} checks green` and stop. You are finished.
28707 ttys009 0:00.00 caffeinate -i -t 300 output. If stdin is an interactive TTY and no --body was given, it throws immediately instead of blocking (AXI commands must not hang on interactive input). Also: gh secret list/gh variable list do not support --limit/pagination flags in the gh CLI, so unlike issue/pr/release list, our list subcommands take no --limit flag. Updated src/cli.ts TOP_HELP command index, src/suggestions.ts (home line + secret/variable domains), src/skill.ts SKILL_DESCRIPTION, README.md command table, and regenerated skills/gh-axi/SKILL.md via pnpm run build:skill so the installable skill stays in sync. Added unit tests for both new commands, the new gh.ts stdin-exec path, secretValue.ts, and stdin.ts, plus routing/help-index assertions in cli.test.ts and help-examples.test.ts. Full test suite (485 tests), tsc --noEmit, and eslint all pass. Also manually verified end-to-end against the real kunchenguid/gh-axi repo: ran secret/variable set, list, delete round-trips (via both piped stdin and --body flag) and confirmed list never leaks secret values.

## What Changed

- Added `secret` and `variable` command families with `list`, `set`, and `delete` subcommands for repository-level GitHub Actions secrets and variables, including shared repo flag handling and help/discovery updates.
- Added stdin-based value handling for `set` operations, with `secret set` kept stdin-only so secret values do not enter argv or command output.
- Extended command suggestions, README/skill documentation, and unit/E2E coverage for routing, stdin execution, help examples, and repo-aware suggestion formatting.

## Risk Assessment

✅ Low: The change is scoped to new command wrappers, stdin plumbing, suggestions, and docs, and I did not find material correctness or security regressions in the reviewed diff.

## Testing

I inspected the worktree and target diff, ran the directly affected Vitest files and the full unit suite, then generated CLI evidence with the real local bin entrypoint plus a fake gh shim. The evidence covers top-level discoverability, secret and variable list/set/delete flows, secret --body rejection, repo flag propagation, and child gh argv/stdin handling without touching GitHub state; all checks passed.

- Evidence: [secret-variable CLI E2E transcript](https://github.com/kunchenguid/gh-axi/blob/bd250b6e948817d66ffd66ae243d53ccaf198c2c/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/cli-e2e-transcript.txt)
- Evidence: [fake gh child argv/stdin capture](https://github.com/kunchenguid/gh-axi/blob/bd250b6e948817d66ffd66ae243d53ccaf198c2c/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-gh-calls.jsonl)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- 🚨 `src/commands/secret.ts:49` - `--body/-b` for secrets still puts the secret in the `gh-axi` process argv before `ghExecWithStdin` can protect the child `gh` invocation. Either make secret values stdin-only, or explicitly accept and document that `--body` is convenient but not argv-safe.
- ⚠️ `src/suggestions.ts:482` - The new secret/variable suggestions use `gh-axi${repoFlag(c)} ...`, so an explicit repo renders as `gh-axi -R owner/repo secret ...`, while this CLI only supports repo flags after the command. Emit command-first suggestions such as `gh-axi secret list -R owner/repo` for these new commands.

🔧 Fix: Fix secret variable repo suggestions
1 error still open:
- 🚨 `src/commands/secret.ts:49` - `--body/-b` for `secret set` still puts the secret in the `gh-axi` process argv before `ghExecWithStdin` protects only the child `gh` invocation, which conflicts with the new guarantee that secret values must never appear in argv. Make secret values stdin-only, or explicitly document `--body` as convenient but argv-visible.

🔧 Fix: Make secret set stdin-only
1 warning still open:
- ⚠️ `AGENTS.md:29` - This committed agent-memory paragraph is stale after the stdin-only secret fix: it still says `secretCommand` resolves `--body`/`-b`, and it also claims variable values must never appear in argv even though `variable set --body` intentionally remains supported and is visible in the `gh-axi` process argv. Update it to state that secrets are stdin-only and argv-sensitive, while variables may use `--body`/`-b` or stdin and are only kept out of the child `gh` argv.

🔧 Fix: Update secret variable agent docs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pwd -P && git rev-parse --show-toplevel && git status --short --branch`
- `git diff --stat 0d758656d00c07651cf199eef18ffc1bb5ca9281..613ac5c6e07e6dd5f56d46668e09c24dfcec9113`
- `pnpm vitest run test/commands/secret.test.ts test/commands/variable.test.ts test/secretValue.test.ts test/stdin.test.ts test/gh.test.ts test/cli.test.ts test/suggestions.test.ts test/help-examples.test.ts`
- `pnpm test`
- `PATH="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-bin:$PATH" FAKE_GH_LOG="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-gh-calls.jsonl" pnpm exec tsx bin/gh-axi.ts --help | sed -n '1,12p'`
- `PATH="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-bin:$PATH" FAKE_GH_LOG="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-gh-calls.jsonl" pnpm exec tsx bin/gh-axi.ts secret list -R owner/repo`
- `printf '%s' '<synthetic-secret>' | PATH="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-bin:$PATH" FAKE_GH_LOG="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-gh-calls.jsonl" pnpm exec tsx bin/gh-axi.ts secret set API_KEY -R owner/repo`
- `PATH="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-bin:$PATH" FAKE_GH_LOG="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-gh-calls.jsonl" pnpm exec tsx bin/gh-axi.ts secret set API_KEY --body '<synthetic-secret>' -R owner/repo`
- `PATH="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-bin:$PATH" FAKE_GH_LOG="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-gh-calls.jsonl" pnpm exec tsx bin/gh-axi.ts secret delete API_KEY -R owner/repo`
- `PATH="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-bin:$PATH" FAKE_GH_LOG="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-gh-calls.jsonl" pnpm exec tsx bin/gh-axi.ts variable list -R owner/repo`
- `PATH="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-bin:$PATH" FAKE_GH_LOG="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-gh-calls.jsonl" pnpm exec tsx bin/gh-axi.ts variable set NODE_ENV --body production -R owner/repo`
- `printf '%s' 'staging' | PATH="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-bin:$PATH" FAKE_GH_LOG="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-gh-calls.jsonl" pnpm exec tsx bin/gh-axi.ts variable set NODE_ENV -R owner/repo`
- `PATH="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-bin:$PATH" FAKE_GH_LOG="$PWD/.no-mistakes/evidence/fm/gh-axi-secret-var-cmd/fake-gh-calls.jsonl" pnpm exec tsx bin/gh-axi.ts variable delete NODE_ENV -R owner/repo`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
