### PR TITLE
fix(repo): honor positional repo view targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ gh-axi                          # dashboard - live state, no args needed
 gh-axi issue list               # list issues in current repo
 gh-axi issue subissue list 16   # list sub-issues for issue #16
 gh-axi pr view 42               # view pull request #42
-gh-axi repo view owner/repo     # view a specific repository
 gh-axi run list -R owner/repo   # list workflow runs for a specific repo
 gh-axi issue list --hostname git.example.com  # target a GitHub Enterprise host
 gh-axi run view 123456 --job 789012       # inspect a single job within a run
@@ -139,12 +138,12 @@ Repository and host targeting are command-first too:
 - `gh-axi issue list -R owner/name`
 - `gh-axi issue list --repo owner/name`
 - `gh-axi issue list --repo=owner/name`
-- `gh-axi repo view owner/name`
 - `gh-axi run list -R owner/name`
+- `gh-axi repo view --repo owner/name`
 - `gh-axi search issues "login bug" --repo owner/name`
 - `gh-axi issue list --hostname git.example.com`
 
-Only `repo view` accepts `owner/name` as a positional repository target; use `-R` or `--repo` after the command for other repo-scoped commands.
+`repo view` also accepts `gh-axi repo view owner/name` as a repo-view-specific compatibility exception for `gh repo view [<repository>]`. For other commands, use the command-first `--repo owner/name` form.
 
 When a command also needs a destination repository, use a dedicated flag for it:
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ gh-axi                          # dashboard - live state, no args needed
 gh-axi issue list               # list issues in current repo
 gh-axi issue subissue list 16   # list sub-issues for issue #16
 gh-axi pr view 42               # view pull request #42
+gh-axi repo view owner/repo     # view a specific repository
 gh-axi run list -R owner/repo   # list workflow runs for a specific repo
 gh-axi issue list --hostname git.example.com  # target a GitHub Enterprise host
 gh-axi run view 123456 --job 789012       # inspect a single job within a run
@@ -138,6 +139,7 @@ Repository and host targeting are command-first too:
 - `gh-axi issue list -R owner/name`
 - `gh-axi issue list --repo owner/name`
 - `gh-axi issue list --repo=owner/name`
+- `gh-axi repo view owner/name`
 - `gh-axi run list -R owner/name`
 - `gh-axi search issues "login bug" --repo owner/name`
 - `gh-axi issue list --hostname git.example.com`

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Repository and host targeting are command-first too:
 - `gh-axi search issues "login bug" --repo owner/name`
 - `gh-axi issue list --hostname git.example.com`
 
-`repo view` also accepts `gh-axi repo view owner/name` as a repo-view-specific compatibility exception for `gh repo view [<repository>]`. For other commands, use the command-first `--repo owner/name` form.
+`repo view` also accepts exactly one positional repository, `gh-axi repo view owner/name`, as a repo-view-specific compatibility exception for `gh repo view [<repository>]`. Do not combine that positional form with `--repo`, and do not pass extra positional arguments. For other commands, use the command-first `--repo owner/name` form.
 
 When a command also needs a destination repository, use a dedicated flag for it:
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Repository and host targeting are command-first too:
 - `gh-axi search issues "login bug" --repo owner/name`
 - `gh-axi issue list --hostname git.example.com`
 
+Only `repo view` accepts `owner/name` as a positional repository target; use `-R` or `--repo` after the command for other repo-scoped commands.
+
 When a command also needs a destination repository, use a dedicated flag for it:
 
 - `gh-axi issue transfer 42 -R source/repo --to-repo dest/repo`

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -28,7 +28,7 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 1. Run `npx -y gh-axi` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: `issue list`, `issue view <n>`, `pr view <n>`, `pr checks <n>`, `run view <id>`, and so on.
 3. Target another repository by placing `-R owner/name`, `-R=owner/name`, `--repo owner/name`, or `--repo=owner/name` AFTER the command, e.g. `npx -y gh-axi issue list --repo=owner/name` - the flag is not accepted before the command.
-4. For repository details, `repo view owner/name` also accepts the target repository as a positional argument.
+4. For repository details, `repo view owner/name` accepts one positional target repository; use `--repo owner/name` for repository targeting on other commands.
 5. Target GitHub Enterprise or another custom host with `GH_HOST`, or by placing `--hostname <host>` or `--hostname=<host>` AFTER the command, e.g. `npx -y gh-axi issue list --hostname=git.example.com`.
 6. Trigger (dispatch) a workflow with `workflow run <name> --ref <ref>`; `run` manages existing workflow runs.
 7. Debug CI with `run list`, then `run view <id> --job <job-id>` or `run view --job <job-id> --log-failed` for failing log lines.

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -28,11 +28,12 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 1. Run `npx -y gh-axi` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: `issue list`, `issue view <n>`, `pr view <n>`, `pr checks <n>`, `run view <id>`, and so on.
 3. Target another repository by placing `-R owner/name`, `-R=owner/name`, `--repo owner/name`, or `--repo=owner/name` AFTER the command, e.g. `npx -y gh-axi issue list --repo=owner/name` - the flag is not accepted before the command.
-4. Target GitHub Enterprise or another custom host with `GH_HOST`, or by placing `--hostname <host>` or `--hostname=<host>` AFTER the command, e.g. `npx -y gh-axi issue list --hostname=git.example.com`.
-5. Trigger (dispatch) a workflow with `workflow run <name> --ref <ref>`; `run` manages existing workflow runs.
-6. Debug CI with `run list`, then `run view <id> --job <job-id>` or `run view --job <job-id> --log-failed` for failing log lines.
+4. For repository details, `repo view owner/name` also accepts the target repository as a positional argument.
+5. Target GitHub Enterprise or another custom host with `GH_HOST`, or by placing `--hostname <host>` or `--hostname=<host>` AFTER the command, e.g. `npx -y gh-axi issue list --hostname=git.example.com`.
+6. Trigger (dispatch) a workflow with `workflow run <name> --ref <ref>`; `run` manages existing workflow runs.
+7. Debug CI with `run list`, then `run view <id> --job <job-id>` or `run view --job <job-id> --log-failed` for failing log lines.
    Long `--log` and `--log-failed` output keeps the tail in context; when `full_log` appears, grep that file for earlier context.
-7. Every response ends with contextual next-step hints under `help:` - follow them.
+8. Every response ends with contextual next-step hints under `help:` - follow them.
 
 ## Commands
 

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -27,7 +27,7 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 
 1. Run `npx -y gh-axi` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: `issue list`, `issue view <n>`, `pr view <n>`, `pr checks <n>`, `run view <id>`, and so on.
-3. Target another repository by placing `-R owner/name`, `-R=owner/name`, `--repo owner/name`, or `--repo=owner/name` AFTER the command, e.g. `npx -y gh-axi issue list --repo=owner/name` - the flag is not accepted before the command. `repo view` also accepts `repo view owner/name` as a command-specific compatibility exception for `gh repo view [<repository>]`; do not generalize that positional form to other commands.
+3. Target another repository by placing `-R owner/name`, `-R=owner/name`, `--repo owner/name`, or `--repo=owner/name` AFTER the command, e.g. `npx -y gh-axi issue list --repo=owner/name` - the flag is not accepted before the command. `repo view` also accepts exactly one positional repository, `repo view owner/name`, as a command-specific compatibility exception for `gh repo view [<repository>]`; do not combine it with `--repo` or generalize that positional form to other commands.
 4. Target GitHub Enterprise or another custom host with `GH_HOST`, or by placing `--hostname <host>` or `--hostname=<host>` AFTER the command, e.g. `npx -y gh-axi issue list --hostname=git.example.com`.
 5. Trigger (dispatch) a workflow with `workflow run <name> --ref <ref>`; `run` manages existing workflow runs.
 6. Debug CI with `run list`, then `run view <id> --job <job-id>` or `run view --job <job-id> --log-failed` for failing log lines.

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -27,13 +27,12 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 
 1. Run `npx -y gh-axi` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: `issue list`, `issue view <n>`, `pr view <n>`, `pr checks <n>`, `run view <id>`, and so on.
-3. Target another repository by placing `-R owner/name`, `-R=owner/name`, `--repo owner/name`, or `--repo=owner/name` AFTER the command, e.g. `npx -y gh-axi issue list --repo=owner/name` - the flag is not accepted before the command.
-4. For repository details, `repo view owner/name` accepts one positional target repository; use `--repo owner/name` for repository targeting on other commands.
-5. Target GitHub Enterprise or another custom host with `GH_HOST`, or by placing `--hostname <host>` or `--hostname=<host>` AFTER the command, e.g. `npx -y gh-axi issue list --hostname=git.example.com`.
-6. Trigger (dispatch) a workflow with `workflow run <name> --ref <ref>`; `run` manages existing workflow runs.
-7. Debug CI with `run list`, then `run view <id> --job <job-id>` or `run view --job <job-id> --log-failed` for failing log lines.
+3. Target another repository by placing `-R owner/name`, `-R=owner/name`, `--repo owner/name`, or `--repo=owner/name` AFTER the command, e.g. `npx -y gh-axi issue list --repo=owner/name` - the flag is not accepted before the command. `repo view` also accepts `repo view owner/name` as a command-specific compatibility exception for `gh repo view [<repository>]`; do not generalize that positional form to other commands.
+4. Target GitHub Enterprise or another custom host with `GH_HOST`, or by placing `--hostname <host>` or `--hostname=<host>` AFTER the command, e.g. `npx -y gh-axi issue list --hostname=git.example.com`.
+5. Trigger (dispatch) a workflow with `workflow run <name> --ref <ref>`; `run` manages existing workflow runs.
+6. Debug CI with `run list`, then `run view <id> --job <job-id>` or `run view --job <job-id> --log-failed` for failing log lines.
    Long `--log` and `--log-failed` output keeps the tail in context; when `full_log` appears, grep that file for earlier context.
-8. Every response ends with contextual next-step hints under `help:` - follow them.
+7. Every response ends with contextual next-step hints under `help:` - follow them.
 
 ## Commands
 

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -21,7 +21,7 @@ import { getSuggestions } from '../suggestions.js';
 
 export const REPO_HELP = `usage: gh-axi repo <subcommand> [flags]
 subcommands[6]:
-  view, create <name>, edit, clone <repo>, fork [repo], list [owner]
+  view [owner/name], create <name>, edit, clone <repo>, fork [repo], list [owner]
 flags{create}:
   --public, --private, --internal, --description, --clone, --template
 flags{edit}:
@@ -32,6 +32,7 @@ flags{list}:
   --limit <n> (default 30), --visibility, --language, --archived
 examples:
   gh-axi repo view
+  gh-axi repo view owner/name
   gh-axi repo create my-project --public --description "A new project"
   gh-axi repo list --visibility public --language TypeScript`;
 
@@ -58,9 +59,21 @@ const listSchema: FieldDef[] = [
 
 
 async function viewRepo(args: string[], ctx?: RepoContext): Promise<string> {
+  const positionals = args.filter((a) => !a.startsWith('-'));
+  const repoArg = positionals[1];
+  const extraArg = positionals[2];
+  if (extraArg) {
+    throw new AxiError(
+      `Unsupported positional argument for repo view: ${extraArg}. Use --repo <owner/name> to select a repository.`,
+      'VALIDATION_ERROR',
+    );
+  }
+
   const ghArgs = ['repo', 'view'];
-  // repo view takes the repo as a positional arg — always pass it if available
-  if (ctx) ghArgs.push(ctx.nwo);
+  // repo view takes the repo as a positional arg. Use an explicit positional
+  // first, then the resolved context repo, and otherwise leave gh ambient.
+  if (repoArg) ghArgs.push(repoArg);
+  else if (ctx) ghArgs.push(ctx.nwo);
   ghArgs.push('--json', 'name,description,defaultBranchRef,stargazerCount,forkCount,issues,pullRequests,visibility,primaryLanguage');
   const repo = await ghJson<Record<string, unknown>>(ghArgs); // Don't pass ctx — we handle repo arg ourselves
 

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -1,8 +1,8 @@
-import { encode } from "@toon-format/toon";
-import type { RepoContext } from "../context.js";
-import { ghJson, ghExec } from "../gh.js";
-import { AxiError } from "../errors.js";
-import { getFlag, hasFlag } from "../args.js";
+import { encode } from '@toon-format/toon';
+import type { RepoContext } from '../context.js';
+import { ghJson, ghExec } from '../gh.js';
+import { AxiError } from '../errors.js';
+import { getFlag, hasFlag } from '../args.js';
 import {
   field,
   lower,
@@ -15,13 +15,15 @@ import {
   renderOutput,
   renderError,
   type FieldDef,
-} from "../toon.js";
-import { formatCountLine } from "../format.js";
-import { getSuggestions } from "../suggestions.js";
+} from '../toon.js';
+import { formatCountLine } from '../format.js';
+import { getSuggestions } from '../suggestions.js';
 
 export const REPO_HELP = `usage: gh-axi repo <subcommand> [flags]
 subcommands[6]:
   view [owner/name], create <name>, edit, clone <repo>, fork [repo], list [owner]
+flags{view}:
+  --repo <owner/name> (general gh-axi targeting form); one positional owner/name is also accepted for gh repo view parity
 flags{create}:
   --public, --private, --internal, --description, --clone, --template
 flags{edit}:
@@ -32,221 +34,188 @@ flags{list}:
   --limit <n> (default 30), --visibility, --language, --archived
 examples:
   gh-axi repo view
+  gh-axi repo view --repo owner/name
   gh-axi repo view owner/name
   gh-axi repo create my-project --public --description "A new project"
   gh-axi repo list --visibility public --language TypeScript`;
 
 const viewSchema: FieldDef[] = [
-  field("name"),
-  field("description"),
-  pluck("defaultBranchRef", "name", "branch"),
-  field("stargazerCount", "stars"),
-  field("forkCount", "forks"),
-  custom(
-    "issues",
-    (item) =>
-      (item.issues as Record<string, unknown> | undefined)?.totalCount ?? 0,
-  ),
-  custom(
-    "prs",
-    (item) =>
-      (item.pullRequests as Record<string, unknown> | undefined)?.totalCount ??
-      0,
-  ),
-  lower("visibility"),
-  pluck("primaryLanguage", "name", "language"),
+  field('name'),
+  field('description'),
+  pluck('defaultBranchRef', 'name', 'branch'),
+  field('stargazerCount', 'stars'),
+  field('forkCount', 'forks'),
+  custom('issues', (item) => (item.issues as Record<string, unknown> | undefined)?.totalCount ?? 0),
+  custom('prs', (item) => (item.pullRequests as Record<string, unknown> | undefined)?.totalCount ?? 0),
+  lower('visibility'),
+  pluck('primaryLanguage', 'name', 'language'),
 ];
 
 const listSchema: FieldDef[] = [
-  field("name"),
-  field("description"),
-  lower("visibility"),
-  pluck("primaryLanguage", "name", "language"),
-  field("stargazerCount", "stars"),
-  relativeTime("updatedAt", "updated"),
+  field('name'),
+  field('description'),
+  lower('visibility'),
+  pluck('primaryLanguage', 'name', 'language'),
+  field('stargazerCount', 'stars'),
+  relativeTime('updatedAt', 'updated'),
 ];
 
+
 async function viewRepo(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith("-"));
+  const positionals = args.filter((a) => !a.startsWith('-'));
   const repoArg = positionals[1];
   const extraArg = positionals[2];
-  if (repoArg && ctx?.source === "flag") {
+  if (repoArg && ctx?.source === 'flag') {
     throw new AxiError(
       `Unsupported positional argument for repo view with --repo: ${repoArg}. Use --repo <owner/name> to select a repository.`,
-      "VALIDATION_ERROR",
+      'VALIDATION_ERROR',
     );
   }
   if (extraArg) {
     throw new AxiError(
       `Unsupported positional argument for repo view: ${extraArg}. Use --repo <owner/name> to select a repository.`,
-      "VALIDATION_ERROR",
+      'VALIDATION_ERROR',
     );
   }
 
-  const ghArgs = ["repo", "view"];
-  // repo view takes the repo as a positional arg. Use an explicit positional
-  // first, then the resolved context repo, and otherwise leave gh ambient.
+  const ghArgs = ['repo', 'view'];
+  // gh repo view accepts a positional repository; keep that parity only when
+  // it does not conflict with gh-axi's command-first --repo targeting.
   if (repoArg) ghArgs.push(repoArg);
   else if (ctx) ghArgs.push(ctx.nwo);
-  ghArgs.push(
-    "--json",
-    "name,description,defaultBranchRef,stargazerCount,forkCount,issues,pullRequests,visibility,primaryLanguage",
-  );
+  ghArgs.push('--json', 'name,description,defaultBranchRef,stargazerCount,forkCount,issues,pullRequests,visibility,primaryLanguage');
   const repo = await ghJson<Record<string, unknown>>(ghArgs); // Don't pass ctx — we handle repo arg ourselves
 
-  return renderOutput([renderDetail("repo", repo, viewSchema)]);
+  return renderOutput([
+    renderDetail('repo', repo, viewSchema),
+  ]);
 }
 
 async function createRepo(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith("--"));
+  const positionals = args.filter((a) => !a.startsWith('--'));
   const name = positionals[1];
-  if (!name)
-    throw new AxiError(
-      "Repository name is required: gh-axi repo create <name>",
-      "VALIDATION_ERROR",
-    );
+  if (!name) throw new AxiError('Repository name is required: gh-axi repo create <name>', 'VALIDATION_ERROR');
 
-  const ghArgs = ["repo", "create", name];
-  if (hasFlag(args, "--public")) ghArgs.push("--public");
-  else if (hasFlag(args, "--private")) ghArgs.push("--private");
-  else if (hasFlag(args, "--internal")) ghArgs.push("--internal");
-  const description = getFlag(args, "--description");
-  if (description) ghArgs.push("--description", description);
-  if (hasFlag(args, "--clone")) ghArgs.push("--clone");
-  const template = getFlag(args, "--template");
-  if (template) ghArgs.push("--template", template);
+  const ghArgs = ['repo', 'create', name];
+  if (hasFlag(args, '--public')) ghArgs.push('--public');
+  else if (hasFlag(args, '--private')) ghArgs.push('--private');
+  else if (hasFlag(args, '--internal')) ghArgs.push('--internal');
+  const description = getFlag(args, '--description');
+  if (description) ghArgs.push('--description', description);
+  if (hasFlag(args, '--clone')) ghArgs.push('--clone');
+  const template = getFlag(args, '--template');
+  if (template) ghArgs.push('--template', template);
 
   await ghExec(ghArgs);
-  const suggestions = getSuggestions({
-    domain: "repo",
-    action: "create",
-    repo: ctx,
-  });
+  const suggestions = getSuggestions({ domain: 'repo', action: 'create', repo: ctx });
   return renderOutput([
-    encode({ created: "ok", repo: name }),
+    encode({ created: 'ok', repo: name }),
     renderHelp(suggestions),
   ]);
 }
 
 async function editRepo(args: string[], ctx?: RepoContext): Promise<string> {
-  const ghArgs = ["repo", "edit"];
-  if (ctx && ctx.source !== "git") ghArgs.push(ctx.nwo);
-  const description = getFlag(args, "--description");
-  if (description) ghArgs.push("--description", description);
-  const visibility = getFlag(args, "--visibility");
-  if (visibility) ghArgs.push("--visibility", visibility);
-  const defaultBranch = getFlag(args, "--default-branch");
-  if (defaultBranch) ghArgs.push("--default-branch", defaultBranch);
-  const enableIssues = getFlag(args, "--enable-issues");
-  if (enableIssues) ghArgs.push("--enable-issues=" + enableIssues);
-  const enableWiki = getFlag(args, "--enable-wiki");
-  if (enableWiki) ghArgs.push("--enable-wiki=" + enableWiki);
+  const ghArgs = ['repo', 'edit'];
+  if (ctx && ctx.source !== 'git') ghArgs.push(ctx.nwo);
+  const description = getFlag(args, '--description');
+  if (description) ghArgs.push('--description', description);
+  const visibility = getFlag(args, '--visibility');
+  if (visibility) ghArgs.push('--visibility', visibility);
+  const defaultBranch = getFlag(args, '--default-branch');
+  if (defaultBranch) ghArgs.push('--default-branch', defaultBranch);
+  const enableIssues = getFlag(args, '--enable-issues');
+  if (enableIssues) ghArgs.push('--enable-issues=' + enableIssues);
+  const enableWiki = getFlag(args, '--enable-wiki');
+  if (enableWiki) ghArgs.push('--enable-wiki=' + enableWiki);
 
   await ghExec(ghArgs); // Don't pass ctx — we handle repo arg ourselves
-  const suggestions = getSuggestions({
-    domain: "repo",
-    action: "edit",
-    repo: ctx,
-  });
-  return renderOutput([encode({ edit: "ok" }), renderHelp(suggestions)]);
+  const suggestions = getSuggestions({ domain: 'repo', action: 'edit', repo: ctx });
+  return renderOutput([
+    encode({ edit: 'ok' }),
+    renderHelp(suggestions),
+  ]);
 }
 
 async function cloneRepo(args: string[]): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith("--"));
+  const positionals = args.filter((a) => !a.startsWith('--'));
   const repo = positionals[1];
-  if (!repo)
-    throw new AxiError(
-      "Repository is required: gh-axi repo clone <repo>",
-      "VALIDATION_ERROR",
-    );
+  if (!repo) throw new AxiError('Repository is required: gh-axi repo clone <repo>', 'VALIDATION_ERROR');
 
-  await ghExec(["repo", "clone", repo]);
-  const suggestions = getSuggestions({ domain: "repo", action: "clone" });
-  return renderOutput([encode({ clone: "ok", repo }), renderHelp(suggestions)]);
+  await ghExec(['repo', 'clone', repo]);
+  const suggestions = getSuggestions({ domain: 'repo', action: 'clone' });
+  return renderOutput([
+    encode({ clone: 'ok', repo }),
+    renderHelp(suggestions),
+  ]);
 }
 
 async function forkRepo(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith("--"));
+  const positionals = args.filter((a) => !a.startsWith('--'));
   const repo = positionals[1]; // optional
 
-  const ghArgs = ["repo", "fork"];
+  const ghArgs = ['repo', 'fork'];
   if (repo) ghArgs.push(repo);
-  if (hasFlag(args, "--clone")) ghArgs.push("--clone");
-  if (hasFlag(args, "--remote")) ghArgs.push("--remote");
+  if (hasFlag(args, '--clone')) ghArgs.push('--clone');
+  if (hasFlag(args, '--remote')) ghArgs.push('--remote');
 
   await ghExec(ghArgs, ctx);
-  const suggestions = getSuggestions({
-    domain: "repo",
-    action: "fork",
-    repo: ctx,
-  });
+  const suggestions = getSuggestions({ domain: 'repo', action: 'fork', repo: ctx });
   return renderOutput([
-    encode({ fork: "ok", repo: repo ?? ctx?.nwo ?? "current" }),
+    encode({ fork: 'ok', repo: repo ?? ctx?.nwo ?? 'current' }),
     renderHelp(suggestions),
   ]);
 }
 
 async function listRepos(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith("--"));
+  const positionals = args.filter((a) => !a.startsWith('--'));
   const owner = positionals[1]; // optional
 
-  const limit = getFlag(args, "--limit") ?? "30";
+  const limit = getFlag(args, '--limit') ?? '30';
   const ghArgs = [
-    "repo",
-    "list",
-    "--json",
-    "name,description,visibility,primaryLanguage,stargazerCount,updatedAt",
-    "--limit",
-    limit,
+    'repo', 'list',
+    '--json', 'name,description,visibility,primaryLanguage,stargazerCount,updatedAt',
+    '--limit', limit,
   ];
   if (owner) ghArgs.splice(2, 0, owner); // insert owner after 'list'
-  const visibility = getFlag(args, "--visibility");
-  if (visibility) ghArgs.push("--visibility", visibility);
-  const language = getFlag(args, "--language");
-  if (language) ghArgs.push("--language", language);
-  if (hasFlag(args, "--archived")) ghArgs.push("--archived");
+  const visibility = getFlag(args, '--visibility');
+  if (visibility) ghArgs.push('--visibility', visibility);
+  const language = getFlag(args, '--language');
+  if (language) ghArgs.push('--language', language);
+  if (hasFlag(args, '--archived')) ghArgs.push('--archived');
 
   const repos = await ghJson<Record<string, unknown>[]>(ghArgs);
   const isEmpty = repos.length === 0;
   const limitNum = Number(limit);
   const countLine = formatCountLine({ count: repos.length, limit: limitNum });
-  const suggestions = getSuggestions({
-    domain: "repo",
-    action: "list",
-    isEmpty,
-    repo: ctx,
-  });
+  const suggestions = getSuggestions({ domain: 'repo', action: 'list', isEmpty, repo: ctx });
   return renderOutput([
     countLine,
-    renderList("repos", repos, listSchema),
+    renderList('repos', repos, listSchema),
     renderHelp(suggestions),
   ]);
 }
 
-export async function repoCommand(
-  args: string[],
-  ctx?: RepoContext,
-): Promise<string> {
+export async function repoCommand(args: string[], ctx?: RepoContext): Promise<string> {
   const sub = args[0];
 
-  if (sub === "--help" || sub === undefined) return REPO_HELP;
+  if (sub === '--help' || sub === undefined) return REPO_HELP;
 
   switch (sub) {
-    case "view":
+    case 'view':
       return viewRepo(args, ctx);
-    case "create":
+    case 'create':
       return createRepo(args, ctx);
-    case "edit":
+    case 'edit':
       return editRepo(args, ctx);
-    case "clone":
+    case 'clone':
       return cloneRepo(args);
-    case "fork":
+    case 'fork':
       return forkRepo(args, ctx);
-    case "list":
+    case 'list':
       return listRepos(args, ctx);
     default:
-      return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [
-        "Available subcommands: view, create, edit, clone, fork, list",
+      return renderError(`Unknown subcommand: ${sub}`, 'VALIDATION_ERROR', [
+        'Available subcommands: view, create, edit, clone, fork, list',
       ]);
   }
 }

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -1,8 +1,8 @@
-import { encode } from '@toon-format/toon';
-import type { RepoContext } from '../context.js';
-import { ghJson, ghExec } from '../gh.js';
-import { AxiError } from '../errors.js';
-import { getFlag, hasFlag } from '../args.js';
+import { encode } from "@toon-format/toon";
+import type { RepoContext } from "../context.js";
+import { ghJson, ghExec } from "../gh.js";
+import { AxiError } from "../errors.js";
+import { getFlag, hasFlag } from "../args.js";
 import {
   field,
   lower,
@@ -15,9 +15,9 @@ import {
   renderOutput,
   renderError,
   type FieldDef,
-} from '../toon.js';
-import { formatCountLine } from '../format.js';
-import { getSuggestions } from '../suggestions.js';
+} from "../toon.js";
+import { formatCountLine } from "../format.js";
+import { getSuggestions } from "../suggestions.js";
 
 export const REPO_HELP = `usage: gh-axi repo <subcommand> [flags]
 subcommands[6]:
@@ -37,176 +37,210 @@ examples:
   gh-axi repo list --visibility public --language TypeScript`;
 
 const viewSchema: FieldDef[] = [
-  field('name'),
-  field('description'),
-  pluck('defaultBranchRef', 'name', 'branch'),
-  field('stargazerCount', 'stars'),
-  field('forkCount', 'forks'),
-  custom('issues', (item) => (item.issues as Record<string, unknown> | undefined)?.totalCount ?? 0),
-  custom('prs', (item) => (item.pullRequests as Record<string, unknown> | undefined)?.totalCount ?? 0),
-  lower('visibility'),
-  pluck('primaryLanguage', 'name', 'language'),
+  field("name"),
+  field("description"),
+  pluck("defaultBranchRef", "name", "branch"),
+  field("stargazerCount", "stars"),
+  field("forkCount", "forks"),
+  custom(
+    "issues",
+    (item) =>
+      (item.issues as Record<string, unknown> | undefined)?.totalCount ?? 0,
+  ),
+  custom(
+    "prs",
+    (item) =>
+      (item.pullRequests as Record<string, unknown> | undefined)?.totalCount ??
+      0,
+  ),
+  lower("visibility"),
+  pluck("primaryLanguage", "name", "language"),
 ];
 
 const listSchema: FieldDef[] = [
-  field('name'),
-  field('description'),
-  lower('visibility'),
-  pluck('primaryLanguage', 'name', 'language'),
-  field('stargazerCount', 'stars'),
-  relativeTime('updatedAt', 'updated'),
+  field("name"),
+  field("description"),
+  lower("visibility"),
+  pluck("primaryLanguage", "name", "language"),
+  field("stargazerCount", "stars"),
+  relativeTime("updatedAt", "updated"),
 ];
 
-
 async function viewRepo(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('-'));
+  const positionals = args.filter((a) => !a.startsWith("-"));
   const repoArg = positionals[1];
   const extraArg = positionals[2];
   if (extraArg) {
     throw new AxiError(
       `Unsupported positional argument for repo view: ${extraArg}. Use --repo <owner/name> to select a repository.`,
-      'VALIDATION_ERROR',
+      "VALIDATION_ERROR",
     );
   }
 
-  const ghArgs = ['repo', 'view'];
+  const ghArgs = ["repo", "view"];
   // repo view takes the repo as a positional arg. Use an explicit positional
   // first, then the resolved context repo, and otherwise leave gh ambient.
   if (repoArg) ghArgs.push(repoArg);
   else if (ctx) ghArgs.push(ctx.nwo);
-  ghArgs.push('--json', 'name,description,defaultBranchRef,stargazerCount,forkCount,issues,pullRequests,visibility,primaryLanguage');
+  ghArgs.push(
+    "--json",
+    "name,description,defaultBranchRef,stargazerCount,forkCount,issues,pullRequests,visibility,primaryLanguage",
+  );
   const repo = await ghJson<Record<string, unknown>>(ghArgs); // Don't pass ctx — we handle repo arg ourselves
 
-  return renderOutput([
-    renderDetail('repo', repo, viewSchema),
-  ]);
+  return renderOutput([renderDetail("repo", repo, viewSchema)]);
 }
 
 async function createRepo(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const name = positionals[1];
-  if (!name) throw new AxiError('Repository name is required: gh-axi repo create <name>', 'VALIDATION_ERROR');
+  if (!name)
+    throw new AxiError(
+      "Repository name is required: gh-axi repo create <name>",
+      "VALIDATION_ERROR",
+    );
 
-  const ghArgs = ['repo', 'create', name];
-  if (hasFlag(args, '--public')) ghArgs.push('--public');
-  else if (hasFlag(args, '--private')) ghArgs.push('--private');
-  else if (hasFlag(args, '--internal')) ghArgs.push('--internal');
-  const description = getFlag(args, '--description');
-  if (description) ghArgs.push('--description', description);
-  if (hasFlag(args, '--clone')) ghArgs.push('--clone');
-  const template = getFlag(args, '--template');
-  if (template) ghArgs.push('--template', template);
+  const ghArgs = ["repo", "create", name];
+  if (hasFlag(args, "--public")) ghArgs.push("--public");
+  else if (hasFlag(args, "--private")) ghArgs.push("--private");
+  else if (hasFlag(args, "--internal")) ghArgs.push("--internal");
+  const description = getFlag(args, "--description");
+  if (description) ghArgs.push("--description", description);
+  if (hasFlag(args, "--clone")) ghArgs.push("--clone");
+  const template = getFlag(args, "--template");
+  if (template) ghArgs.push("--template", template);
 
   await ghExec(ghArgs);
-  const suggestions = getSuggestions({ domain: 'repo', action: 'create', repo: ctx });
+  const suggestions = getSuggestions({
+    domain: "repo",
+    action: "create",
+    repo: ctx,
+  });
   return renderOutput([
-    encode({ created: 'ok', repo: name }),
+    encode({ created: "ok", repo: name }),
     renderHelp(suggestions),
   ]);
 }
 
 async function editRepo(args: string[], ctx?: RepoContext): Promise<string> {
-  const ghArgs = ['repo', 'edit'];
-  if (ctx && ctx.source !== 'git') ghArgs.push(ctx.nwo);
-  const description = getFlag(args, '--description');
-  if (description) ghArgs.push('--description', description);
-  const visibility = getFlag(args, '--visibility');
-  if (visibility) ghArgs.push('--visibility', visibility);
-  const defaultBranch = getFlag(args, '--default-branch');
-  if (defaultBranch) ghArgs.push('--default-branch', defaultBranch);
-  const enableIssues = getFlag(args, '--enable-issues');
-  if (enableIssues) ghArgs.push('--enable-issues=' + enableIssues);
-  const enableWiki = getFlag(args, '--enable-wiki');
-  if (enableWiki) ghArgs.push('--enable-wiki=' + enableWiki);
+  const ghArgs = ["repo", "edit"];
+  if (ctx && ctx.source !== "git") ghArgs.push(ctx.nwo);
+  const description = getFlag(args, "--description");
+  if (description) ghArgs.push("--description", description);
+  const visibility = getFlag(args, "--visibility");
+  if (visibility) ghArgs.push("--visibility", visibility);
+  const defaultBranch = getFlag(args, "--default-branch");
+  if (defaultBranch) ghArgs.push("--default-branch", defaultBranch);
+  const enableIssues = getFlag(args, "--enable-issues");
+  if (enableIssues) ghArgs.push("--enable-issues=" + enableIssues);
+  const enableWiki = getFlag(args, "--enable-wiki");
+  if (enableWiki) ghArgs.push("--enable-wiki=" + enableWiki);
 
   await ghExec(ghArgs); // Don't pass ctx — we handle repo arg ourselves
-  const suggestions = getSuggestions({ domain: 'repo', action: 'edit', repo: ctx });
-  return renderOutput([
-    encode({ edit: 'ok' }),
-    renderHelp(suggestions),
-  ]);
+  const suggestions = getSuggestions({
+    domain: "repo",
+    action: "edit",
+    repo: ctx,
+  });
+  return renderOutput([encode({ edit: "ok" }), renderHelp(suggestions)]);
 }
 
 async function cloneRepo(args: string[]): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const repo = positionals[1];
-  if (!repo) throw new AxiError('Repository is required: gh-axi repo clone <repo>', 'VALIDATION_ERROR');
+  if (!repo)
+    throw new AxiError(
+      "Repository is required: gh-axi repo clone <repo>",
+      "VALIDATION_ERROR",
+    );
 
-  await ghExec(['repo', 'clone', repo]);
-  const suggestions = getSuggestions({ domain: 'repo', action: 'clone' });
-  return renderOutput([
-    encode({ clone: 'ok', repo }),
-    renderHelp(suggestions),
-  ]);
+  await ghExec(["repo", "clone", repo]);
+  const suggestions = getSuggestions({ domain: "repo", action: "clone" });
+  return renderOutput([encode({ clone: "ok", repo }), renderHelp(suggestions)]);
 }
 
 async function forkRepo(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const repo = positionals[1]; // optional
 
-  const ghArgs = ['repo', 'fork'];
+  const ghArgs = ["repo", "fork"];
   if (repo) ghArgs.push(repo);
-  if (hasFlag(args, '--clone')) ghArgs.push('--clone');
-  if (hasFlag(args, '--remote')) ghArgs.push('--remote');
+  if (hasFlag(args, "--clone")) ghArgs.push("--clone");
+  if (hasFlag(args, "--remote")) ghArgs.push("--remote");
 
   await ghExec(ghArgs, ctx);
-  const suggestions = getSuggestions({ domain: 'repo', action: 'fork', repo: ctx });
+  const suggestions = getSuggestions({
+    domain: "repo",
+    action: "fork",
+    repo: ctx,
+  });
   return renderOutput([
-    encode({ fork: 'ok', repo: repo ?? ctx?.nwo ?? 'current' }),
+    encode({ fork: "ok", repo: repo ?? ctx?.nwo ?? "current" }),
     renderHelp(suggestions),
   ]);
 }
 
 async function listRepos(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
+  const positionals = args.filter((a) => !a.startsWith("--"));
   const owner = positionals[1]; // optional
 
-  const limit = getFlag(args, '--limit') ?? '30';
+  const limit = getFlag(args, "--limit") ?? "30";
   const ghArgs = [
-    'repo', 'list',
-    '--json', 'name,description,visibility,primaryLanguage,stargazerCount,updatedAt',
-    '--limit', limit,
+    "repo",
+    "list",
+    "--json",
+    "name,description,visibility,primaryLanguage,stargazerCount,updatedAt",
+    "--limit",
+    limit,
   ];
   if (owner) ghArgs.splice(2, 0, owner); // insert owner after 'list'
-  const visibility = getFlag(args, '--visibility');
-  if (visibility) ghArgs.push('--visibility', visibility);
-  const language = getFlag(args, '--language');
-  if (language) ghArgs.push('--language', language);
-  if (hasFlag(args, '--archived')) ghArgs.push('--archived');
+  const visibility = getFlag(args, "--visibility");
+  if (visibility) ghArgs.push("--visibility", visibility);
+  const language = getFlag(args, "--language");
+  if (language) ghArgs.push("--language", language);
+  if (hasFlag(args, "--archived")) ghArgs.push("--archived");
 
   const repos = await ghJson<Record<string, unknown>[]>(ghArgs);
   const isEmpty = repos.length === 0;
   const limitNum = Number(limit);
   const countLine = formatCountLine({ count: repos.length, limit: limitNum });
-  const suggestions = getSuggestions({ domain: 'repo', action: 'list', isEmpty, repo: ctx });
+  const suggestions = getSuggestions({
+    domain: "repo",
+    action: "list",
+    isEmpty,
+    repo: ctx,
+  });
   return renderOutput([
     countLine,
-    renderList('repos', repos, listSchema),
+    renderList("repos", repos, listSchema),
     renderHelp(suggestions),
   ]);
 }
 
-export async function repoCommand(args: string[], ctx?: RepoContext): Promise<string> {
+export async function repoCommand(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
   const sub = args[0];
 
-  if (sub === '--help' || sub === undefined) return REPO_HELP;
+  if (sub === "--help" || sub === undefined) return REPO_HELP;
 
   switch (sub) {
-    case 'view':
+    case "view":
       return viewRepo(args, ctx);
-    case 'create':
+    case "create":
       return createRepo(args, ctx);
-    case 'edit':
+    case "edit":
       return editRepo(args, ctx);
-    case 'clone':
+    case "clone":
       return cloneRepo(args);
-    case 'fork':
+    case "fork":
       return forkRepo(args, ctx);
-    case 'list':
+    case "list":
       return listRepos(args, ctx);
     default:
-      return renderError(`Unknown subcommand: ${sub}`, 'VALIDATION_ERROR', [
-        'Available subcommands: view, create, edit, clone, fork, list',
+      return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [
+        "Available subcommands: view, create, edit, clone, fork, list",
       ]);
   }
 }

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -23,7 +23,7 @@ export const REPO_HELP = `usage: gh-axi repo <subcommand> [flags]
 subcommands[6]:
   view [owner/name], create <name>, edit, clone <repo>, fork [repo], list [owner]
 flags{view}:
-  --repo <owner/name> (general gh-axi targeting form); one positional owner/name is also accepted for gh repo view parity
+  --repo <owner/name> or exactly one positional owner/name; choose one selector
 flags{create}:
   --public, --private, --internal, --description, --clone, --template
 flags{edit}:

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -70,6 +70,12 @@ async function viewRepo(args: string[], ctx?: RepoContext): Promise<string> {
   const positionals = args.filter((a) => !a.startsWith("-"));
   const repoArg = positionals[1];
   const extraArg = positionals[2];
+  if (repoArg && ctx?.source === "flag") {
+    throw new AxiError(
+      `Unsupported positional argument for repo view with --repo: ${repoArg}. Use --repo <owner/name> to select a repository.`,
+      "VALIDATION_ERROR",
+    );
+  }
   if (extraArg) {
     throw new AxiError(
       `Unsupported positional argument for repo view: ${extraArg}. Use --repo <owner/name> to select a repository.`,

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -71,11 +71,12 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 1. Run \`npx -y gh-axi\` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: \`issue list\`, \`issue view <n>\`, \`pr view <n>\`, \`pr checks <n>\`, \`run view <id>\`, and so on.
 3. Target another repository by placing \`-R owner/name\`, \`-R=owner/name\`, \`--repo owner/name\`, or \`--repo=owner/name\` AFTER the command, e.g. \`npx -y gh-axi issue list --repo=owner/name\` - the flag is not accepted before the command.
-4. Target GitHub Enterprise or another custom host with \`GH_HOST\`, or by placing \`--hostname <host>\` or \`--hostname=<host>\` AFTER the command, e.g. \`npx -y gh-axi issue list --hostname=git.example.com\`.
-5. Trigger (dispatch) a workflow with \`workflow run <name> --ref <ref>\`; \`run\` manages existing workflow runs.
-6. Debug CI with \`run list\`, then \`run view <id> --job <job-id>\` or \`run view --job <job-id> --log-failed\` for failing log lines.
+4. For repository details, \`repo view owner/name\` also accepts the target repository as a positional argument.
+5. Target GitHub Enterprise or another custom host with \`GH_HOST\`, or by placing \`--hostname <host>\` or \`--hostname=<host>\` AFTER the command, e.g. \`npx -y gh-axi issue list --hostname=git.example.com\`.
+6. Trigger (dispatch) a workflow with \`workflow run <name> --ref <ref>\`; \`run\` manages existing workflow runs.
+7. Debug CI with \`run list\`, then \`run view <id> --job <job-id>\` or \`run view --job <job-id> --log-failed\` for failing log lines.
    Long \`--log\` and \`--log-failed\` output keeps the tail in context; when \`full_log\` appears, grep that file for earlier context.
-7. Every response ends with contextual next-step hints under \`help:\` - follow them.
+8. Every response ends with contextual next-step hints under \`help:\` - follow them.
 
 ## Commands
 

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -70,7 +70,7 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 
 1. Run \`npx -y gh-axi\` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: \`issue list\`, \`issue view <n>\`, \`pr view <n>\`, \`pr checks <n>\`, \`run view <id>\`, and so on.
-3. Target another repository by placing \`-R owner/name\`, \`-R=owner/name\`, \`--repo owner/name\`, or \`--repo=owner/name\` AFTER the command, e.g. \`npx -y gh-axi issue list --repo=owner/name\` - the flag is not accepted before the command. \`repo view\` also accepts \`repo view owner/name\` as a command-specific compatibility exception for \`gh repo view [<repository>]\`; do not generalize that positional form to other commands.
+3. Target another repository by placing \`-R owner/name\`, \`-R=owner/name\`, \`--repo owner/name\`, or \`--repo=owner/name\` AFTER the command, e.g. \`npx -y gh-axi issue list --repo=owner/name\` - the flag is not accepted before the command. \`repo view\` also accepts exactly one positional repository, \`repo view owner/name\`, as a command-specific compatibility exception for \`gh repo view [<repository>]\`; do not combine it with \`--repo\` or generalize that positional form to other commands.
 4. Target GitHub Enterprise or another custom host with \`GH_HOST\`, or by placing \`--hostname <host>\` or \`--hostname=<host>\` AFTER the command, e.g. \`npx -y gh-axi issue list --hostname=git.example.com\`.
 5. Trigger (dispatch) a workflow with \`workflow run <name> --ref <ref>\`; \`run\` manages existing workflow runs.
 6. Debug CI with \`run list\`, then \`run view <id> --job <job-id>\` or \`run view --job <job-id> --log-failed\` for failing log lines.

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -70,13 +70,12 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 
 1. Run \`npx -y gh-axi\` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: \`issue list\`, \`issue view <n>\`, \`pr view <n>\`, \`pr checks <n>\`, \`run view <id>\`, and so on.
-3. Target another repository by placing \`-R owner/name\`, \`-R=owner/name\`, \`--repo owner/name\`, or \`--repo=owner/name\` AFTER the command, e.g. \`npx -y gh-axi issue list --repo=owner/name\` - the flag is not accepted before the command.
-4. For repository details, \`repo view owner/name\` accepts one positional target repository; use \`--repo owner/name\` for repository targeting on other commands.
-5. Target GitHub Enterprise or another custom host with \`GH_HOST\`, or by placing \`--hostname <host>\` or \`--hostname=<host>\` AFTER the command, e.g. \`npx -y gh-axi issue list --hostname=git.example.com\`.
-6. Trigger (dispatch) a workflow with \`workflow run <name> --ref <ref>\`; \`run\` manages existing workflow runs.
-7. Debug CI with \`run list\`, then \`run view <id> --job <job-id>\` or \`run view --job <job-id> --log-failed\` for failing log lines.
+3. Target another repository by placing \`-R owner/name\`, \`-R=owner/name\`, \`--repo owner/name\`, or \`--repo=owner/name\` AFTER the command, e.g. \`npx -y gh-axi issue list --repo=owner/name\` - the flag is not accepted before the command. \`repo view\` also accepts \`repo view owner/name\` as a command-specific compatibility exception for \`gh repo view [<repository>]\`; do not generalize that positional form to other commands.
+4. Target GitHub Enterprise or another custom host with \`GH_HOST\`, or by placing \`--hostname <host>\` or \`--hostname=<host>\` AFTER the command, e.g. \`npx -y gh-axi issue list --hostname=git.example.com\`.
+5. Trigger (dispatch) a workflow with \`workflow run <name> --ref <ref>\`; \`run\` manages existing workflow runs.
+6. Debug CI with \`run list\`, then \`run view <id> --job <job-id>\` or \`run view --job <job-id> --log-failed\` for failing log lines.
    Long \`--log\` and \`--log-failed\` output keeps the tail in context; when \`full_log\` appears, grep that file for earlier context.
-8. Every response ends with contextual next-step hints under \`help:\` - follow them.
+7. Every response ends with contextual next-step hints under \`help:\` - follow them.
 
 ## Commands
 

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -71,7 +71,7 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 1. Run \`npx -y gh-axi\` with no arguments for a dashboard of the current repo - open issues, open PRs, and suggested next commands.
 2. Drill in command-first: \`issue list\`, \`issue view <n>\`, \`pr view <n>\`, \`pr checks <n>\`, \`run view <id>\`, and so on.
 3. Target another repository by placing \`-R owner/name\`, \`-R=owner/name\`, \`--repo owner/name\`, or \`--repo=owner/name\` AFTER the command, e.g. \`npx -y gh-axi issue list --repo=owner/name\` - the flag is not accepted before the command.
-4. For repository details, \`repo view owner/name\` also accepts the target repository as a positional argument.
+4. For repository details, \`repo view owner/name\` accepts one positional target repository; use \`--repo owner/name\` for repository targeting on other commands.
 5. Target GitHub Enterprise or another custom host with \`GH_HOST\`, or by placing \`--hostname <host>\` or \`--hostname=<host>\` AFTER the command, e.g. \`npx -y gh-axi issue list --hostname=git.example.com\`.
 6. Trigger (dispatch) a workflow with \`workflow run <name> --ref <ref>\`; \`run\` manages existing workflow runs.
 7. Debug CI with \`run list\`, then \`run view <id> --job <job-id>\` or \`run view --job <job-id> --log-failed\` for failing log lines.

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -476,9 +476,7 @@ const table: SuggestionEntry[] = [
   // Repo list
   {
     match: (c) => c.domain === "repo" && c.action === "list",
-    lines: () => [
-      `Run \`gh-axi repo view <owner/name>\` to view a repository`,
-    ],
+    lines: () => [`Run \`gh-axi repo view <owner/name>\` to view a repository`],
   },
 
   // Repo edit/clone/fork

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -476,7 +476,9 @@ const table: SuggestionEntry[] = [
   // Repo list
   {
     match: (c) => c.domain === "repo" && c.action === "list",
-    lines: () => [`Run \`gh-axi repo view <owner/name>\` to view a repository`],
+    lines: () => [
+      `Run \`gh-axi repo view --repo <owner/name>\` to view a repository`,
+    ],
   },
 
   // Repo edit/clone/fork

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -477,7 +477,7 @@ const table: SuggestionEntry[] = [
   {
     match: (c) => c.domain === "repo" && c.action === "list",
     lines: () => [
-      `Run \`gh-axi repo view -R <owner/name>\` to view a repository`,
+      `Run \`gh-axi repo view <owner/name>\` to view a repository`,
     ],
   },
 

--- a/test/commands/repo.test.ts
+++ b/test/commands/repo.test.ts
@@ -75,14 +75,35 @@ describe("repoCommand", () => {
       expect(callArgs).toContain("octo/repo");
     });
 
-    it("passes a positional owner/name repo to gh repo view", async () => {
+    it("passes a positional owner/name repo to gh repo view without flag context", async () => {
       mockedGhJson.mockResolvedValue({ name: "agent-os" });
 
-      await repoCommand(["view", "minekube/agent-os"], ctx);
+      await repoCommand(["view", "minekube/agent-os"], {
+        ...ctx,
+        source: "git",
+      });
 
       const callArgs = mockedGhJson.mock.calls[0][0];
       expect(callArgs).toContain("minekube/agent-os");
       expect(callArgs).not.toContain("octo/repo");
+    });
+
+    it("rejects a positional repo selector when repo context comes from --repo", async () => {
+      await expect(
+        repoCommand(["view", "minekube/agent-os"], ctx),
+      ).rejects.toThrow(
+        "Unsupported positional argument for repo view with --repo: minekube/agent-os. Use --repo <owner/name> to select a repository.",
+      );
+      expect(mockedGhJson).not.toHaveBeenCalled();
+    });
+
+    it("rejects the positional repo selector first when --repo also has extra positionals", async () => {
+      await expect(
+        repoCommand(["view", "minekube/agent-os", "extra"], ctx),
+      ).rejects.toThrow(
+        "Unsupported positional argument for repo view with --repo: minekube/agent-os. Use --repo <owner/name> to select a repository.",
+      );
+      expect(mockedGhJson).not.toHaveBeenCalled();
     });
 
     it("keeps bare ambient repo view when no repo context exists", async () => {
@@ -100,7 +121,10 @@ describe("repoCommand", () => {
 
     it("rejects extra positional args for repo view", async () => {
       await expect(
-        repoCommand(["view", "minekube/agent-os", "extra"], ctx),
+        repoCommand(["view", "minekube/agent-os", "extra"], {
+          ...ctx,
+          source: "git",
+        }),
       ).rejects.toThrow(
         "Unsupported positional argument for repo view: extra. Use --repo <owner/name> to select a repository.",
       );

--- a/test/commands/repo.test.ts
+++ b/test/commands/repo.test.ts
@@ -70,6 +70,35 @@ describe('repoCommand', () => {
       expect(callArgs).toContain('octo/repo');
     });
 
+    it('passes a positional owner/name repo to gh repo view', async () => {
+      mockedGhJson.mockResolvedValue({ name: 'agent-os' });
+
+      await repoCommand(['view', 'minekube/agent-os'], ctx);
+
+      const callArgs = mockedGhJson.mock.calls[0][0];
+      expect(callArgs).toContain('minekube/agent-os');
+      expect(callArgs).not.toContain('octo/repo');
+    });
+
+    it('keeps bare ambient repo view when no repo context exists', async () => {
+      mockedGhJson.mockResolvedValue({ name: 'repo' });
+
+      await repoCommand(['view']);
+
+      expect(mockedGhJson).toHaveBeenCalledWith([
+        'repo',
+        'view',
+        '--json',
+        'name,description,defaultBranchRef,stargazerCount,forkCount,issues,pullRequests,visibility,primaryLanguage',
+      ]);
+    });
+
+    it('rejects extra positional args for repo view', async () => {
+      await expect(
+        repoCommand(['view', 'minekube/agent-os', 'extra'], ctx),
+      ).rejects.toThrow('Unsupported positional argument for repo view: extra. Use --repo <owner/name> to select a repository.');
+    });
+
     it('omits help suggestions from detail view', async () => {
       mockedGhJson.mockResolvedValue({
         name: 'repo', description: 'test', defaultBranchRef: { name: 'main' },

--- a/test/commands/repo.test.ts
+++ b/test/commands/repo.test.ts
@@ -1,261 +1,222 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 
-vi.mock("../../src/gh.js", () => ({
+vi.mock('../../src/gh.js', () => ({
   ghJson: vi.fn(),
   ghExec: vi.fn(),
   ghRaw: vi.fn(),
 }));
 
-import { ghJson, ghExec } from "../../src/gh.js";
-import { repoCommand, REPO_HELP } from "../../src/commands/repo.js";
-import { AxiError } from "../../src/errors.js";
-import type { RepoContext } from "../../src/context.js";
+import { ghJson, ghExec } from '../../src/gh.js';
+import { repoCommand, REPO_HELP } from '../../src/commands/repo.js';
+import { AxiError } from '../../src/errors.js';
+import type { RepoContext } from '../../src/context.js';
 
 const mockedGhJson = vi.mocked(ghJson);
 const mockedGhExec = vi.mocked(ghExec);
 
-const ctx: RepoContext = {
-  owner: "octo",
-  name: "repo",
-  nwo: "octo/repo",
-  source: "flag",
-};
+const ctx: RepoContext = { owner: 'octo', name: 'repo', nwo: 'octo/repo', source: 'flag' };
 
-describe("repoCommand", () => {
+describe('repoCommand', () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  describe("router", () => {
-    it("returns help when --help is passed", async () => {
-      const result = await repoCommand(["--help"], ctx);
+  describe('router', () => {
+    it('returns help when --help is passed', async () => {
+      const result = await repoCommand(['--help'], ctx);
       expect(result).toBe(REPO_HELP);
     });
 
-    it("returns help when no subcommand is given", async () => {
+    it('returns help when no subcommand is given', async () => {
       const result = await repoCommand([], ctx);
       expect(result).toBe(REPO_HELP);
     });
 
-    it("returns error for unknown subcommand", async () => {
-      const result = await repoCommand(["unknown"], ctx);
-      expect(result).toContain("Unknown subcommand: unknown");
+    it('returns error for unknown subcommand', async () => {
+      const result = await repoCommand(['unknown'], ctx);
+      expect(result).toContain('Unknown subcommand: unknown');
     });
   });
 
-  describe("view", () => {
-    it("returns repo detail", async () => {
+  describe('view', () => {
+    it('returns repo detail', async () => {
       mockedGhJson.mockResolvedValue({
-        name: "repo",
-        description: "A test repo",
-        defaultBranchRef: { name: "main" },
+        name: 'repo',
+        description: 'A test repo',
+        defaultBranchRef: { name: 'main' },
         stargazerCount: 42,
         forkCount: 5,
         issues: { totalCount: 10 },
         pullRequests: { totalCount: 3 },
-        visibility: "PUBLIC",
-        primaryLanguage: { name: "TypeScript" },
+        visibility: 'PUBLIC',
+        primaryLanguage: { name: 'TypeScript' },
       });
 
-      const result = await repoCommand(["view"], ctx);
+      const result = await repoCommand(['view'], ctx);
 
-      expect(result).toContain("repo");
-      expect(result).toContain("A test repo");
-      expect(result).toContain("main");
-      expect(result).toContain("TypeScript");
+      expect(result).toContain('repo');
+      expect(result).toContain('A test repo');
+      expect(result).toContain('main');
+      expect(result).toContain('TypeScript');
       expect(mockedGhJson).toHaveBeenCalledTimes(1);
     });
 
-    it("passes repo nwo as positional arg when ctx is provided", async () => {
-      mockedGhJson.mockResolvedValue({ name: "repo" });
+    it('passes repo nwo as positional arg when ctx is provided', async () => {
+      mockedGhJson.mockResolvedValue({ name: 'repo' });
 
-      await repoCommand(["view"], ctx);
+      await repoCommand(['view'], ctx);
 
       const callArgs = mockedGhJson.mock.calls[0][0];
-      expect(callArgs).toContain("octo/repo");
+      expect(callArgs).toContain('octo/repo');
     });
 
-    it("passes a positional owner/name repo to gh repo view without flag context", async () => {
-      mockedGhJson.mockResolvedValue({ name: "agent-os" });
+    it('passes a positional owner/name repo to gh repo view without flag context', async () => {
+      mockedGhJson.mockResolvedValue({ name: 'agent-os' });
 
-      await repoCommand(["view", "minekube/agent-os"], {
+      await repoCommand(['view', 'minekube/agent-os'], {
         ...ctx,
-        source: "git",
+        source: 'git',
       });
 
       const callArgs = mockedGhJson.mock.calls[0][0];
-      expect(callArgs).toContain("minekube/agent-os");
-      expect(callArgs).not.toContain("octo/repo");
+      expect(callArgs).toContain('minekube/agent-os');
+      expect(callArgs).not.toContain('octo/repo');
     });
 
-    it("rejects a positional repo selector when repo context comes from --repo", async () => {
+    it('rejects a positional repo selector when repo context comes from --repo', async () => {
       await expect(
-        repoCommand(["view", "minekube/agent-os"], ctx),
+        repoCommand(['view', 'minekube/agent-os'], ctx),
       ).rejects.toThrow(
-        "Unsupported positional argument for repo view with --repo: minekube/agent-os. Use --repo <owner/name> to select a repository.",
+        'Unsupported positional argument for repo view with --repo: minekube/agent-os. Use --repo <owner/name> to select a repository.',
       );
       expect(mockedGhJson).not.toHaveBeenCalled();
     });
 
-    it("rejects the positional repo selector first when --repo also has extra positionals", async () => {
-      await expect(
-        repoCommand(["view", "minekube/agent-os", "extra"], ctx),
-      ).rejects.toThrow(
-        "Unsupported positional argument for repo view with --repo: minekube/agent-os. Use --repo <owner/name> to select a repository.",
-      );
-      expect(mockedGhJson).not.toHaveBeenCalled();
-    });
+    it('keeps bare ambient repo view when no repo context exists', async () => {
+      mockedGhJson.mockResolvedValue({ name: 'repo' });
 
-    it("keeps bare ambient repo view when no repo context exists", async () => {
-      mockedGhJson.mockResolvedValue({ name: "repo" });
-
-      await repoCommand(["view"]);
+      await repoCommand(['view']);
 
       expect(mockedGhJson).toHaveBeenCalledWith([
-        "repo",
-        "view",
-        "--json",
-        "name,description,defaultBranchRef,stargazerCount,forkCount,issues,pullRequests,visibility,primaryLanguage",
+        'repo',
+        'view',
+        '--json',
+        'name,description,defaultBranchRef,stargazerCount,forkCount,issues,pullRequests,visibility,primaryLanguage',
       ]);
     });
 
-    it("rejects extra positional args for repo view", async () => {
+    it('rejects extra positional args for repo view', async () => {
       await expect(
-        repoCommand(["view", "minekube/agent-os", "extra"], {
+        repoCommand(['view', 'minekube/agent-os', 'extra'], {
           ...ctx,
-          source: "git",
+          source: 'git',
         }),
       ).rejects.toThrow(
-        "Unsupported positional argument for repo view: extra. Use --repo <owner/name> to select a repository.",
+        'Unsupported positional argument for repo view: extra. Use --repo <owner/name> to select a repository.',
       );
+      expect(mockedGhJson).not.toHaveBeenCalled();
     });
 
-    it("omits help suggestions from detail view", async () => {
+    it('omits help suggestions from detail view', async () => {
       mockedGhJson.mockResolvedValue({
-        name: "repo",
-        description: "test",
-        defaultBranchRef: { name: "main" },
-        stargazerCount: 0,
-        forkCount: 0,
-        issues: { totalCount: 0 },
-        pullRequests: { totalCount: 0 },
-        visibility: "PUBLIC",
-        primaryLanguage: { name: "Go" },
+        name: 'repo', description: 'test', defaultBranchRef: { name: 'main' },
+        stargazerCount: 0, forkCount: 0, issues: { totalCount: 0 },
+        pullRequests: { totalCount: 0 }, visibility: 'PUBLIC', primaryLanguage: { name: 'Go' },
       });
-      const result = await repoCommand(["view"], ctx);
+      const result = await repoCommand(['view'], ctx);
       expect(result).not.toMatch(/^help\[/m);
     });
   });
 
-  describe("create", () => {
-    it("creates a repo with required name", async () => {
-      mockedGhExec.mockResolvedValue("");
+  describe('create', () => {
+    it('creates a repo with required name', async () => {
+      mockedGhExec.mockResolvedValue('');
 
-      const result = await repoCommand(["create", "my-new-repo"]);
+      const result = await repoCommand(['create', 'my-new-repo']);
 
-      expect(result).toContain("created");
-      expect(result).toContain("my-new-repo");
+      expect(result).toContain('created');
+      expect(result).toContain('my-new-repo');
       expect(mockedGhExec).toHaveBeenCalledWith(
-        expect.arrayContaining(["repo", "create", "my-new-repo"]),
+        expect.arrayContaining(['repo', 'create', 'my-new-repo']),
       );
     });
 
-    it("throws when name is missing", async () => {
-      await expect(repoCommand(["create"])).rejects.toThrow(AxiError);
+    it('throws when name is missing', async () => {
+      await expect(
+        repoCommand(['create']),
+      ).rejects.toThrow(AxiError);
     });
 
-    it("passes --public flag", async () => {
-      mockedGhExec.mockResolvedValue("");
+    it('passes --public flag', async () => {
+      mockedGhExec.mockResolvedValue('');
 
-      await repoCommand(["create", "my-repo", "--public"]);
+      await repoCommand(['create', 'my-repo', '--public']);
 
       expect(mockedGhExec).toHaveBeenCalledWith(
-        expect.arrayContaining(["--public"]),
+        expect.arrayContaining(['--public']),
       );
     });
   });
 
-  describe("list", () => {
-    it("emits count line with number of repos", async () => {
+  describe('list', () => {
+    it('emits count line with number of repos', async () => {
       mockedGhJson.mockResolvedValue([
-        {
-          name: "repo-a",
-          description: "First",
-          visibility: "PUBLIC",
-          primaryLanguage: { name: "TypeScript" },
-          stargazerCount: 10,
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-        {
-          name: "repo-b",
-          description: "Second",
-          visibility: "PRIVATE",
-          primaryLanguage: { name: "Go" },
-          stargazerCount: 5,
-          updatedAt: "2024-01-02T00:00:00Z",
-        },
+        { name: 'repo-a', description: 'First', visibility: 'PUBLIC', primaryLanguage: { name: 'TypeScript' }, stargazerCount: 10, updatedAt: '2024-01-01T00:00:00Z' },
+        { name: 'repo-b', description: 'Second', visibility: 'PRIVATE', primaryLanguage: { name: 'Go' }, stargazerCount: 5, updatedAt: '2024-01-02T00:00:00Z' },
       ]);
 
-      const result = await repoCommand(["list"], ctx);
+      const result = await repoCommand(['list'], ctx);
 
-      expect(result).toContain("count: 2");
+      expect(result).toContain('count: 2');
     });
 
-    it("emits count: 0 when no repos exist", async () => {
+    it('emits count: 0 when no repos exist', async () => {
       mockedGhJson.mockResolvedValue([]);
 
-      const result = await repoCommand(["list"], ctx);
+      const result = await repoCommand(['list'], ctx);
 
-      expect(result).toContain("count: 0");
+      expect(result).toContain('count: 0');
     });
 
-    it("shows truncation hint when result count equals default limit", async () => {
+    it('shows truncation hint when result count equals default limit', async () => {
       // Default limit is 30
       const items = Array.from({ length: 30 }, (_, i) => ({
-        name: `repo-${i}`,
-        description: "",
-        visibility: "PUBLIC",
-        primaryLanguage: null,
-        stargazerCount: 0,
-        updatedAt: "2024-01-01T00:00:00Z",
+        name: `repo-${i}`, description: '', visibility: 'PUBLIC', primaryLanguage: null, stargazerCount: 0, updatedAt: '2024-01-01T00:00:00Z',
       }));
       mockedGhJson.mockResolvedValue(items);
 
-      const result = await repoCommand(["list"], ctx);
+      const result = await repoCommand(['list'], ctx);
 
-      expect(result).toContain("showing first 30");
+      expect(result).toContain('showing first 30');
     });
 
-    it("shows truncation hint when custom limit is hit", async () => {
+    it('shows truncation hint when custom limit is hit', async () => {
       const items = Array.from({ length: 10 }, (_, i) => ({
-        name: `repo-${i}`,
-        description: "",
-        visibility: "PUBLIC",
-        primaryLanguage: null,
-        stargazerCount: 0,
-        updatedAt: "2024-01-01T00:00:00Z",
+        name: `repo-${i}`, description: '', visibility: 'PUBLIC', primaryLanguage: null, stargazerCount: 0, updatedAt: '2024-01-01T00:00:00Z',
       }));
       mockedGhJson.mockResolvedValue(items);
 
-      const result = await repoCommand(["list", "--limit", "10"], ctx);
+      const result = await repoCommand(['list', '--limit', '10'], ctx);
 
-      expect(result).toContain("showing first 10");
+      expect(result).toContain('showing first 10');
     });
   });
 
-  describe("clone", () => {
-    it("clones a repo", async () => {
-      mockedGhExec.mockResolvedValue("");
+  describe('clone', () => {
+    it('clones a repo', async () => {
+      mockedGhExec.mockResolvedValue('');
 
-      const result = await repoCommand(["clone", "octo/repo"]);
+      const result = await repoCommand(['clone', 'octo/repo']);
 
-      expect(result).toContain("clone");
-      expect(result).toContain("ok");
-      expect(mockedGhExec).toHaveBeenCalledWith(["repo", "clone", "octo/repo"]);
+      expect(result).toContain('clone');
+      expect(result).toContain('ok');
+      expect(mockedGhExec).toHaveBeenCalledWith(['repo', 'clone', 'octo/repo']);
     });
 
-    it("throws when repo is missing", async () => {
-      await expect(repoCommand(["clone"])).rejects.toThrow(AxiError);
+    it('throws when repo is missing', async () => {
+      await expect(
+        repoCommand(['clone']),
+      ).rejects.toThrow(AxiError);
     });
   });
 });

--- a/test/commands/repo.test.ts
+++ b/test/commands/repo.test.ts
@@ -1,204 +1,237 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from "vitest";
 
-vi.mock('../../src/gh.js', () => ({
+vi.mock("../../src/gh.js", () => ({
   ghJson: vi.fn(),
   ghExec: vi.fn(),
   ghRaw: vi.fn(),
 }));
 
-import { ghJson, ghExec } from '../../src/gh.js';
-import { repoCommand, REPO_HELP } from '../../src/commands/repo.js';
-import { AxiError } from '../../src/errors.js';
-import type { RepoContext } from '../../src/context.js';
+import { ghJson, ghExec } from "../../src/gh.js";
+import { repoCommand, REPO_HELP } from "../../src/commands/repo.js";
+import { AxiError } from "../../src/errors.js";
+import type { RepoContext } from "../../src/context.js";
 
 const mockedGhJson = vi.mocked(ghJson);
 const mockedGhExec = vi.mocked(ghExec);
 
-const ctx: RepoContext = { owner: 'octo', name: 'repo', nwo: 'octo/repo', source: 'flag' };
+const ctx: RepoContext = {
+  owner: "octo",
+  name: "repo",
+  nwo: "octo/repo",
+  source: "flag",
+};
 
-describe('repoCommand', () => {
+describe("repoCommand", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  describe('router', () => {
-    it('returns help when --help is passed', async () => {
-      const result = await repoCommand(['--help'], ctx);
+  describe("router", () => {
+    it("returns help when --help is passed", async () => {
+      const result = await repoCommand(["--help"], ctx);
       expect(result).toBe(REPO_HELP);
     });
 
-    it('returns help when no subcommand is given', async () => {
+    it("returns help when no subcommand is given", async () => {
       const result = await repoCommand([], ctx);
       expect(result).toBe(REPO_HELP);
     });
 
-    it('returns error for unknown subcommand', async () => {
-      const result = await repoCommand(['unknown'], ctx);
-      expect(result).toContain('Unknown subcommand: unknown');
+    it("returns error for unknown subcommand", async () => {
+      const result = await repoCommand(["unknown"], ctx);
+      expect(result).toContain("Unknown subcommand: unknown");
     });
   });
 
-  describe('view', () => {
-    it('returns repo detail', async () => {
+  describe("view", () => {
+    it("returns repo detail", async () => {
       mockedGhJson.mockResolvedValue({
-        name: 'repo',
-        description: 'A test repo',
-        defaultBranchRef: { name: 'main' },
+        name: "repo",
+        description: "A test repo",
+        defaultBranchRef: { name: "main" },
         stargazerCount: 42,
         forkCount: 5,
         issues: { totalCount: 10 },
         pullRequests: { totalCount: 3 },
-        visibility: 'PUBLIC',
-        primaryLanguage: { name: 'TypeScript' },
+        visibility: "PUBLIC",
+        primaryLanguage: { name: "TypeScript" },
       });
 
-      const result = await repoCommand(['view'], ctx);
+      const result = await repoCommand(["view"], ctx);
 
-      expect(result).toContain('repo');
-      expect(result).toContain('A test repo');
-      expect(result).toContain('main');
-      expect(result).toContain('TypeScript');
+      expect(result).toContain("repo");
+      expect(result).toContain("A test repo");
+      expect(result).toContain("main");
+      expect(result).toContain("TypeScript");
       expect(mockedGhJson).toHaveBeenCalledTimes(1);
     });
 
-    it('passes repo nwo as positional arg when ctx is provided', async () => {
-      mockedGhJson.mockResolvedValue({ name: 'repo' });
+    it("passes repo nwo as positional arg when ctx is provided", async () => {
+      mockedGhJson.mockResolvedValue({ name: "repo" });
 
-      await repoCommand(['view'], ctx);
-
-      const callArgs = mockedGhJson.mock.calls[0][0];
-      expect(callArgs).toContain('octo/repo');
-    });
-
-    it('passes a positional owner/name repo to gh repo view', async () => {
-      mockedGhJson.mockResolvedValue({ name: 'agent-os' });
-
-      await repoCommand(['view', 'minekube/agent-os'], ctx);
+      await repoCommand(["view"], ctx);
 
       const callArgs = mockedGhJson.mock.calls[0][0];
-      expect(callArgs).toContain('minekube/agent-os');
-      expect(callArgs).not.toContain('octo/repo');
+      expect(callArgs).toContain("octo/repo");
     });
 
-    it('keeps bare ambient repo view when no repo context exists', async () => {
-      mockedGhJson.mockResolvedValue({ name: 'repo' });
+    it("passes a positional owner/name repo to gh repo view", async () => {
+      mockedGhJson.mockResolvedValue({ name: "agent-os" });
 
-      await repoCommand(['view']);
+      await repoCommand(["view", "minekube/agent-os"], ctx);
+
+      const callArgs = mockedGhJson.mock.calls[0][0];
+      expect(callArgs).toContain("minekube/agent-os");
+      expect(callArgs).not.toContain("octo/repo");
+    });
+
+    it("keeps bare ambient repo view when no repo context exists", async () => {
+      mockedGhJson.mockResolvedValue({ name: "repo" });
+
+      await repoCommand(["view"]);
 
       expect(mockedGhJson).toHaveBeenCalledWith([
-        'repo',
-        'view',
-        '--json',
-        'name,description,defaultBranchRef,stargazerCount,forkCount,issues,pullRequests,visibility,primaryLanguage',
+        "repo",
+        "view",
+        "--json",
+        "name,description,defaultBranchRef,stargazerCount,forkCount,issues,pullRequests,visibility,primaryLanguage",
       ]);
     });
 
-    it('rejects extra positional args for repo view', async () => {
+    it("rejects extra positional args for repo view", async () => {
       await expect(
-        repoCommand(['view', 'minekube/agent-os', 'extra'], ctx),
-      ).rejects.toThrow('Unsupported positional argument for repo view: extra. Use --repo <owner/name> to select a repository.');
+        repoCommand(["view", "minekube/agent-os", "extra"], ctx),
+      ).rejects.toThrow(
+        "Unsupported positional argument for repo view: extra. Use --repo <owner/name> to select a repository.",
+      );
     });
 
-    it('omits help suggestions from detail view', async () => {
+    it("omits help suggestions from detail view", async () => {
       mockedGhJson.mockResolvedValue({
-        name: 'repo', description: 'test', defaultBranchRef: { name: 'main' },
-        stargazerCount: 0, forkCount: 0, issues: { totalCount: 0 },
-        pullRequests: { totalCount: 0 }, visibility: 'PUBLIC', primaryLanguage: { name: 'Go' },
+        name: "repo",
+        description: "test",
+        defaultBranchRef: { name: "main" },
+        stargazerCount: 0,
+        forkCount: 0,
+        issues: { totalCount: 0 },
+        pullRequests: { totalCount: 0 },
+        visibility: "PUBLIC",
+        primaryLanguage: { name: "Go" },
       });
-      const result = await repoCommand(['view'], ctx);
+      const result = await repoCommand(["view"], ctx);
       expect(result).not.toMatch(/^help\[/m);
     });
   });
 
-  describe('create', () => {
-    it('creates a repo with required name', async () => {
-      mockedGhExec.mockResolvedValue('');
+  describe("create", () => {
+    it("creates a repo with required name", async () => {
+      mockedGhExec.mockResolvedValue("");
 
-      const result = await repoCommand(['create', 'my-new-repo']);
+      const result = await repoCommand(["create", "my-new-repo"]);
 
-      expect(result).toContain('created');
-      expect(result).toContain('my-new-repo');
+      expect(result).toContain("created");
+      expect(result).toContain("my-new-repo");
       expect(mockedGhExec).toHaveBeenCalledWith(
-        expect.arrayContaining(['repo', 'create', 'my-new-repo']),
+        expect.arrayContaining(["repo", "create", "my-new-repo"]),
       );
     });
 
-    it('throws when name is missing', async () => {
-      await expect(
-        repoCommand(['create']),
-      ).rejects.toThrow(AxiError);
+    it("throws when name is missing", async () => {
+      await expect(repoCommand(["create"])).rejects.toThrow(AxiError);
     });
 
-    it('passes --public flag', async () => {
-      mockedGhExec.mockResolvedValue('');
+    it("passes --public flag", async () => {
+      mockedGhExec.mockResolvedValue("");
 
-      await repoCommand(['create', 'my-repo', '--public']);
+      await repoCommand(["create", "my-repo", "--public"]);
 
       expect(mockedGhExec).toHaveBeenCalledWith(
-        expect.arrayContaining(['--public']),
+        expect.arrayContaining(["--public"]),
       );
     });
   });
 
-  describe('list', () => {
-    it('emits count line with number of repos', async () => {
+  describe("list", () => {
+    it("emits count line with number of repos", async () => {
       mockedGhJson.mockResolvedValue([
-        { name: 'repo-a', description: 'First', visibility: 'PUBLIC', primaryLanguage: { name: 'TypeScript' }, stargazerCount: 10, updatedAt: '2024-01-01T00:00:00Z' },
-        { name: 'repo-b', description: 'Second', visibility: 'PRIVATE', primaryLanguage: { name: 'Go' }, stargazerCount: 5, updatedAt: '2024-01-02T00:00:00Z' },
+        {
+          name: "repo-a",
+          description: "First",
+          visibility: "PUBLIC",
+          primaryLanguage: { name: "TypeScript" },
+          stargazerCount: 10,
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          name: "repo-b",
+          description: "Second",
+          visibility: "PRIVATE",
+          primaryLanguage: { name: "Go" },
+          stargazerCount: 5,
+          updatedAt: "2024-01-02T00:00:00Z",
+        },
       ]);
 
-      const result = await repoCommand(['list'], ctx);
+      const result = await repoCommand(["list"], ctx);
 
-      expect(result).toContain('count: 2');
+      expect(result).toContain("count: 2");
     });
 
-    it('emits count: 0 when no repos exist', async () => {
+    it("emits count: 0 when no repos exist", async () => {
       mockedGhJson.mockResolvedValue([]);
 
-      const result = await repoCommand(['list'], ctx);
+      const result = await repoCommand(["list"], ctx);
 
-      expect(result).toContain('count: 0');
+      expect(result).toContain("count: 0");
     });
 
-    it('shows truncation hint when result count equals default limit', async () => {
+    it("shows truncation hint when result count equals default limit", async () => {
       // Default limit is 30
       const items = Array.from({ length: 30 }, (_, i) => ({
-        name: `repo-${i}`, description: '', visibility: 'PUBLIC', primaryLanguage: null, stargazerCount: 0, updatedAt: '2024-01-01T00:00:00Z',
+        name: `repo-${i}`,
+        description: "",
+        visibility: "PUBLIC",
+        primaryLanguage: null,
+        stargazerCount: 0,
+        updatedAt: "2024-01-01T00:00:00Z",
       }));
       mockedGhJson.mockResolvedValue(items);
 
-      const result = await repoCommand(['list'], ctx);
+      const result = await repoCommand(["list"], ctx);
 
-      expect(result).toContain('showing first 30');
+      expect(result).toContain("showing first 30");
     });
 
-    it('shows truncation hint when custom limit is hit', async () => {
+    it("shows truncation hint when custom limit is hit", async () => {
       const items = Array.from({ length: 10 }, (_, i) => ({
-        name: `repo-${i}`, description: '', visibility: 'PUBLIC', primaryLanguage: null, stargazerCount: 0, updatedAt: '2024-01-01T00:00:00Z',
+        name: `repo-${i}`,
+        description: "",
+        visibility: "PUBLIC",
+        primaryLanguage: null,
+        stargazerCount: 0,
+        updatedAt: "2024-01-01T00:00:00Z",
       }));
       mockedGhJson.mockResolvedValue(items);
 
-      const result = await repoCommand(['list', '--limit', '10'], ctx);
+      const result = await repoCommand(["list", "--limit", "10"], ctx);
 
-      expect(result).toContain('showing first 10');
+      expect(result).toContain("showing first 10");
     });
   });
 
-  describe('clone', () => {
-    it('clones a repo', async () => {
-      mockedGhExec.mockResolvedValue('');
+  describe("clone", () => {
+    it("clones a repo", async () => {
+      mockedGhExec.mockResolvedValue("");
 
-      const result = await repoCommand(['clone', 'octo/repo']);
+      const result = await repoCommand(["clone", "octo/repo"]);
 
-      expect(result).toContain('clone');
-      expect(result).toContain('ok');
-      expect(mockedGhExec).toHaveBeenCalledWith(['repo', 'clone', 'octo/repo']);
+      expect(result).toContain("clone");
+      expect(result).toContain("ok");
+      expect(mockedGhExec).toHaveBeenCalledWith(["repo", "clone", "octo/repo"]);
     });
 
-    it('throws when repo is missing', async () => {
-      await expect(
-        repoCommand(['clone']),
-      ).rejects.toThrow(AxiError);
+    it("throws when repo is missing", async () => {
+      await expect(repoCommand(["clone"])).rejects.toThrow(AxiError);
     });
   });
 });


### PR DESCRIPTION
## Intent

Address captain review blockers on PR #66 for issue #64. Keep one positional owner/name for gh-axi repo view only as an explicit gh-compatible exception to official gh repo view [<repository>] syntax; keep --repo owner/name and --repo=owner/name documented as the general gh-axi command-first cross-repo targeting form; reject ambiguous/conflicting selectors such as positional plus --repo and reject extra positionals with clear validation errors. Clean the prior formatting/style churn so repo.ts and repo.test.ts stay in the existing single-quote style with a focused net diff. Regenerate skills/gh-axi/SKILL.md from src/skill.ts and refresh the PR body so it has no duplicate evidence sections or misleading positional examples.

## What Changed
- Allow `gh-axi repo view <owner>/<repo>` to pass an explicit positional repository target through to `gh repo view`, while rejecting ambiguous combinations with `--repo` and extra positional arguments with validation errors.
- Update repo view suggestions and docs to preserve `--repo` as the general command-first cross-repo targeting form while documenting the `repo view` positional exception.
- Add focused repo command coverage for positional targets, `--repo` targets, conflicting selectors, and extra positional arguments.

## Risk Assessment

✅ Low: The change is narrow, well-covered by focused unit tests in the diff, and the new selector behavior is localized to `repo view` without touching shared command routing semantics.

## Testing

Inspected the target diff, ran focused repo/CLI/skill/suggestion tests, verified generated skill docs are current, captured an end-to-end CLI transcript showing positional `repo view`, command-first `--repo`, conflict rejection, and extra-positional rejection, then removed the generated `node_modules`; all exercised checks passed and the worktree was left clean.

<details>
<summary>Evidence: Repo view CLI evidence transcript</summary>

```text

## positional repo view compatibility
$ ./node_modules/.bin/tsx bin/gh-axi.ts repo view minekube/agent-os
[exit 0]
[stdout]
repo:
  name: agent-os
  description: fake gh repo view for minekube/agent-os
  branch: main
  stars: 12
  forks: 3
  issues: 4
  prs: 5
  visibility: public
  language: TypeScript

## command-first --repo targeting
$ ./node_modules/.bin/tsx bin/gh-axi.ts repo view --repo kunchenguid/gh-axi
[exit 0]
[stdout]
repo:
  name: gh-axi
  description: fake gh repo view for kunchenguid/gh-axi
  branch: main
  stars: 12
  forks: 3
  issues: 4
  prs: 5
  visibility: public
  language: TypeScript

## reject positional plus --repo conflict
$ ./node_modules/.bin/tsx bin/gh-axi.ts repo view minekube/agent-os --repo kunchenguid/gh-axi
[exit 2]
[stdout]
error: "Unsupported positional argument for repo view with --repo: minekube/agent-os. Use --repo <owner/name> to select a repository."
code: VALIDATION_ERROR

## reject extra positional
$ ./node_modules/.bin/tsx bin/gh-axi.ts repo view minekube/agent-os extra
[exit 2]
[stdout]
error: "Unsupported positional argument for repo view: extra. Use --repo <owner/name> to select a repository."
code: VALIDATION_ERROR

## fake gh argv observed
repo view minekube/agent-os --json name,description,defaultBranchRef,stargazerCount,forkCount,issues,pullRequests,visibility,primaryLanguage
repo view kunchenguid/gh-axi --json name,description,defaultBranchRef,stargazerCount,forkCount,issues,pullRequests,visibility,primaryLanguage
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git status --short --branch`
- `git diff --stat 2236646523af56d938b7a1fa1cb5b499aff33e57..0af5d455d5afb1f420fbc350f40a689c977a3bf6`
- `git diff --name-only 2236646523af56d938b7a1fa1cb5b499aff33e57..0af5d455d5afb1f420fbc350f40a689c977a3bf6`
- `pnpm exec vitest run test/commands/repo.test.ts test/cli.test.ts`
- <code>Created a fake `gh` in `/var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KWZ99RGWSRGXJ6QZ6JP0RQ6A` and ran `./node_modules/.bin/tsx bin/gh-axi.ts repo view minekube/agent-os`, `./node_modules/.bin/tsx bin/gh-axi.ts repo view --repo kunchenguid/gh-axi`, `./node_modules/.bin/tsx bin/gh-axi.ts repo view minekube/agent-os --repo kunchenguid/gh-axi`, and `./node_modules/.bin/tsx bin/gh-axi.ts repo view minekube/agent-os extra` with that fake `gh` first on `PATH`</code>
- `pnpm exec vitest run test/skill.test.ts test/suggestions.test.ts`
- `pnpm run build:skill && git diff --exit-code -- skills/gh-axi/SKILL.md src/skill.ts`
- `rm -rf node_modules && git status --short --ignored`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
