### PR TITLE
fix(suggestions): place -R after command in repo-qualified hints

### DIFF
--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -22,6 +22,10 @@ function repoFlag(ctx: SuggestionContext): string {
   return "";
 }
 
+function normalizeRepoFlagLine(line: string): string {
+  return line.replace(/`gh-axi -R ([^`\s]+) ([^`]+)`/g, "`gh-axi $2 -R $1`");
+}
+
 const table: SuggestionEntry[] = [
   // Home
   {
@@ -549,7 +553,7 @@ const table: SuggestionEntry[] = [
 export function getSuggestions(ctx: SuggestionContext): string[] {
   for (const entry of table) {
     if (entry.match(ctx)) {
-      return entry.lines(ctx);
+      return entry.lines(ctx).map(normalizeRepoFlagLine);
     }
   }
   return [];

--- a/test/suggestions.test.ts
+++ b/test/suggestions.test.ts
@@ -58,6 +58,10 @@ describe("getSuggestions", () => {
       repo: { owner: "cli", name: "cli", nwo: "cli/cli", source: "flag" },
     });
     expect(lines.every((l) => l.includes("-R cli/cli"))).toBe(true);
+    expect(lines.every((l) => !l.includes("gh-axi -R"))).toBe(true);
+    expect(lines).toContain(
+      "Run `gh-axi issue view <number> -R cli/cli` to view details",
+    );
   });
 
   it("does not carry -R flag when repo source is git", () => {


### PR DESCRIPTION
> **Supersedes #37 — please close #37 when this merges.**
>
> This PR ports the fix originally proposed in #37 by @pmarreddy (verified to reproduce on current `main`) and adds the regression test. It is raised through the required `no-mistakes` pipeline, so it satisfies the **"PR must be raised via no-mistakes"** check that #37 currently fails. #37 is now stale and should be closed in favor of this one.

## What Changed

- Added `normalizeRepoFlagLine`, which rewrites emitted suggestion lines so a repo-qualified `` `gh-axi -R <nwo> <command>` `` hint becomes `` `gh-axi <command> -R <nwo>` ``, matching the placement the CLI validator accepts.
- Applied the rewrite to every hint in `getSuggestions` by mapping `entry.lines(ctx)` through `normalizeRepoFlagLine`.
- Extended the suggestions tests to assert no emitted line contains `gh-axi -R` and that the `issue view` hint carries `-R cli/cli` after the command.

## Risk Assessment

✅ Low: A single-purpose, well-tested one-line behavioral fix with a bounded regex that correctly repositions the -R flag and provably leaves the already-correct secret/variable hints untouched.

## Testing

Ran the targeted suggestions tests and the full 493-test vitest suite (all green), then exercised the actual gh-axi CLI against the public cli/cli repo. The transcript shows the CLI's own validator rejects `-R` placed before the command, while the fixed suggestion hints now place `-R` after the command and are directly runnable — following an emitted hint verbatim returns a real issue. No code or setup issues found; working tree left clean.

<details>
<summary>Evidence: gh-axi -R placement CLI transcript (reject-before vs run-after)</summary>

```text
# Evidence: repo flag (-R) placement in gh-axi suggestion hints
# PR #37 — fix(suggestions): place -R after command in repo-qualified hints

## 1. The CLI itself REJECTS -R placed BEFORE the command (the old hint shape)
$ gh-axi -R cli/cli issue list --limit 2
error: Flags must come after the command
code: VALIDATION_ERROR
help[2]: "Run `gh-axi.ts <command> [args] [flags]`",Move `-R` after the command instead of before it

## 2. AFTER fix: suggestion hints now place -R AFTER the command, matching what the CLI accepts
$ gh-axi issue list -R cli/cli --limit 2
count: 2 of 969 total
issues[2]{number,title,state,author,created}:
  13785,"gh skill install: support a configurable default agent",open,sgrimee,56m ago
  13768,Better multi-account `gh` account usage,open,platinummonkey,21h ago
help[2]:
  Run `gh-axi issue view <number> -R cli/cli` to view details
  Run `gh-axi issue create --title "..." --body-file <path> -R cli/cli` to create

## 3. Following the emitted hint verbatim now succeeds (previously the hint was un-runnable)
$ gh-axi issue view <number> -R cli/cli   (using #13768 from the list above)
issue:
  number: 13768
  title: Better multi-account `gh` account usage
  state: open
  author: platinummonkey
  created: 21h ago
  body: "# Problem\n\n`gh` account selection is global which makes it difficult to work concurrently with agents. Ideally this should be made automatic & context-scoped (like `git`'s `includeIf`). For users with multiple accounts logged in with different access this is problematic when those accounts have different access restrictions that are not host-based.\n\n`git` already solves the \"multiple identities on one machine\" problem *automatically* via path-based config (or pseudo-host based config) includes a\n... (truncated, 4528 chars total — use --full to see complete body)"
```
</details>
<details>
<summary>Evidence: Fixed hint output (real CLI)</summary>

```text
$ gh-axi issue list -R cli/cli --limit 2
help[2]:
Run `gh-axi issue view <number> -R cli/cli` to view details
Run `gh-axi issue create --title "..." --body-file <path> -R cli/cli` to create

$ gh-axi -R cli/cli issue list (old hint shape)
error: Flags must come after the command
Move `-R` after the command instead of before it
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `src/suggestions.ts:25` - The fix uses an inject-then-rewrite approach: repoFlag() still injects ` -R &lt;nwo&gt;` immediately after `gh-axi` in ~70 templates, then normalizeRepoFlagLine() regex-rewrites every output line to move it after the command. Meanwhile the newer secret/variable templates (lines 486-536) already append repoFlag at the correct end position and bypass the rewrite entirely. This is functionally correct and well-tested, but leaves two divergent conventions in the file plus a regex post-pass that a future template author must keep in mind. Not a bug — noting for maintainability.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm exec vitest run test/suggestions.test.ts` (11 pass, incl. the new -R-placement assertions)</code>
- <code>`pnpm exec vitest run` full suite — 493/493 pass</code>
- <code>Manual CLI: `gh-axi -R cli/cli issue list` → rejected by validator (old hint shape)</code>
- <code>Manual CLI: `gh-axi issue list -R cli/cli --limit 2` → hints emit `gh-axi issue view &lt;number&gt; -R cli/cli`</code>
- <code>Manual CLI: `gh-axi issue view 13768 -R cli/cli` → following the emitted hint verbatim succeeds</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

