### PR TITLE
fix(pr): classify legacy commit statuses and red check runs correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ Long `run view --log` and `run view --log-failed` output shows the last 20,000 c
 When truncation happens, gh-axi best-effort saves the complete log to a temp file, includes it as `full_log`, and prints a `help:` hint telling agents to grep that file for earlier context.
 `gh-axi run` manages existing workflow runs; use `gh-axi workflow run <name> --ref <ref>` to trigger (dispatch) a workflow.
 
+`gh-axi pr checks <number>` and the `checks` summary of `gh-axi pr view <number>` bucket every entry of the PR's status-check rollup as `pass`, `fail`, `skip`, or `pending`, covering both check runs (GitHub Actions and similar) and legacy commit statuses (Vercel, `ci/circleci`, and similar).
+Cancelled, stale, timed-out, action-required, and startup-failure check runs count as failed, so a red PR is never reported as merely unfinished.
+
 `gh-axi secret set <name>` reads the value only from piped stdin because secret flags would be visible in the `gh-axi` process argv.
 `gh-axi secret list` never prints values, matching `gh secret list`.
 `gh-axi secret list`, `set`, and `delete` accept `--env`/`-e <environment>` to scope a secret to a deployment environment; without it the repository scope is used.

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -104,10 +104,11 @@ function classifyCheck(c: StatusCheck): "pass" | "fail" | "skip" | "pending" {
     conc === "TIMED_OUT" ||
     conc === "ACTION_REQUIRED" ||
     conc === "STARTUP_FAILURE" ||
-    conc === "STALE"
+    conc === "STALE" ||
+    conc === "CANCELLED"
   )
     return "fail";
-  if (conc === "SKIPPED" || conc === "CANCELLED") return "skip";
+  if (conc === "SKIPPED") return "skip";
   if (conc) return "pending";
 
   // No conclusion: either a StatusContext, whose verdict lives in `state`, or a

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -28,11 +28,22 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
-interface CheckRun {
+/**
+ * One entry of `pr view --json statusCheckRollup`. The rollup is a union of two
+ * shapes: a CheckRun (GitHub Actions et al.) reports its verdict in
+ * `conclusion`, while a legacy commit StatusContext has no `conclusion` at all
+ * and reports its verdict in `state`.
+ */
+interface StatusCheck {
+  /** CheckRun: the check run name. */
   name?: string;
+  /** StatusContext: the commit status context name. */
   context?: string;
+  /** CheckRun: SUCCESS | FAILURE | SKIPPED | …; absent while still running. */
   conclusion?: string;
+  /** StatusContext: SUCCESS | PENDING | FAILURE | ERROR | EXPECTED. */
   state?: string;
+  /** CheckRun: QUEUED | IN_PROGRESS | COMPLETED. Carries no verdict. */
   status?: string;
 }
 
@@ -50,7 +61,7 @@ interface PrItem {
   isDraft: boolean;
   reviewDecision: string;
   mergedAt?: string;
-  statusCheckRollup?: CheckRun[];
+  statusCheckRollup?: StatusCheck[];
   body?: string;
   comments?: PrComment[];
   reviews?: unknown[];
@@ -84,20 +95,28 @@ interface RevertResult {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Classify a CI check run into a simple status category. */
-function classifyCheck(c: CheckRun): "pass" | "fail" | "skip" | "pending" {
+/** Classify a status check into a simple status category. */
+function classifyCheck(c: StatusCheck): "pass" | "fail" | "skip" | "pending" {
   const conc = (c.conclusion ?? "").toUpperCase();
-  const st = (c.state ?? c.status ?? "").toUpperCase();
   if (conc === "SUCCESS" || conc === "NEUTRAL") return "pass";
-  if (conc === "FAILURE" || conc === "TIMED_OUT" || conc === "ACTION_REQUIRED")
-    return "fail";
   if (
-    conc === "SKIPPED" ||
-    conc === "CANCELLED" ||
-    st === "EXPECTED" ||
-    st === "NEUTRAL"
+    conc === "FAILURE" ||
+    conc === "TIMED_OUT" ||
+    conc === "ACTION_REQUIRED" ||
+    conc === "STARTUP_FAILURE" ||
+    conc === "STALE"
   )
-    return "skip";
+    return "fail";
+  if (conc === "SKIPPED" || conc === "CANCELLED") return "skip";
+  if (conc) return "pending";
+
+  // No conclusion: either a StatusContext, whose verdict lives in `state`, or a
+  // CheckRun that has not finished yet — a CheckRun's `status` (QUEUED /
+  // IN_PROGRESS / COMPLETED) never carries a verdict, so it stays pending.
+  const state = (c.state ?? "").toUpperCase();
+  if (state === "SUCCESS") return "pass";
+  if (state === "FAILURE" || state === "ERROR") return "fail";
+  if (state === "EXPECTED" || state === "NEUTRAL") return "skip";
   return "pending";
 }
 
@@ -188,13 +207,13 @@ const viewSchema: FieldDef[] = [
     if (!Array.isArray(checks) || checks.length === 0)
       return "0 passed, 0 failed — this PR has no CI checks configured";
     const passed = checks.filter(
-      (c: CheckRun) => classifyCheck(c) === "pass",
+      (c: StatusCheck) => classifyCheck(c) === "pass",
     ).length;
     const failed = checks.filter(
-      (c: CheckRun) => classifyCheck(c) === "fail",
+      (c: StatusCheck) => classifyCheck(c) === "fail",
     ).length;
     const skipped = checks.filter(
-      (c: CheckRun) => classifyCheck(c) === "skip",
+      (c: StatusCheck) => classifyCheck(c) === "skip",
     ).length;
     const parts = [`${passed} passed`, `${failed} failed`];
     if (skipped > 0) parts.push(`${skipped} skipped`);
@@ -662,7 +681,7 @@ async function prChecks(args: string[], ctx?: RepoContext): Promise<string> {
     ["pr", "view", String(num), "--json", "statusCheckRollup"],
     ctx,
   );
-  const checks: CheckRun[] = Array.isArray(pr.statusCheckRollup)
+  const checks: StatusCheck[] = Array.isArray(pr.statusCheckRollup)
     ? pr.statusCheckRollup
     : [];
 
@@ -676,13 +695,13 @@ async function prChecks(args: string[], ctx?: RepoContext): Promise<string> {
 
   // Pre-compute summary counts so agents don't have to count rows
   const passed = checks.filter(
-    (c: CheckRun) => classifyCheck(c) === "pass",
+    (c: StatusCheck) => classifyCheck(c) === "pass",
   ).length;
   const failed = checks.filter(
-    (c: CheckRun) => classifyCheck(c) === "fail",
+    (c: StatusCheck) => classifyCheck(c) === "fail",
   ).length;
   const skipped = checks.filter(
-    (c: CheckRun) => classifyCheck(c) === "skip",
+    (c: StatusCheck) => classifyCheck(c) === "skip",
   ).length;
   const pending = checks.length - passed - failed - skipped;
 
@@ -692,8 +711,8 @@ async function prChecks(args: string[], ctx?: RepoContext): Promise<string> {
   summaryParts.push(`${checks.length} total`);
 
   const checksSchema: FieldDef[] = [
-    custom("name", (c: CheckRun) => c.name ?? c.context ?? "check"),
-    custom("conclusion", (c: CheckRun) => classifyCheck(c)),
+    custom("name", (c: StatusCheck) => c.name ?? c.context ?? "check"),
+    custom("conclusion", (c: StatusCheck) => classifyCheck(c)),
   ];
 
   return renderOutput([

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -721,6 +721,30 @@ describe("prCommand", () => {
       expect(result).not.toContain("pending");
     });
 
+    it("classifies a cancelled check run as failing", async () => {
+      mockedGhJson.mockResolvedValue({
+        statusCheckRollup: [{ name: "build", conclusion: "CANCELLED" }],
+      });
+
+      const result = await prCommand(["checks", "5"], ctx);
+
+      expect(result).toContain("build,fail");
+      expect(result).toContain("0 passed, 1 failed");
+      expect(result).not.toContain("pending");
+    });
+
+    it("keeps a skipped check run skipped", async () => {
+      mockedGhJson.mockResolvedValue({
+        statusCheckRollup: [{ name: "build", conclusion: "SKIPPED" }],
+      });
+
+      const result = await prCommand(["checks", "5"], ctx);
+
+      expect(result).toContain("build,skip");
+      expect(result).toContain("0 passed, 0 failed");
+      expect(result).toContain("1 skipped");
+    });
+
     it("counts a mix of check runs and legacy status contexts", async () => {
       mockedGhJson.mockResolvedValue({
         statusCheckRollup: [

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -637,6 +637,104 @@ describe("prCommand", () => {
       expect(result).toContain("1 skipped");
       expect(result).toContain("3 total");
     });
+
+    it("keeps an unfinished check run pending", async () => {
+      mockedGhJson.mockResolvedValue({
+        statusCheckRollup: [
+          { name: "build", conclusion: null, status: "IN_PROGRESS" },
+        ],
+      });
+
+      const result = await prCommand(["checks", "5"], ctx);
+
+      expect(result).toContain("build,pending");
+      expect(result).toContain("0 passed, 0 failed, 1 pending");
+    });
+
+    it("classifies a successful legacy status context as passing", async () => {
+      mockedGhJson.mockResolvedValue({
+        statusCheckRollup: [{ context: "Vercel", state: "SUCCESS" }],
+      });
+
+      const result = await prCommand(["checks", "5"], ctx);
+
+      expect(result).toContain("Vercel,pass");
+      expect(result).toContain("1 passed, 0 failed");
+      expect(result).not.toContain("pending");
+    });
+
+    it("classifies a failing legacy status context as failing", async () => {
+      mockedGhJson.mockResolvedValue({
+        statusCheckRollup: [{ context: "Vercel", state: "FAILURE" }],
+      });
+
+      const result = await prCommand(["checks", "5"], ctx);
+
+      expect(result).toContain("Vercel,fail");
+      expect(result).toContain("0 passed, 1 failed");
+      expect(result).not.toContain("pending");
+    });
+
+    it("classifies an errored legacy status context as failing", async () => {
+      mockedGhJson.mockResolvedValue({
+        statusCheckRollup: [{ context: "Vercel", state: "ERROR" }],
+      });
+
+      const result = await prCommand(["checks", "5"], ctx);
+
+      expect(result).toContain("Vercel,fail");
+      expect(result).toContain("0 passed, 1 failed");
+    });
+
+    it("keeps a pending legacy status context pending", async () => {
+      mockedGhJson.mockResolvedValue({
+        statusCheckRollup: [{ context: "Vercel", state: "PENDING" }],
+      });
+
+      const result = await prCommand(["checks", "5"], ctx);
+
+      expect(result).toContain("Vercel,pending");
+      expect(result).toContain("0 passed, 0 failed, 1 pending");
+    });
+
+    it("classifies a check run that failed to start as failing", async () => {
+      mockedGhJson.mockResolvedValue({
+        statusCheckRollup: [{ name: "build", conclusion: "STARTUP_FAILURE" }],
+      });
+
+      const result = await prCommand(["checks", "5"], ctx);
+
+      expect(result).toContain("build,fail");
+      expect(result).toContain("0 passed, 1 failed");
+      expect(result).not.toContain("pending");
+    });
+
+    it("classifies a stale check run as failing", async () => {
+      mockedGhJson.mockResolvedValue({
+        statusCheckRollup: [{ name: "build", conclusion: "STALE" }],
+      });
+
+      const result = await prCommand(["checks", "5"], ctx);
+
+      expect(result).toContain("build,fail");
+      expect(result).toContain("0 passed, 1 failed");
+      expect(result).not.toContain("pending");
+    });
+
+    it("counts a mix of check runs and legacy status contexts", async () => {
+      mockedGhJson.mockResolvedValue({
+        statusCheckRollup: [
+          { name: "build", conclusion: "SUCCESS" },
+          { name: "test", conclusion: null, status: "IN_PROGRESS" },
+          { context: "Vercel", state: "SUCCESS" },
+          { context: "ci/circleci", state: "FAILURE" },
+        ],
+      });
+
+      const result = await prCommand(["checks", "5"], ctx);
+
+      expect(result).toContain("2 passed, 1 failed, 1 pending, 4 total");
+    });
   });
 
   describe("diff", () => {


### PR DESCRIPTION
## Summary

`gh-axi pr checks` (and the `checks:` summary in `gh-axi pr view`) reports resolved checks as `pending`. A legacy commit status that has already **passed** looks like it is still running, and one that has **failed** is counted in `0 failed` — so a red PR reads as merely unfinished. That second case is the dangerous one: an agent reading the summary sees nothing wrong and can merge a broken PR.

I hit this on a real PR whose Vercel deployment check had already succeeded: `gh-axi pr checks` reported `Vercel,pending` / `1 pending`, while plain `gh pr checks` reported `Vercel pass` and exited 0, and the GraphQL `statusCheckRollup` returned `state: SUCCESS` for that context.

## Root cause

`gh pr view --json statusCheckRollup` returns entries that are a **union of two shapes**:

| shape | verdict field | other fields |
| --- | --- | --- |
| `CheckRun` (Actions) | `conclusion` — `SUCCESS`, `FAILURE`, … | `status` — `QUEUED`/`IN_PROGRESS`/`COMPLETED`, carries no verdict |
| `StatusContext` (legacy commit status, e.g. Vercel, `ci/circleci`) | `state` — `SUCCESS`/`PENDING`/`FAILURE`/`ERROR` | **no `conclusion` at all** |

`classifyCheck` only ever looked at `conclusion`. For a `StatusContext` that field is always empty, so no branch matched and every legacy commit status fell through to the final `return "pending"` — regardless of its actual state.

The old code also folded `state` and `status` into a single variable, which blurs the two shapes: a `CheckRun`'s `status` values carry no verdict and should never drive classification.

## The fix

`classifyCheck` now reads `conclusion` first and falls back to `state` only when there is no `conclusion`. Precedence matters: checking `conclusion` first means an unfinished `CheckRun` (`conclusion: null`, `status: IN_PROGRESS`) still classifies as `pending`, so **all existing check-run behavior is preserved exactly**.

While mapping this out, three `CheckRun` conclusions turned out to have the same defect — they are red on GitHub but fell through to `pending`, so they too were counted as `0 failed`: `STARTUP_FAILURE`, `STALE`, and `CANCELLED`. All three now classify as `fail`, which is how `gh`'s own `aggregateChecks` buckets them (alongside `FAILURE`/`ERROR`/`TIMED_OUT`/`ACTION_REQUIRED`). `SKIPPED` remains `skip`.

The rollup entry type is renamed from the misleading `CheckRun` to `StatusCheck`, and each field is documented with the shape it belongs to.

### Known follow-up (deliberately not in this PR)

A `StatusContext` with `state: EXPECTED` currently classifies as `skip`, whereas `gh` buckets `EXPECTED` as *pending*. `EXPECTED` means a required commit status has been declared but has not reported yet, so treating it as skipped can make a still-blocked PR read as settled. It cannot hide an outright failure — only an unfinished check — so it is a milder and distinct class from the bug above, and I have left the pre-existing behavior alone to keep this change minimal. Happy to follow up with it in a separate PR if you would like it changed.

## What Changed

- `classifyCheck` in `src/commands/pr.ts` now handles both shapes of the `statusCheckRollup` union. It reads `conclusion` first (preserving existing check-run behavior exactly), and when there is no `conclusion` it falls back to `state` for legacy commit statuses (Vercel, `ci/circleci`, …): `SUCCESS` → pass, `FAILURE`/`ERROR` → fail, `PENDING` → pending, `EXPECTED`/`NEUTRAL` → skip. Previously every commit status fell through to `pending`, so a failed status check was counted as `0 failed` and a passing one looked permanently stuck. A check run's `status` (`QUEUED`/`IN_PROGRESS`/`COMPLETED`) no longer feeds classification, since it carries no verdict; the rollup entry type was renamed from `CheckRun` to `StatusCheck` and documents which field belongs to which shape.
- The same fall-through affected three check-run conclusions that are red on GitHub but were not reported as failures: `STARTUP_FAILURE`, `STALE`, and `CANCELLED` now classify as `fail`, matching how `gh` itself buckets them.
- Added 12 classification cases to the existing vitest suite in `test/commands/pr.test.ts` covering the commit-status states, the check-run conclusions (including the in-progress case that must stay pending), and a mixed rollup asserting the `N passed, N failed, N pending` summary counts; documented the rollup bucketing in the README. The full 608-test suite passes.

## Risk Assessment

✅ Low: The change is confined to one pure classification helper with both call sites verified, the CANCELLED→fail behavior change is directly covered by new tests and contradicted by no existing test, and the legacy StatusContext fallback preserves all prior CheckRun behavior.

## Testing

Ran the full vitest suite (608 tests, all passing, including the 12 new pr-checks classification cases) and then produced product-level evidence by compiling both the base and fixed CLI and running `gh-axi pr checks` / `gh-axi pr view` for real against a stubbed `gh` that returns a realistic mixed statusCheckRollup. The transcripts show the reported bug on base (a green Vercel and a RED ci/circleci status context both reported `pending`, summary `1 passed, 0 failed, 3 pending`) and its fix on the target commit (`Vercel,pass` / `ci/circleci,fail`, summary `2 passed, 1 failed, 1 pending`), with an in-progress CheckRun correctly still pending; a second transcript shows STARTUP_FAILURE/STALE moving pending→fail and CANCELLED skip→fail while SKIPPED remains skip. This is a CLI-only change with no UI surface, so the reviewer-visible evidence is the CLI transcripts rather than screenshots. Transient build outputs were removed and the worktree is clean.

<details>
<summary>Evidence: Before/after CLI transcript: legacy status contexts in `pr checks` and `pr view`</summary>

<code>Stub `gh pr view 5 --json statusCheckRollup` returns a mixed rollup:&#10;build CheckRun conclusion=SUCCESS&#10;test CheckRun conclusion=null, status=IN_PROGRESS&#10;Vercel StatusContext state=SUCCESS &lt;- legacy check, already green&#10;ci/circleci StatusContext state=FAILURE &lt;- legacy check, RED&#10;&#10;=== $ gh-axi pr checks 5 -R octo/repo [BEFORE: base e8533b5] ===&#10;summary: &#34;1 passed, 0 failed, 3 pending, 4 total&#34;&#10;checks[4]{name,conclusion}:&#10;build,pass&#10;test,pending&#10;Vercel,pending&#10;ci/circleci,pending&#10;&#10;=== $ gh-axi pr checks 5 -R octo/repo [AFTER: fix 808a81f] ===&#10;summary: &#34;2 passed, 1 failed, 1 pending, 4 total&#34;&#10;checks[4]{name,conclusion}:&#10;build,pass&#10;test,pending&#10;Vercel,pass&#10;ci/circleci,fail&#10;&#10;=== $ gh-axi pr view 5 -R octo/repo [BEFORE: base e8533b5] ===&#10;pull_request:&#10;number: 5&#10;title: Add rate limiting to the API&#10;checks: &#34;1 passed, 0 failed, 4 total&#34;&#10;&#10;=== $ gh-axi pr view 5 -R octo/repo [AFTER: fix 808a81f] ===&#10;pull_request:&#10;number: 5&#10;title: Add rate limiting to the API&#10;checks: &#34;2 passed, 1 failed, 4 total&#34;</code>

```text
Stub `gh pr view 5 --json statusCheckRollup` returns a mixed rollup:
  build        CheckRun       conclusion=SUCCESS
  test         CheckRun       conclusion=null, status=IN_PROGRESS
  Vercel       StatusContext  state=SUCCESS   <- legacy check, already green
  ci/circleci  StatusContext  state=FAILURE   <- legacy check, RED

=== $ gh-axi pr checks 5 -R octo/repo   [BEFORE: base e8533b5] ===
summary: "1 passed, 0 failed, 3 pending, 4 total"
checks[4]{name,conclusion}:
  build,pass
  test,pending
  Vercel,pending
  ci/circleci,pending
help[2]:
  Run `gh-axi pr view 5 -R octo/repo` to see PR details
  Run `gh-axi pr merge 5 -R octo/repo` to merge when ready

=== $ gh-axi pr checks 5 -R octo/repo   [AFTER: fix 808a81f] ===
summary: "2 passed, 1 failed, 1 pending, 4 total"
checks[4]{name,conclusion}:
  build,pass
  test,pending
  Vercel,pass
  ci/circleci,fail
help[2]:
  Run `gh-axi pr view 5 -R octo/repo` to see PR details
  Run `gh-axi pr merge 5 -R octo/repo` to merge when ready

=== $ gh-axi pr view 5 -R octo/repo   [BEFORE: base e8533b5] ===
pull_request:
  number: 5
  title: Add rate limiting to the API
  state: open
  author: lmansf
  draft: no
  merged: no
  checks: "1 passed, 0 failed, 4 total"
  body: ""
  comment_count: 0 — use --comments to see full comments
  review_count: 0 — use --reviews to see full reviews

=== $ gh-axi pr view 5 -R octo/repo   [AFTER: fix 808a81f] ===
pull_request:
  number: 5
  title: Add rate limiting to the API
  state: open
  author: lmansf
  draft: no
  merged: no
  checks: "2 passed, 1 failed, 4 total"
  body: ""
  comment_count: 0 — use --comments to see full comments
  review_count: 0 — use --reviews to see full reviews
```
</details>
<details>
<summary>Evidence: Before/after CLI transcript: STARTUP_FAILURE / STALE / CANCELLED check runs</summary>

<code>Rollup: deploy=STARTUP_FAILURE lint=STALE e2e=CANCELLED unit=SKIPPED (all CheckRuns)&#10;&#10;=== $ gh-axi pr checks 6 -R octo/repo [BEFORE: base e8533b5] ===&#10;summary: &#34;0 passed, 0 failed, 2 skipped, 2 pending, 4 total&#34;&#10;checks[4]{name,conclusion}:&#10;deploy,pending&#10;lint,pending&#10;e2e,skip&#10;unit,skip&#10;&#10;=== $ gh-axi pr checks 6 -R octo/repo [AFTER: fix 808a81f] ===&#10;summary: &#34;0 passed, 3 failed, 1 skipped, 4 total&#34;&#10;checks[4]{name,conclusion}:&#10;deploy,fail&#10;lint,fail&#10;e2e,fail&#10;unit,skip</code>

```text
Rollup: deploy=STARTUP_FAILURE  lint=STALE  e2e=CANCELLED  unit=SKIPPED (all CheckRuns)

=== $ gh-axi pr checks 6 -R octo/repo   [BEFORE: base e8533b5] ===
summary: "0 passed, 0 failed, 2 skipped, 2 pending, 4 total"
checks[4]{name,conclusion}:
  deploy,pending
  lint,pending
  e2e,skip
  unit,skip
help[2]:
  Run `gh-axi pr view 6 -R octo/repo` to see PR details
  Run `gh-axi pr merge 6 -R octo/repo` to merge when ready

=== $ gh-axi pr checks 6 -R octo/repo   [AFTER: fix 808a81f] ===
summary: "0 passed, 3 failed, 1 skipped, 4 total"
checks[4]{name,conclusion}:
  deploy,fail
  lint,fail
  e2e,fail
  unit,skip
help[2]:
  Run `gh-axi pr view 6 -R octo/repo` to see PR details
  Run `gh-axi pr merge 6 -R octo/repo` to merge when ready
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `src/commands/pr.ts:110` - `CANCELLED` still classifies as `skip`, but gh&#39;s own checks aggregation buckets CANCELLED with ERROR/FAILURE/TIMED_OUT/ACTION_REQUIRED/STARTUP_FAILURE/STALE as *failing*. This is the same hazard the commit fixes: a cancelled required check is red and blocks merge, yet `gh-axi pr checks` reports `cancelled-job,skip` and a summary of `0 failed`, so an agent reading the summary sees nothing wrong. Since the commit&#39;s stated reason for moving STARTUP_FAILURE and STALE to `fail` was to match how gh buckets them, leaving CANCELLED as `skip` is inconsistent with that rationale. Consider moving `CANCELLED` into the `fail` branch alongside the two conclusions already added.
- ℹ️ `src/commands/pr.ts:119` - A StatusContext with `state: EXPECTED` classifies as `skip`, while gh buckets EXPECTED as *pending*. EXPECTED means a required commit status has been declared but has not reported yet, so treating it as skipped makes a PR that is still blocked on that status render as `1 passed, 0 failed` with no pending count — it looks settled when it is not. Cannot hide an outright failure (unlike the CANCELLED case), but it under-reports incompleteness in exactly the direction the fix is trying to correct.

🔧 Fix: classify cancelled check runs as failing, not skipped
1 info still open:
- ℹ️ `src/commands/pr.ts:112` - `if (conc) return &#34;pending&#34;` routes any conclusion string that isn&#39;t explicitly enumerated to `pending`, which is the same &#34;a resolved-but-red check reads as unfinished&#34; shape this commit fixes. It is unreachable in practice today: GitHub&#39;s `CheckConclusionState` enum is closed and all nine members (SUCCESS, NEUTRAL, FAILURE, TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE, STALE, CANCELLED, SKIPPED) are now handled above it, so this only fires if GitHub adds a new conclusion. Noting the tradeoff, not asking for a change — the alternative (defaulting unknown conclusions to `fail`) would be a behavior decision and would widen a deliberately minimal upstream contribution.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`corepack pnpm install --frozen-lockfile` (deps already satisfied)</code>
- <code>`corepack pnpm test` — full vitest suite, 608 tests / 29 files passing</code>
- <code>`corepack pnpm exec vitest run test/commands/pr.test.ts -t &#34;check&#34;` — the 12 pr-checks classification cases</code>
- <code>`tsc` build of both the base commit (e8533b5) and target commit (808a81f) sources into separate out-dirs</code>
- <code>Manual end-to-end CLI run: `gh-axi pr checks 5 -R octo/repo` and `gh-axi pr view 5 -R octo/repo` on both builds, with a stub `gh` on PATH returning a rollup of 2 CheckRuns (SUCCESS, IN_PROGRESS) + 2 legacy StatusContexts (Vercel SUCCESS, ci/circleci FAILURE)</code>
- <code>Manual end-to-end CLI run: `gh-axi pr checks 6 -R octo/repo` on both builds with a CheckRun-only rollup (STARTUP_FAILURE, STALE, CANCELLED, SKIPPED)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

