### PR TITLE
feat(cli): support GitHub Enterprise hosts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,13 @@ The SDK also appends a `"built-in":` section to the top-level `--help` output at
 Releases are cut by release-please from conventional commit messages on `main`; merging the bot's release PR triggers `npm publish` via `.github/workflows/release-please.yml`.
 Do not hand-edit `CHANGELOG.md` or `.release-please-manifest.json` (a guard workflow blocks PRs that touch them), and regenerate `skills/gh-axi/SKILL.md` with `pnpm run build:skill` instead of editing it directly.
 
+## GitHub Enterprise host support (`src/host.ts`, `src/cli.ts`)
+
+`gh-axi` targets a custom GitHub host (e.g. a GHE server like `ghe.example.com`) via a global `--hostname <host>` flag or the `GH_HOST` env var; explicit `--hostname` wins.
+Like `-R`/`--repo`, `--hostname` must come *after* the command (the SDK rejects leading flags), and it is stripped from the args before they reach the underlying `gh` (it is never a subcommand flag).
+`src/cli.ts`'s `resolveContext` sets `process.env.GH_HOST` only when `--hostname` is present; the child `gh` process inherits `process.env`, so no explicit env is threaded through `gh.ts`. When no `--hostname` is given, `GH_HOST` is left untouched, keeping the default (github.com) behavior byte-for-byte identical.
+`src/host.ts#resolveHost()` (flag > `GH_HOST` > `github.com`) is the single source of truth for the effective host used when *building or parsing* URLs — `parseRemoteUrl` in `src/context.ts` matches the configured host in `git remote` URLs, and `issue transfer`'s fallback URL is built as `https://<host>/...`. The `gh pr create` output regex (`/pull/(\d+)/`) is already host-agnostic.
+
 ## Secret/variable value input (`src/secretValue.ts`, `src/stdin.ts`, `gh.ts#ghExecWithStdin`)
 
 `gh secret list`/`gh variable list` do not support `--limit` or any pagination flag (unlike `issue`/`pr`/`release` list), so `secret.ts`/`variable.ts` list all results in one call with no `--limit` flag of their own.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,9 @@ Do not hand-edit `CHANGELOG.md` or `.release-please-manifest.json` (a guard work
 ## GitHub Enterprise host support (`src/host.ts`, `src/cli.ts`)
 
 `gh-axi` targets a custom GitHub host (e.g. a GHE server like `ghe.example.com`) via a global `--hostname <host>` flag or the `GH_HOST` env var; explicit `--hostname` wins.
-Like `-R`/`--repo`, `--hostname` must come *after* the command (the SDK rejects leading flags), and it is stripped from the args before they reach the underlying `gh` (it is never a subcommand flag).
+Like `-R`/`--repo`, `--hostname` must come _after_ the command (the SDK rejects leading flags), and it is stripped from the args before they reach the underlying `gh` (it is never a subcommand flag).
 `src/cli.ts`'s `resolveContext` sets `process.env.GH_HOST` only when `--hostname` is present; the child `gh` process inherits `process.env`, so no explicit env is threaded through `gh.ts`. When no `--hostname` is given, `GH_HOST` is left untouched, keeping the default (github.com) behavior byte-for-byte identical.
-`src/host.ts#resolveHost()` (flag > `GH_HOST` > `github.com`) is the single source of truth for the effective host used when *building or parsing* URLs — `parseRemoteUrl` in `src/context.ts` matches the configured host in `git remote` URLs, and `issue transfer`'s fallback URL is built as `https://<host>/...`. The `gh pr create` output regex (`/pull/(\d+)/`) is already host-agnostic.
+`src/host.ts#resolveHost()` (flag > `GH_HOST` > `github.com`) is the single source of truth for the effective host used when _building or parsing_ URLs — `parseRemoteUrl` in `src/context.ts` matches the configured host in `git remote` URLs, and `issue transfer`'s fallback URL is built as `https://<host>/...`. The `gh pr create` output regex (`/pull/(\d+)/`) is already host-agnostic.
 
 ## Secret/variable value input (`src/secretValue.ts`, `src/stdin.ts`, `gh.ts#ghExecWithStdin`)
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ Repository and host targeting are command-first too:
 - `gh-axi run list -R owner/name`
 - `gh-axi search issues "login bug" --repo owner/name`
 - `gh-axi issue list --hostname git.example.com`
-- `gh-axi issue list --hostname=git.example.com`
 
 When a command also needs a destination repository, use a dedicated flag for it:
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ npx skills add kunchenguid/gh-axi --skill gh-axi -g
 That is the entire setup - no npm install needed.
 The skill teaches your agent to run gh-axi through `npx -y gh-axi`, so the CLI comes along on demand.
 You still need [`gh`](https://cli.github.com/) installed and authenticated via `gh auth login` (Node 20+ required).
+For GitHub Enterprise or another custom host, authenticate `gh` for that host and either pass `--hostname <host>` after the command or set `GH_HOST`.
 
 The skill is not a user-facing slash command (`user-invocable: false`).
 Its frontmatter also includes Hermes Agent metadata (`metadata.hermes`) so Hermes can categorize it as a `devops` skill for GitHub, git, CI, pull requests, and releases.
@@ -85,6 +86,7 @@ gh-axi issue list               # list issues in current repo
 gh-axi issue subissue list 16   # list sub-issues for issue #16
 gh-axi pr view 42               # view pull request #42
 gh-axi run list -R owner/repo   # list workflow runs for a specific repo
+gh-axi issue list --hostname git.example.com  # target a GitHub Enterprise host
 gh-axi run view 123456 --job 789012       # inspect a single job within a run
 gh-axi run view --job 789012 --log-failed # show failed log lines for one job
 gh-axi workflow run ci.yml --ref main     # trigger a workflow
@@ -129,14 +131,17 @@ When truncation happens, gh-axi best-effort saves the complete log to a temp fil
 
 - `--help` — show help for any command
 - `-v`, `-V`, `--version` — show the installed `gh-axi` version
+- `--hostname <host>` / `--hostname=<host>` — target a custom GitHub host; explicit flags win over `GH_HOST`
 
-Repository targeting is command-first too:
+Repository and host targeting are command-first too:
 
 - `gh-axi issue list -R owner/name`
 - `gh-axi issue list --repo owner/name`
 - `gh-axi issue list --repo=owner/name`
 - `gh-axi run list -R owner/name`
 - `gh-axi search issues "login bug" --repo owner/name`
+- `gh-axi issue list --hostname git.example.com`
+- `gh-axi issue list --hostname=git.example.com`
 
 When a command also needs a destination repository, use a dedicated flag for it:
 

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -17,6 +17,7 @@ You do not need gh-axi installed globally - invoke it with `npx -y gh-axi <comma
 If gh-axi output shows a follow-up command starting with `gh-axi`, run it as `npx -y gh-axi ...` instead.
 
 gh-axi requires the [`gh`](https://cli.github.com/) CLI installed and authenticated (`gh auth login`). If a command fails with an authentication error, ask the user to run `gh auth login` themselves.
+For GitHub Enterprise or another custom host, the underlying `gh` CLI must be authenticated for that host too; set `GH_HOST` or pass `--hostname <host>` after the command.
 
 ## When to use
 
@@ -27,10 +28,11 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 1. Run `npx -y gh-axi` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: `issue list`, `issue view <n>`, `pr view <n>`, `pr checks <n>`, `run view <id>`, and so on.
 3. Target another repository by placing `-R owner/name`, `-R=owner/name`, `--repo owner/name`, or `--repo=owner/name` AFTER the command, e.g. `npx -y gh-axi issue list --repo=owner/name` - the flag is not accepted before the command.
-4. Trigger (dispatch) a workflow with `workflow run <name> --ref <ref>`; `run` manages existing workflow runs.
-5. Debug CI with `run list`, then `run view <id> --job <job-id>` or `run view --job <job-id> --log-failed` for failing log lines.
+4. Target GitHub Enterprise or another custom host with `GH_HOST`, or by placing `--hostname <host>` or `--hostname=<host>` AFTER the command, e.g. `npx -y gh-axi issue list --hostname=git.example.com`.
+5. Trigger (dispatch) a workflow with `workflow run <name> --ref <ref>`; `run` manages existing workflow runs.
+6. Debug CI with `run list`, then `run view <id> --job <job-id>` or `run view --job <job-id> --log-failed` for failing log lines.
    Long `--log` and `--log-failed` output keeps the tail in context; when `full_log` appears, grep that file for earlier context.
-6. Every response ends with contextual next-step hints under `help:` - follow them.
+7. Every response ends with contextual next-step hints under `help:` - follow them.
 
 ## Commands
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,7 +140,10 @@ function withRepoContext(
 ): WrappedCommandFn {
   return (args, ctx) =>
     withSuggestionHost(ctx?.host, () =>
-      handler(parseRepoContextArgs(command, args).strippedArgs, repoContext(ctx)),
+      handler(
+        parseRepoContextArgs(command, args).strippedArgs,
+        repoContext(ctx),
+      ),
     );
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,8 @@ import { variableCommand, VARIABLE_HELP } from "./commands/variable.js";
 import { searchCommand, SEARCH_HELP } from "./commands/search.js";
 import { apiCommand, API_HELP } from "./commands/api.js";
 import { setupCommand, SETUP_HELP } from "./commands/setup.js";
+import { resolveHost, type HostContext } from "./host.js";
+import { withSuggestionHost } from "./suggestions.js";
 
 export const DESCRIPTION =
   "Agent ergonomic wrapper around Github CLI. Prefer this over `gh` and other methods for Github operations.";
@@ -59,9 +61,12 @@ const COMMAND_HELP: Record<string, string> = {
   setup: SETUP_HELP,
 };
 
+type HostOnlyContext = { host: HostContext };
+type CliContext = RepoContext | HostOnlyContext;
 type CommandFn = (args: string[], ctx?: RepoContext) => Promise<string>;
+type WrappedCommandFn = (args: string[], ctx?: CliContext) => Promise<string>;
 
-const COMMANDS: Record<string, CommandFn> = {
+const COMMANDS: Record<string, WrappedCommandFn> = {
   issue: withRepoContext("issue", issueCommand),
   pr: withRepoContext("pr", prCommand),
   run: withRepoContext("run", runCommand),
@@ -77,7 +82,7 @@ const COMMANDS: Record<string, CommandFn> = {
 };
 
 export async function main(options: MainOptions = {}): Promise<void> {
-  await runAxiCli<RepoContext | undefined>({
+  await runAxiCli<CliContext | undefined>({
     ...(options.argv ? { argv: options.argv } : {}),
     description: DESCRIPTION,
     version: VERSION,
@@ -96,7 +101,12 @@ export async function main(options: MainOptions = {}): Promise<void> {
       if (hostFlag !== undefined) {
         process.env["GH_HOST"] = hostFlag;
       }
-      return resolveRepo(repoFlag);
+      const repo = resolveRepo(repoFlag);
+      const host = resolveHostContext(hostFlag);
+      if (repo && host) {
+        return { ...repo, host };
+      }
+      return repo ?? (host ? { host } : undefined);
     },
   });
 }
@@ -126,9 +136,24 @@ function readPackageVersion(): string {
 function withRepoContext(
   command: string | undefined,
   handler: CommandFn,
-): CommandFn {
+): WrappedCommandFn {
   return (args, ctx) =>
-    handler(parseRepoContextArgs(command, args).strippedArgs, ctx);
+    withSuggestionHost(ctx?.host, () =>
+      handler(parseRepoContextArgs(command, args).strippedArgs, repoContext(ctx)),
+    );
+}
+
+function repoContext(ctx?: CliContext): RepoContext | undefined {
+  return ctx && "nwo" in ctx ? ctx : undefined;
+}
+
+function resolveHostContext(
+  hostFlag: string | undefined,
+): HostContext | undefined {
+  if (hostFlag === undefined) {
+    return undefined;
+  }
+  return { value: resolveHost(hostFlag), source: "flag" };
 }
 
 function parseRepoContextArgs(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,6 @@ examples:
   gh-axi issue list -R owner/name
   gh-axi issue list --repo=owner/name
   gh-axi issue list --hostname git.example.com
-  gh-axi issue list --hostname=git.example.com
   gh-axi pr view 42
   gh-axi secret list
   gh-axi setup hooks

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,13 +31,14 @@ type MainOptions = {
 export const TOP_HELP = `usage: gh-axi [command] [args] [flags]
 commands[13]:
   (none)=dashboard, issue, pr, run, workflow, release, repo, label, secret, variable, search, api, setup
-flags[3]:
-  -R/--repo <OWNER/NAME> (after command), accepts space or equals form, --help, -v/-V/--version
+flags[4]:
+  -R/--repo <OWNER/NAME> (after command), accepts space or equals form, --hostname <host> (after command) or GH_HOST env, --help, -v/-V/--version
 examples:
   gh-axi
   gh-axi issue list --state open
   gh-axi issue list -R owner/name
   gh-axi issue list --repo=owner/name
+  gh-axi issue list --hostname git.example.com
   gh-axi pr view 42
   gh-axi secret list
   gh-axi setup hooks
@@ -85,8 +86,18 @@ export async function main(options: MainOptions = {}): Promise<void> {
     home: withRepoContext(undefined, homeCommand),
     commands: COMMANDS,
     getCommandHelp: (command) => COMMAND_HELP[command],
-    resolveContext: ({ command, args }) =>
-      resolveRepo(parseRepoContextArgs(command, args).repoFlag),
+    resolveContext: ({ command, args }) => {
+      const { repoFlag, hostFlag } = parseRepoContextArgs(command, args);
+      // Explicit --hostname wins over the GH_HOST env var. Setting GH_HOST here
+      // means the child `gh` process (which inherits process.env) targets the
+      // configured host, and resolveHost() reflects it for URL parsing/building.
+      // When no --hostname is given we leave GH_HOST untouched, so default and
+      // env-only behavior stay unchanged.
+      if (hostFlag !== undefined) {
+        process.env["GH_HOST"] = hostFlag;
+      }
+      return resolveRepo(repoFlag);
+    },
   });
 }
 
@@ -123,9 +134,14 @@ function withRepoContext(
 function parseRepoContextArgs(
   command: string | undefined,
   args: string[],
-): { repoFlag: string | undefined; strippedArgs: string[] } {
+): {
+  repoFlag: string | undefined;
+  hostFlag: string | undefined;
+  strippedArgs: string[];
+} {
   const stripped: string[] = [];
   let repoFlag: string | undefined;
+  let hostFlag: string | undefined;
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index];
@@ -163,8 +179,21 @@ function parseRepoContextArgs(
       continue;
     }
 
+    // --hostname routes to GH_HOST for the child gh process; it is never a
+    // subcommand flag, so strip it for every command.
+    if (arg === "--hostname" && index + 1 < args.length) {
+      hostFlag = args[index + 1];
+      index++;
+      continue;
+    }
+
+    if (arg.startsWith("--hostname=") && arg.length > "--hostname=".length) {
+      hostFlag = arg.slice("--hostname=".length);
+      continue;
+    }
+
     stripped.push(arg);
   }
 
-  return { repoFlag, strippedArgs: stripped };
+  return { repoFlag, hostFlag, strippedArgs: stripped };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,13 +34,14 @@ export const TOP_HELP = `usage: gh-axi [command] [args] [flags]
 commands[13]:
   (none)=dashboard, issue, pr, run, workflow, release, repo, label, secret, variable, search, api, setup
 flags[4]:
-  -R/--repo <OWNER/NAME> (after command), accepts space or equals form, --hostname <host> (after command) or GH_HOST env, --help, -v/-V/--version
+  -R/--repo <OWNER/NAME> (after command), --hostname <host> (after command) or GH_HOST env, both flags accept space or equals form, --help, -v/-V/--version
 examples:
   gh-axi
   gh-axi issue list --state open
   gh-axi issue list -R owner/name
   gh-axi issue list --repo=owner/name
   gh-axi issue list --hostname git.example.com
+  gh-axi issue list --hostname=git.example.com
   gh-axi pr view 42
   gh-axi secret list
   gh-axi setup hooks

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -1,4 +1,5 @@
 import type { RepoContext } from "../context.js";
+import { resolveHost } from "../host.js";
 import { ghJson, ghExec, ghRaw } from "../gh.js";
 import { AxiError, mapGhError } from "../errors.js";
 import { getSuggestions } from "../suggestions.js";
@@ -985,7 +986,10 @@ async function transferIssue(
     ]);
   } catch {
     // Fallback: return what we know
-    item = { number: num, url: `https://github.com/${destRepo}/issues/${num}` };
+    item = {
+      number: num,
+      url: `https://${resolveHost()}/${destRepo}/issues/${num}`,
+    };
   }
 
   const blocks: string[] = [renderDetail("issue", item, transferResultSchema)];

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -448,7 +448,7 @@ async function prCreate(args: string[], ctx?: RepoContext): Promise<string> {
   if (project) ghArgs.push("--project", project);
 
   const stdout = await ghExec(ghArgs, ctx);
-  // Parse PR number from URL: https://github.com/OWNER/REPO/pull/123
+  // Parse PR number from the emitted URL: https://<host>/OWNER/REPO/pull/123
   const urlMatch = stdout.match(/\/pull\/(\d+)/);
   const num = urlMatch ? Number(urlMatch[1]) : undefined;
   const url = stdout.trim().split("\n").pop()?.trim() ?? "";

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
-import { execFileSync } from 'node:child_process';
-import { escapeRegExp, resolveHost, type HostContext } from './host.js';
+import { execFileSync } from "node:child_process";
+import { escapeRegExp, resolveHost, type HostContext } from "./host.js";
 
 export interface RepoContext {
   owner: string;
@@ -7,7 +7,7 @@ export interface RepoContext {
   /** Full "OWNER/NAME" string */
   nwo: string;
   /** How the repo was resolved — determines whether to append --repo to gh calls */
-  source: 'flag' | 'env' | 'git';
+  source: "flag" | "env" | "git";
   host?: HostContext;
 }
 
@@ -17,18 +17,18 @@ export interface RepoContext {
  */
 export function resolveRepo(flagValue?: string): RepoContext | undefined {
   if (flagValue) {
-    return parseNwo(flagValue, 'flag');
+    return parseNwo(flagValue, "flag");
   }
 
-  const envRepo = process.env['GH_REPO'];
+  const envRepo = process.env["GH_REPO"];
   if (envRepo) {
-    return parseNwo(envRepo, 'env');
+    return parseNwo(envRepo, "env");
   }
 
   try {
-    const url = execFileSync('git', ['remote', 'get-url', 'origin'], {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
+    const url = execFileSync("git", ["remote", "get-url", "origin"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
     }).trim();
     return parseRemoteUrl(url);
   } catch {
@@ -36,8 +36,11 @@ export function resolveRepo(flagValue?: string): RepoContext | undefined {
   }
 }
 
-function parseNwo(nwo: string, source: 'flag' | 'env'): RepoContext | undefined {
-  const parts = nwo.split('/');
+function parseNwo(
+  nwo: string,
+  source: "flag" | "env",
+): RepoContext | undefined {
+  const parts = nwo.split("/");
   if (parts.length !== 2 || !parts[0] || !parts[1]) return undefined;
   return { owner: parts[0], name: parts[1], nwo, source };
 }
@@ -53,7 +56,7 @@ function parseRemoteUrl(url: string): RepoContext | undefined {
   if (sshMatch) {
     const owner = sshMatch[1];
     const name = sshMatch[2];
-    return { owner, name, nwo: `${owner}/${name}`, source: 'git' };
+    return { owner, name, nwo: `${owner}/${name}`, source: "git" };
   }
   // HTTPS: https://<host>/OWNER/NAME.git
   const httpsMatch = url.match(
@@ -62,7 +65,7 @@ function parseRemoteUrl(url: string): RepoContext | undefined {
   if (httpsMatch) {
     const owner = httpsMatch[1];
     const name = httpsMatch[2];
-    return { owner, name, nwo: `${owner}/${name}`, source: 'git' };
+    return { owner, name, nwo: `${owner}/${name}`, source: "git" };
   }
   return undefined;
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { escapeRegExp, resolveHost } from './host.js';
 
 export interface RepoContext {
   owner: string;
@@ -41,15 +42,18 @@ function parseNwo(nwo: string, source: 'flag' | 'env'): RepoContext | undefined 
 }
 
 function parseRemoteUrl(url: string): RepoContext | undefined {
-  // SSH: git@github.com:OWNER/NAME.git
-  const sshMatch = url.match(/github\.com[:/]([^/]+)\/([^/]+?)(?:\.git)?$/);
+  // Match against the configured host (defaults to github.com), so remotes on a
+  // GitHub Enterprise host such as git.example.com resolve too.
+  const host = escapeRegExp(resolveHost());
+  // SSH: git@<host>:OWNER/NAME.git
+  const sshMatch = url.match(new RegExp(`${host}[:/]([^/]+)/([^/]+?)(?:\\.git)?$`));
   if (sshMatch) {
     const owner = sshMatch[1];
     const name = sshMatch[2];
     return { owner, name, nwo: `${owner}/${name}`, source: 'git' };
   }
-  // HTTPS: https://github.com/OWNER/NAME.git
-  const httpsMatch = url.match(/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+  // HTTPS: https://<host>/OWNER/NAME.git
+  const httpsMatch = url.match(new RegExp(`${host}/([^/]+)/([^/]+?)(?:\\.git)?$`));
   if (httpsMatch) {
     const owner = httpsMatch[1];
     const name = httpsMatch[2];

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { escapeRegExp, resolveHost } from './host.js';
+import { escapeRegExp, resolveHost, type HostContext } from './host.js';
 
 export interface RepoContext {
   owner: string;
@@ -8,6 +8,7 @@ export interface RepoContext {
   nwo: string;
   /** How the repo was resolved — determines whether to append --repo to gh calls */
   source: 'flag' | 'env' | 'git';
+  host?: HostContext;
 }
 
 /**
@@ -46,14 +47,18 @@ function parseRemoteUrl(url: string): RepoContext | undefined {
   // GitHub Enterprise host such as git.example.com resolve too.
   const host = escapeRegExp(resolveHost());
   // SSH: git@<host>:OWNER/NAME.git
-  const sshMatch = url.match(new RegExp(`${host}[:/]([^/]+)/([^/]+?)(?:\\.git)?$`));
+  const sshMatch = url.match(
+    new RegExp(`(?:^|@|/)${host}[:/]([^/]+)/([^/]+?)(?:\\.git)?$`),
+  );
   if (sshMatch) {
     const owner = sshMatch[1];
     const name = sshMatch[2];
     return { owner, name, nwo: `${owner}/${name}`, source: 'git' };
   }
   // HTTPS: https://<host>/OWNER/NAME.git
-  const httpsMatch = url.match(new RegExp(`${host}/([^/]+)/([^/]+?)(?:\\.git)?$`));
+  const httpsMatch = url.match(
+    new RegExp(`(?:^|@|/)${host}/([^/]+)/([^/]+?)(?:\\.git)?$`),
+  );
   if (httpsMatch) {
     const owner = httpsMatch[1];
     const name = httpsMatch[2];

--- a/src/host.ts
+++ b/src/host.ts
@@ -1,0 +1,21 @@
+/** Default GitHub host used when none is configured. */
+export const DEFAULT_HOST = "github.com";
+
+/**
+ * Resolve the effective GitHub host.
+ * Priority: explicit --hostname flag > GH_HOST env > github.com.
+ *
+ * The resolved host feeds two places: the child `gh` process (via the GH_HOST
+ * env var, which the child inherits) and the URLs gh-axi parses or builds.
+ */
+export function resolveHost(flagValue?: string): string {
+  if (flagValue) return flagValue;
+  const envHost = process.env["GH_HOST"];
+  if (envHost) return envHost;
+  return DEFAULT_HOST;
+}
+
+/** Escape a host so it can be embedded literally in a RegExp. */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/host.ts
+++ b/src/host.ts
@@ -1,6 +1,11 @@
 /** Default GitHub host used when none is configured. */
 export const DEFAULT_HOST = "github.com";
 
+export interface HostContext {
+  value: string;
+  source: "flag" | "env" | "default";
+}
+
 /**
  * Resolve the effective GitHub host.
  * Priority: explicit --hostname flag > GH_HOST env > github.com.

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -60,6 +60,7 @@ You do not need gh-axi installed globally - invoke it with \`npx -y gh-axi <comm
 If gh-axi output shows a follow-up command starting with \`gh-axi\`, run it as \`npx -y gh-axi ...\` instead.
 
 gh-axi requires the [\`gh\`](https://cli.github.com/) CLI installed and authenticated (\`gh auth login\`). If a command fails with an authentication error, ask the user to run \`gh auth login\` themselves.
+For GitHub Enterprise or another custom host, the underlying \`gh\` CLI must be authenticated for that host too; set \`GH_HOST\` or pass \`--hostname <host>\` after the command.
 
 ## When to use
 
@@ -70,10 +71,11 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 1. Run \`npx -y gh-axi\` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: \`issue list\`, \`issue view <n>\`, \`pr view <n>\`, \`pr checks <n>\`, \`run view <id>\`, and so on.
 3. Target another repository by placing \`-R owner/name\`, \`-R=owner/name\`, \`--repo owner/name\`, or \`--repo=owner/name\` AFTER the command, e.g. \`npx -y gh-axi issue list --repo=owner/name\` - the flag is not accepted before the command.
-4. Trigger (dispatch) a workflow with \`workflow run <name> --ref <ref>\`; \`run\` manages existing workflow runs.
-5. Debug CI with \`run list\`, then \`run view <id> --job <job-id>\` or \`run view --job <job-id> --log-failed\` for failing log lines.
+4. Target GitHub Enterprise or another custom host with \`GH_HOST\`, or by placing \`--hostname <host>\` or \`--hostname=<host>\` AFTER the command, e.g. \`npx -y gh-axi issue list --hostname=git.example.com\`.
+5. Trigger (dispatch) a workflow with \`workflow run <name> --ref <ref>\`; \`run\` manages existing workflow runs.
+6. Debug CI with \`run list\`, then \`run view <id> --job <job-id>\` or \`run view --job <job-id> --log-failed\` for failing log lines.
    Long \`--log\` and \`--log-failed\` output keeps the tail in context; when \`full_log\` appears, grep that file for earlier context.
-6. Every response ends with contextual next-step hints under \`help:\` - follow them.
+7. Every response ends with contextual next-step hints under \`help:\` - follow them.
 
 ## Commands
 

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -1,4 +1,5 @@
 import type { RepoContext } from "./context.js";
+import { DEFAULT_HOST, type HostContext } from "./host.js";
 
 interface SuggestionContext {
   domain: string;
@@ -8,6 +9,7 @@ interface SuggestionContext {
   /** The entity number/id/tag for substitution */
   id?: string | number;
   repo?: RepoContext;
+  host?: HostContext;
 }
 
 type SuggestionEntry = {
@@ -24,6 +26,37 @@ function repoFlag(ctx: SuggestionContext): string {
 
 function normalizeRepoFlagLine(line: string): string {
   return line.replace(/`gh-axi -R ([^`\s]+) ([^`]+)`/g, "`gh-axi $2 -R $1`");
+}
+
+let activeHost: HostContext | undefined;
+
+export async function withSuggestionHost<T>(
+  host: HostContext | undefined,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const previousHost = activeHost;
+  activeHost = host;
+  try {
+    return await callback();
+  } finally {
+    activeHost = previousHost;
+  }
+}
+
+function hostnameFlag(ctx: SuggestionContext): string {
+  const host = ctx.host ?? ctx.repo?.host ?? activeHost;
+  if (!host || host.source !== "flag" || host.value === DEFAULT_HOST) {
+    return "";
+  }
+  return ` --hostname ${host.value}`;
+}
+
+function appendHostnameFlag(line: string, ctx: SuggestionContext): string {
+  const flag = hostnameFlag(ctx);
+  if (!flag) {
+    return line;
+  }
+  return line.replace(/`([^`]*\bgh-axi\b[^`]*)`/g, `\`$1${flag}\``);
 }
 
 const table: SuggestionEntry[] = [
@@ -553,7 +586,10 @@ const table: SuggestionEntry[] = [
 export function getSuggestions(ctx: SuggestionContext): string[] {
   for (const entry of table) {
     if (entry.match(ctx)) {
-      return entry.lines(ctx).map(normalizeRepoFlagLine);
+      return entry
+        .lines(ctx)
+        .map(normalizeRepoFlagLine)
+        .map((line) => appendHostnameFlag(line, ctx));
     }
   }
   return [];

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -76,6 +76,7 @@ vi.mock("../src/context.js", () => ({
 import { main, TOP_HELP } from "../src/cli.js";
 import { homeCommand } from "../src/commands/home.js";
 import { issueCommand } from "../src/commands/issue.js";
+import { prCommand } from "../src/commands/pr.js";
 import { releaseCommand } from "../src/commands/release.js";
 import { resolveRepo } from "../src/context.js";
 
@@ -106,8 +107,11 @@ describe("main CLI", () => {
   });
 
   it("documents the top-level version flags in help output", () => {
-    expect(TOP_HELP).toContain("flags[3]:");
+    expect(TOP_HELP).toContain("flags[4]:");
     expect(TOP_HELP).toContain("-R/--repo <OWNER/NAME> (after command)");
+    expect(TOP_HELP).toContain(
+      "--hostname <host> (after command) or GH_HOST env",
+    );
     expect(TOP_HELP).toContain("--help");
     expect(TOP_HELP).toContain("-v/-V/--version");
   });
@@ -372,5 +376,111 @@ describe("main CLI", () => {
       ["transfer", "123", "--to-repo", "dest/repo"],
       ctx,
     );
+  });
+
+  describe("--hostname / GH_HOST", () => {
+    const originalHost = process.env.GH_HOST;
+
+    afterEach(() => {
+      if (originalHost === undefined) {
+        delete process.env.GH_HOST;
+      } else {
+        process.env.GH_HOST = originalHost;
+      }
+    });
+
+    it("documents --hostname in the top-level help", () => {
+      expect(TOP_HELP).toContain("--hostname <host>");
+      expect(TOP_HELP).toContain(
+        "gh-axi issue list --hostname git.example.com",
+      );
+    });
+
+    it("resolves --hostname after the command into GH_HOST", async () => {
+      delete process.env.GH_HOST;
+      await main();
+
+      const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+      options.resolveContext({
+        command: "issue",
+        args: ["list", "--hostname", "git.example.com"],
+      });
+
+      expect(process.env.GH_HOST).toBe("git.example.com");
+    });
+
+    it("accepts --hostname=value form", async () => {
+      delete process.env.GH_HOST;
+      await main();
+
+      const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+      options.resolveContext({
+        command: "pr",
+        args: ["view", "42", "--hostname=git.example.com"],
+      });
+
+      expect(process.env.GH_HOST).toBe("git.example.com");
+    });
+
+    it("lets an explicit --hostname win over an existing GH_HOST env", async () => {
+      process.env.GH_HOST = "env.example.com";
+      await main();
+
+      const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+      options.resolveContext({
+        command: "issue",
+        args: ["list", "--hostname", "flag.example.com"],
+      });
+
+      expect(process.env.GH_HOST).toBe("flag.example.com");
+    });
+
+    it("leaves GH_HOST untouched when no --hostname is given", async () => {
+      process.env.GH_HOST = "env.example.com";
+      await main();
+
+      const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+      options.resolveContext({ command: "issue", args: ["list"] });
+
+      expect(process.env.GH_HOST).toBe("env.example.com");
+    });
+
+    it("strips --hostname before invoking command handlers", async () => {
+      await main();
+
+      const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+      const ctx = {
+        owner: "octo",
+        name: "repo",
+        nwo: "octo/repo",
+        source: "git",
+      };
+
+      await options.commands.issue(
+        ["list", "--hostname", "git.example.com"],
+        ctx,
+      );
+
+      expect(vi.mocked(issueCommand)).toHaveBeenCalledWith(["list"], ctx);
+    });
+
+    it("strips --hostname=value before invoking command handlers", async () => {
+      await main();
+
+      const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+      const ctx = {
+        owner: "octo",
+        name: "repo",
+        nwo: "octo/repo",
+        source: "git",
+      };
+
+      await options.commands.pr(
+        ["view", "42", "--hostname=git.example.com"],
+        ctx,
+      );
+
+      expect(vi.mocked(prCommand)).toHaveBeenCalledWith(["view", "42"], ctx);
+    });
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -409,6 +409,23 @@ describe("main CLI", () => {
       expect(process.env.GH_HOST).toBe("git.example.com");
     });
 
+    it("tracks explicit --hostname in resolved context", async () => {
+      delete process.env.GH_HOST;
+      await main();
+
+      const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+      const context = options.resolveContext({
+        command: "issue",
+        args: ["list", "--hostname", "git.example.com"],
+      });
+
+      expect(context).toEqual(
+        expect.objectContaining({
+          host: { value: "git.example.com", source: "flag" },
+        }),
+      );
+    });
+
     it("accepts --hostname=value form", async () => {
       delete process.env.GH_HOST;
       await main();

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -679,6 +679,50 @@ describe("issueCommand", () => {
         "dest/repo",
       ]);
     });
+
+    it("builds the fallback URL on the configured host when the follow-up view fails", async () => {
+      const originalHost = process.env.GH_HOST;
+      process.env.GH_HOST = "git.example.com";
+      try {
+        mockedGhExec.mockResolvedValue("");
+        mockedGhJson.mockRejectedValue(new AxiError("nope", "NOT_FOUND"));
+
+        const result = await issueCommand(
+          ["transfer", "10", "--to-repo", "dest/repo"],
+          ctx,
+        );
+
+        expect(result).toContain("https://git.example.com/dest/repo/issues/10");
+      } finally {
+        if (originalHost === undefined) {
+          delete process.env.GH_HOST;
+        } else {
+          process.env.GH_HOST = originalHost;
+        }
+      }
+    });
+
+    it("builds the fallback URL on github.com by default", async () => {
+      const originalHost = process.env.GH_HOST;
+      delete process.env.GH_HOST;
+      try {
+        mockedGhExec.mockResolvedValue("");
+        mockedGhJson.mockRejectedValue(new AxiError("nope", "NOT_FOUND"));
+
+        const result = await issueCommand(
+          ["transfer", "10", "--to-repo", "dest/repo"],
+          ctx,
+        );
+
+        expect(result).toContain("https://github.com/dest/repo/issues/10");
+      } finally {
+        if (originalHost === undefined) {
+          delete process.env.GH_HOST;
+        } else {
+          process.env.GH_HOST = originalHost;
+        }
+      }
+    });
   });
 
   describe("view with sub-issue relationships", () => {

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -149,4 +149,10 @@ describe('resolveRepo', () => {
     mockedExecFileSync.mockReturnValue('git@github.com:cli/cli.git\n');
     expect(resolveRepo()).toBeUndefined();
   });
+
+  it('does not match a subdomain-prefixed remote host', () => {
+    process.env['GH_HOST'] = 'git.example.com';
+    mockedExecFileSync.mockReturnValue('git@old-git.example.com:cli/cli.git\n');
+    expect(resolveRepo()).toBeUndefined();
+  });
 });

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,20 +1,20 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { execFileSync } from 'node:child_process';
-import { resolveRepo } from '../src/context.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { resolveRepo } from "../src/context.js";
 
-vi.mock('node:child_process', () => ({
+vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
 }));
 
 const mockedExecFileSync = vi.mocked(execFileSync);
 
-describe('resolveRepo', () => {
+describe("resolveRepo", () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
     process.env = { ...originalEnv };
-    delete process.env['GH_REPO'];
-    delete process.env['GH_HOST'];
+    delete process.env["GH_REPO"];
+    delete process.env["GH_HOST"];
     mockedExecFileSync.mockReset();
   });
 
@@ -22,137 +22,143 @@ describe('resolveRepo', () => {
     process.env = originalEnv;
   });
 
-  it('returns undefined when no repo is available', () => {
+  it("returns undefined when no repo is available", () => {
     mockedExecFileSync.mockImplementation(() => {
-      throw new Error('not a git repo');
+      throw new Error("not a git repo");
     });
     expect(resolveRepo()).toBeUndefined();
   });
 
-  it('parses flag value correctly', () => {
-    const result = resolveRepo('cli/cli');
+  it("parses flag value correctly", () => {
+    const result = resolveRepo("cli/cli");
     expect(result).toEqual({
-      owner: 'cli',
-      name: 'cli',
-      nwo: 'cli/cli',
-      source: 'flag',
+      owner: "cli",
+      name: "cli",
+      nwo: "cli/cli",
+      source: "flag",
     });
     // Should not call git when flag is provided
     expect(mockedExecFileSync).not.toHaveBeenCalled();
   });
 
-  it('returns undefined for invalid flag value', () => {
-    expect(resolveRepo('invalid')).toBeUndefined();
-    expect(resolveRepo('a/b/c')).toBeUndefined();
-    expect(resolveRepo('/name')).toBeUndefined();
-    expect(resolveRepo('owner/')).toBeUndefined();
+  it("returns undefined for invalid flag value", () => {
+    expect(resolveRepo("invalid")).toBeUndefined();
+    expect(resolveRepo("a/b/c")).toBeUndefined();
+    expect(resolveRepo("/name")).toBeUndefined();
+    expect(resolveRepo("owner/")).toBeUndefined();
   });
 
-  it('uses GH_REPO env var', () => {
-    process.env['GH_REPO'] = 'octocat/hello-world';
+  it("uses GH_REPO env var", () => {
+    process.env["GH_REPO"] = "octocat/hello-world";
     const result = resolveRepo();
     expect(result).toEqual({
-      owner: 'octocat',
-      name: 'hello-world',
-      nwo: 'octocat/hello-world',
-      source: 'env',
+      owner: "octocat",
+      name: "hello-world",
+      nwo: "octocat/hello-world",
+      source: "env",
     });
     expect(mockedExecFileSync).not.toHaveBeenCalled();
   });
 
-  it('parses SSH git remote URLs', () => {
-    mockedExecFileSync.mockReturnValue('git@github.com:cli/cli.git\n');
+  it("parses SSH git remote URLs", () => {
+    mockedExecFileSync.mockReturnValue("git@github.com:cli/cli.git\n");
     const result = resolveRepo();
     expect(result).toEqual({
-      owner: 'cli',
-      name: 'cli',
-      nwo: 'cli/cli',
-      source: 'git',
+      owner: "cli",
+      name: "cli",
+      nwo: "cli/cli",
+      source: "git",
     });
   });
 
-  it('parses SSH git remote URLs without .git suffix', () => {
-    mockedExecFileSync.mockReturnValue('git@github.com:owner/repo\n');
+  it("parses SSH git remote URLs without .git suffix", () => {
+    mockedExecFileSync.mockReturnValue("git@github.com:owner/repo\n");
     const result = resolveRepo();
     expect(result).toEqual({
-      owner: 'owner',
-      name: 'repo',
-      nwo: 'owner/repo',
-      source: 'git',
+      owner: "owner",
+      name: "repo",
+      nwo: "owner/repo",
+      source: "git",
     });
   });
 
-  it('parses HTTPS git remote URLs', () => {
-    mockedExecFileSync.mockReturnValue('https://github.com/cli/cli.git\n');
+  it("parses HTTPS git remote URLs", () => {
+    mockedExecFileSync.mockReturnValue("https://github.com/cli/cli.git\n");
     const result = resolveRepo();
     expect(result).toEqual({
-      owner: 'cli',
-      name: 'cli',
-      nwo: 'cli/cli',
-      source: 'git',
+      owner: "cli",
+      name: "cli",
+      nwo: "cli/cli",
+      source: "git",
     });
   });
 
-  it('parses HTTPS git remote URLs without .git suffix', () => {
-    mockedExecFileSync.mockReturnValue('https://github.com/owner/repo\n');
+  it("parses HTTPS git remote URLs without .git suffix", () => {
+    mockedExecFileSync.mockReturnValue("https://github.com/owner/repo\n");
     const result = resolveRepo();
     expect(result).toEqual({
-      owner: 'owner',
-      name: 'repo',
-      nwo: 'owner/repo',
-      source: 'git',
+      owner: "owner",
+      name: "repo",
+      nwo: "owner/repo",
+      source: "git",
     });
   });
 
-  it('prioritizes flag over env and git', () => {
-    process.env['GH_REPO'] = 'env-owner/env-repo';
-    mockedExecFileSync.mockReturnValue('git@github.com:git-owner/git-repo.git\n');
-    const result = resolveRepo('flag-owner/flag-repo');
-    expect(result!.source).toBe('flag');
-    expect(result!.nwo).toBe('flag-owner/flag-repo');
+  it("prioritizes flag over env and git", () => {
+    process.env["GH_REPO"] = "env-owner/env-repo";
+    mockedExecFileSync.mockReturnValue(
+      "git@github.com:git-owner/git-repo.git\n",
+    );
+    const result = resolveRepo("flag-owner/flag-repo");
+    expect(result!.source).toBe("flag");
+    expect(result!.nwo).toBe("flag-owner/flag-repo");
   });
 
-  it('prioritizes env over git', () => {
-    process.env['GH_REPO'] = 'env-owner/env-repo';
-    mockedExecFileSync.mockReturnValue('git@github.com:git-owner/git-repo.git\n');
+  it("prioritizes env over git", () => {
+    process.env["GH_REPO"] = "env-owner/env-repo";
+    mockedExecFileSync.mockReturnValue(
+      "git@github.com:git-owner/git-repo.git\n",
+    );
     const result = resolveRepo();
-    expect(result!.source).toBe('env');
-    expect(result!.nwo).toBe('env-owner/env-repo');
+    expect(result!.source).toBe("env");
+    expect(result!.nwo).toBe("env-owner/env-repo");
   });
 
-  it('parses SSH remotes on a GitHub Enterprise host from GH_HOST', () => {
-    process.env['GH_HOST'] = 'git.example.com';
-    mockedExecFileSync.mockReturnValue('git@git.example.com:cli/cli.git\n');
+  it("parses SSH remotes on a GitHub Enterprise host from GH_HOST", () => {
+    process.env["GH_HOST"] = "git.example.com";
+    mockedExecFileSync.mockReturnValue("git@git.example.com:cli/cli.git\n");
     const result = resolveRepo();
     expect(result).toEqual({
-      owner: 'cli',
-      name: 'cli',
-      nwo: 'cli/cli',
-      source: 'git',
+      owner: "cli",
+      name: "cli",
+      nwo: "cli/cli",
+      source: "git",
     });
   });
 
-  it('parses HTTPS remotes on a GitHub Enterprise host from GH_HOST', () => {
-    process.env['GH_HOST'] = 'git.example.com';
-    mockedExecFileSync.mockReturnValue('https://git.example.com/owner/repo.git\n');
+  it("parses HTTPS remotes on a GitHub Enterprise host from GH_HOST", () => {
+    process.env["GH_HOST"] = "git.example.com";
+    mockedExecFileSync.mockReturnValue(
+      "https://git.example.com/owner/repo.git\n",
+    );
     const result = resolveRepo();
     expect(result).toEqual({
-      owner: 'owner',
-      name: 'repo',
-      nwo: 'owner/repo',
-      source: 'git',
+      owner: "owner",
+      name: "repo",
+      nwo: "owner/repo",
+      source: "git",
     });
   });
 
-  it('does not match a github.com remote when GH_HOST names another host', () => {
-    process.env['GH_HOST'] = 'git.example.com';
-    mockedExecFileSync.mockReturnValue('git@github.com:cli/cli.git\n');
+  it("does not match a github.com remote when GH_HOST names another host", () => {
+    process.env["GH_HOST"] = "git.example.com";
+    mockedExecFileSync.mockReturnValue("git@github.com:cli/cli.git\n");
     expect(resolveRepo()).toBeUndefined();
   });
 
-  it('does not match a subdomain-prefixed remote host', () => {
-    process.env['GH_HOST'] = 'git.example.com';
-    mockedExecFileSync.mockReturnValue('git@old-git.example.com:cli/cli.git\n');
+  it("does not match a subdomain-prefixed remote host", () => {
+    process.env["GH_HOST"] = "git.example.com";
+    mockedExecFileSync.mockReturnValue("git@old-git.example.com:cli/cli.git\n");
     expect(resolveRepo()).toBeUndefined();
   });
 });

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -14,6 +14,7 @@ describe('resolveRepo', () => {
   beforeEach(() => {
     process.env = { ...originalEnv };
     delete process.env['GH_REPO'];
+    delete process.env['GH_HOST'];
     mockedExecFileSync.mockReset();
   });
 
@@ -117,5 +118,35 @@ describe('resolveRepo', () => {
     const result = resolveRepo();
     expect(result!.source).toBe('env');
     expect(result!.nwo).toBe('env-owner/env-repo');
+  });
+
+  it('parses SSH remotes on a GitHub Enterprise host from GH_HOST', () => {
+    process.env['GH_HOST'] = 'git.example.com';
+    mockedExecFileSync.mockReturnValue('git@git.example.com:cli/cli.git\n');
+    const result = resolveRepo();
+    expect(result).toEqual({
+      owner: 'cli',
+      name: 'cli',
+      nwo: 'cli/cli',
+      source: 'git',
+    });
+  });
+
+  it('parses HTTPS remotes on a GitHub Enterprise host from GH_HOST', () => {
+    process.env['GH_HOST'] = 'git.example.com';
+    mockedExecFileSync.mockReturnValue('https://git.example.com/owner/repo.git\n');
+    const result = resolveRepo();
+    expect(result).toEqual({
+      owner: 'owner',
+      name: 'repo',
+      nwo: 'owner/repo',
+      source: 'git',
+    });
+  });
+
+  it('does not match a github.com remote when GH_HOST names another host', () => {
+    process.env['GH_HOST'] = 'git.example.com';
+    mockedExecFileSync.mockReturnValue('git@github.com:cli/cli.git\n');
+    expect(resolveRepo()).toBeUndefined();
   });
 });

--- a/test/host.test.ts
+++ b/test/host.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_HOST, escapeRegExp, resolveHost } from "../src/host.js";
+
+describe("resolveHost", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env["GH_HOST"];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("defaults to github.com when nothing is configured", () => {
+    expect(resolveHost()).toBe(DEFAULT_HOST);
+    expect(resolveHost()).toBe("github.com");
+  });
+
+  it("honors the GH_HOST env var", () => {
+    process.env["GH_HOST"] = "git.example.com";
+    expect(resolveHost()).toBe("git.example.com");
+  });
+
+  it("lets an explicit flag value win over GH_HOST", () => {
+    process.env["GH_HOST"] = "env.example.com";
+    expect(resolveHost("flag.example.com")).toBe("flag.example.com");
+  });
+
+  it("uses the flag value when GH_HOST is unset", () => {
+    expect(resolveHost("ghe.example.com")).toBe("ghe.example.com");
+  });
+
+  it("treats an empty flag value as unset and falls back", () => {
+    process.env["GH_HOST"] = "env.example.com";
+    expect(resolveHost("")).toBe("env.example.com");
+  });
+});
+
+describe("escapeRegExp", () => {
+  it("escapes regex metacharacters such as dots", () => {
+    const pattern = new RegExp(escapeRegExp("git.example.com"));
+    expect(pattern.test("git.example.com")).toBe(true);
+    // The dot must be literal, not a wildcard.
+    expect(pattern.test("gitxexamplexcom")).toBe(false);
+  });
+});

--- a/test/suggestions.test.ts
+++ b/test/suggestions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getSuggestions } from "../src/suggestions.js";
+import { getSuggestions, withSuggestionHost } from "../src/suggestions.js";
 
 describe("getSuggestions", () => {
   it("returns home suggestions", () => {
@@ -61,6 +61,64 @@ describe("getSuggestions", () => {
     expect(lines.every((l) => !l.includes("gh-axi -R"))).toBe(true);
     expect(lines).toContain(
       "Run `gh-axi issue view <number> -R cli/cli` to view details",
+    );
+  });
+
+  it("carries explicit non-default hostname flags", () => {
+    const lines = getSuggestions({
+      domain: "issue",
+      action: "list",
+      isEmpty: false,
+      repo: {
+        owner: "cli",
+        name: "cli",
+        nwo: "cli/cli",
+        source: "flag",
+        host: { value: "git.example.com", source: "flag" },
+      },
+    });
+
+    expect(lines).toEqual([
+      "Run `gh-axi issue view <number> -R cli/cli --hostname git.example.com` to view details",
+      'Run `gh-axi issue create --title "..." --body-file <path> -R cli/cli --hostname git.example.com` to create',
+    ]);
+  });
+
+  it("does not carry env-only hostname flags", () => {
+    const lines = getSuggestions({
+      domain: "issue",
+      action: "list",
+      isEmpty: false,
+      host: { value: "git.example.com", source: "env" },
+    });
+
+    expect(lines.every((l) => !l.includes("--hostname"))).toBe(true);
+  });
+
+  it("does not carry default hostname flags", () => {
+    const lines = getSuggestions({
+      domain: "issue",
+      action: "list",
+      isEmpty: false,
+      host: { value: "github.com", source: "flag" },
+    });
+
+    expect(lines.every((l) => !l.includes("--hostname"))).toBe(true);
+  });
+
+  it("carries host-only CLI context into suggestions", async () => {
+    const lines = await withSuggestionHost(
+      { value: "git.example.com", source: "flag" },
+      async () =>
+        getSuggestions({
+          domain: "issue",
+          action: "list",
+          isEmpty: false,
+        }),
+    );
+
+    expect(lines).toContain(
+      "Run `gh-axi issue view <number> --hostname git.example.com` to view details",
     );
   });
 


### PR DESCRIPTION
## Intent

Add GitHub Enterprise (custom hostname) support to gh-axi so it works against internal GHE hosts like ghe.example.com, not only github.com. Add a global --hostname <host> flag and honor the GH_HOST env var, with the explicit flag winning over the env var; resolve the effective host once, defaulting to github.com. Pass the resolved host to the underlying gh by exporting GH_HOST so the child gh process inherits it. Generalize the hard-coded github.com URL parsing/construction to the configured host. Keep default (no host configured) behavior byte-for-byte identical.

Key decisions and tradeoffs (a reviewer reading only the diff would not know these):
- --hostname is parsed AFTER the command, exactly like the existing -R/--repo flag, because the axi-sdk-js CLI rejects any leading flag before the command. It is documented in TOP_HELP (now flags[4]) with an example.
- The child gh process inherits process.env, so cli.ts's resolveContext sets process.env.GH_HOST ONLY when --hostname is present, rather than threading an explicit env object through every gh.ts call. When no --hostname is given, GH_HOST is left untouched, which keeps the default github.com path byte-for-byte identical (no GH_HOST=github.com injection).
- New src/host.ts resolveHost() (flag > GH_HOST > github.com) is the single source of truth for the effective host used when parsing/building URLs. parseRemoteUrl in context.ts now matches the configured host in git remotes (regex-escaped); issue transfer's fallback URL is built as https://<host>/...; the gh pr create output regex (/pull/(\d+)/) was already host-agnostic so only its comment changed.
- The remaining github.com references in errors.ts and skill.ts are cli.github.com docs links (the gh CLI's own website), NOT hosts to generalize, so they were intentionally left unchanged.
- skills/gh-axi/SKILL.md is generated but unaffected (only the commands block and description feed it); verified via pnpm build:skill --check.
- Added vitest tests: host resolution precedence, GHE SSH/HTTPS remote parsing plus a non-matching-host guard, --hostname -> GH_HOST plumbing including flag-wins-over-env and no-flag-leaves-untouched, arg stripping, and transfer URL emit for both a GHE host and the github.com default. All 511 tests, tsc build, eslint, and skill check pass; verified end-to-end with a stub gh that the child receives the right GH_HOST and that --hostname never leaks into the child argv.

## What Changed
- Added GitHub Enterprise host targeting via `--hostname <host>` and `GH_HOST`, with explicit flags taking precedence and child `gh` calls inheriting the resolved host.
- Generalized repo context resolution, remote parsing, transfer URL generation, and follow-up suggestions to use the configured host while preserving default `github.com` behavior.
- Updated README/skill docs and added coverage for host precedence, GHE remote parsing, argv stripping, suggestion preservation, and transfer URLs.

## Risk Assessment

✅ Low: The change is narrowly scoped to host resolution, argument stripping, remote parsing, fallback URL construction, and suggestion rendering, with the prior review risks addressed and no remaining material issues found in the reviewed paths.

## Testing

Installed dependencies from the frozen lockfile via one-shot pnpm because the pinned local pnpm shim was missing, ran the focused hostname-related Vitest files, captured an end-to-end CLI transcript proving `--hostname` overrides `GH_HOST`, env-only host propagation works, default mode does not inject `GH_HOST`, and then ran the full Vitest suite successfully.

<details>
<summary>Evidence: GHE host CLI E2E transcript</summary>

<code>$ GH_HOST=env.example.com GH_REPO=octo/repo gh-axi issue list --hostname ghe.example.com --limit 2&#10;count: 1&#10;issues[1]{number,title,state,author,created}:&#10;62,GHE hostname smoke issue,open,hastarin,12h ago&#10;help[2]:&#10;Run `gh-axi issue view &lt;number&gt; -R octo/repo --hostname ghe.example.com` to view details&#10;Run `gh-axi issue create --title &#34;...&#34; --body-file &lt;path&gt; -R octo/repo --hostname ghe.example.com` to create&#10;&#10;child gh calls show the child received GH_HOST=ghe.example.com and no --hostname argv; env-only preserved GH_HOST=git.env.example; default mode left GH_HOST unset.</code>

```text
$ GH_HOST=env.example.com GH_REPO=octo/repo gh-axi issue list --hostname ghe.example.com --limit 2
count: 1
issues[1]{number,title,state,author,created}:
  62,GHE hostname smoke issue,open,hastarin,12h ago
help[2]:
  Run `gh-axi issue view <number> -R octo/repo --hostname ghe.example.com` to view details
  Run `gh-axi issue create --title "..." --body-file <path> -R octo/repo --hostname ghe.example.com` to create

$ GH_HOST=git.env.example GH_REPO=octo/repo gh-axi issue list --limit 2
count: 1
issues[1]{number,title,state,author,created}:
  62,GHE hostname smoke issue,open,hastarin,12h ago
help[2]:
  Run `gh-axi issue view <number> -R octo/repo` to view details
  Run `gh-axi issue create --title "..." --body-file <path> -R octo/repo` to create

$ GH_HOST unset GH_REPO=octo/repo gh-axi issue list --limit 2
count: 1
issues[1]{number,title,state,author,created}:
  62,GHE hostname smoke issue,open,hastarin,12h ago
help[2]:
  Run `gh-axi issue view <number> -R octo/repo` to view details
  Run `gh-axi issue create --title "..." --body-file <path> -R octo/repo` to create

child gh calls (JSONL):
{"argv":["issue","list","--json","number,title,state,author,createdAt","--limit","2","--repo","octo/repo"],"GH_HOST":"ghe.example.com","GH_REPO":"octo/repo"}
{"argv":["issue","list","--json","number,title,state,author,createdAt","--limit","2","--repo","octo/repo"],"GH_HOST":"git.env.example","GH_REPO":"octo/repo"}
{"argv":["issue","list","--json","number,title,state,author,createdAt","--limit","2","--repo","octo/repo"],"GH_HOST":"<unset>","GH_REPO":"octo/repo"}
```
</details>
<details>
<summary>Evidence: Stub gh child-process log</summary>

<code>{&#34;argv&#34;:[&#34;issue&#34;,&#34;list&#34;,&#34;--json&#34;,&#34;number,title,state,author,createdAt&#34;,&#34;--limit&#34;,&#34;2&#34;,&#34;--repo&#34;,&#34;octo/repo&#34;],&#34;GH_HOST&#34;:&#34;ghe.example.com&#34;,&#34;GH_REPO&#34;:&#34;octo/repo&#34;}&#10;{&#34;argv&#34;:[&#34;issue&#34;,&#34;list&#34;,&#34;--json&#34;,&#34;number,title,state,author,createdAt&#34;,&#34;--limit&#34;,&#34;2&#34;,&#34;--repo&#34;,&#34;octo/repo&#34;],&#34;GH_HOST&#34;:&#34;git.env.example&#34;,&#34;GH_REPO&#34;:&#34;octo/repo&#34;}&#10;{&#34;argv&#34;:[&#34;issue&#34;,&#34;list&#34;,&#34;--json&#34;,&#34;number,title,state,author,createdAt&#34;,&#34;--limit&#34;,&#34;2&#34;,&#34;--repo&#34;,&#34;octo/repo&#34;],&#34;GH_HOST&#34;:&#34;&lt;unset&gt;&#34;,&#34;GH_REPO&#34;:&#34;octo/repo&#34;}</code>

```text
{"argv":["issue","list","--json","number,title,state,author,createdAt","--limit","2","--repo","octo/repo"],"GH_HOST":"ghe.example.com","GH_REPO":"octo/repo"}
{"argv":["issue","list","--json","number,title,state,author,createdAt","--limit","2","--repo","octo/repo"],"GH_HOST":"git.env.example","GH_REPO":"octo/repo"}
{"argv":["issue","list","--json","number,title,state,author,createdAt","--limit","2","--repo","octo/repo"],"GH_HOST":"<unset>","GH_REPO":"octo/repo"}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `src/cli.ts:96` - Explicit `--hostname` is only stored in the current process environment, so rendered follow-up commands cannot preserve it. For example, after `gh-axi issue list --hostname git.example.com -R owner/repo`, suggestions still emit commands with `-R owner/repo` but no `--hostname`; if an agent runs one in a fresh process, it can target `github.com` instead of the GHE host. Consider carrying the effective host in context and including non-default explicit host flags in generated suggestions.
- ⚠️ `src/context.ts:49` - The remote URL regex matches the configured host as an unanchored substring. With `GH_HOST=git.example.com`, a remote such as `git@old-git.example.com:owner/repo.git` would resolve as if it were on `git.example.com`, which can give later API calls the wrong owner/repo for the selected host. Require a real URL/SSH host boundary around the escaped host before extracting owner/name.

🔧 Fix: Preserve hostname and anchor remote parsing
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm exec --yes --package=pnpm@11.1.1 -- pnpm install --frozen-lockfile`
- `npm exec --yes --package=pnpm@11.1.1 -- pnpm exec vitest run test/host.test.ts test/context.test.ts test/cli.test.ts test/commands/issue.test.ts test/suggestions.test.ts`
- `env PATH="/var/folders/mm/mzvsb9xn40vd3pqkp4y8n_sm0000gn/T/no-mistakes-evidence/01KWVMJB5F2J8Y6M6AWY578QBC:$PATH" GH_HOST=env.example.com GH_REPO=octo/repo ./node_modules/.bin/tsx bin/gh-axi.ts issue list --hostname ghe.example.com --limit 2`
- `env PATH="/var/folders/mm/mzvsb9xn40vd3pqkp4y8n_sm0000gn/T/no-mistakes-evidence/01KWVMJB5F2J8Y6M6AWY578QBC:$PATH" GH_HOST=git.env.example GH_REPO=octo/repo ./node_modules/.bin/tsx bin/gh-axi.ts issue list --limit 2`
- `env -u GH_HOST PATH="/var/folders/mm/mzvsb9xn40vd3pqkp4y8n_sm0000gn/T/no-mistakes-evidence/01KWVMJB5F2J8Y6M6AWY578QBC:$PATH" GH_REPO=octo/repo ./node_modules/.bin/tsx bin/gh-axi.ts issue list --limit 2`
- `npm exec --yes --package=pnpm@11.1.1 -- pnpm test`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

