### PR TITLE
fix(setup): install portable session hooks

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,5 +1,15 @@
-import { AxiError, installSessionStartHooks } from "axi-sdk-js";
+import { accessSync, constants, realpathSync, statSync } from "node:fs";
+import { delimiter, join } from "node:path";
+import {
+  AxiError,
+  installSessionStartHooks,
+  resolvePortableHookCommand,
+  type PortableHookCommandContext,
+} from "axi-sdk-js";
 import { renderHelp, renderOutput } from "../toon.js";
+
+const HOOK_MARKER = "gh-axi";
+const BINARY_NAME = "gh-axi";
 
 export const SETUP_HELP = `usage: gh-axi setup hooks
 Install or repair agent SessionStart hooks for gh-axi ambient context.
@@ -15,7 +25,33 @@ export async function setupCommand(args: string[]): Promise<string> {
     ]);
   }
 
-  installSessionStartHooks();
+  const { execPath, context } = resolveHookLauncher();
+  const hookCommand = resolvePortableHookCommand(
+    execPath,
+    [BINARY_NAME],
+    HOOK_MARKER,
+    context,
+  );
+  if (hookCommand !== BINARY_NAME) {
+    throw new AxiError(
+      "Could not resolve a portable gh-axi hook command",
+      "VALIDATION_ERROR",
+      ["Install gh-axi globally and ensure it is on PATH"],
+    );
+  }
+
+  const errors: string[] = [];
+  installSessionStartHooks({
+    marker: HOOK_MARKER,
+    execPath,
+    binaryNames: [BINARY_NAME],
+    shouldInstall: () => true,
+    onError: (message) => errors.push(message),
+  });
+
+  if (errors.length > 0) {
+    throw new AxiError("Hook setup was incomplete", "UNKNOWN", errors);
+  }
 
   return renderOutput([
     "hooks:\n  status: installed\n  integrations: Claude Code, Codex, OpenCode",
@@ -23,4 +59,50 @@ export async function setupCommand(args: string[]): Promise<string> {
       "Restart your agent session to receive gh-axi ambient context",
     ]),
   ]);
+}
+
+function resolveHookLauncher(): {
+  execPath: string;
+  context: PortableHookCommandContext;
+} {
+  const rawPath = process.env.PATH ?? process.env.Path ?? "";
+  const pathEntries = rawPath.split(delimiter).filter(Boolean);
+  const pathExtensions =
+    process.platform === "win32"
+      ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";")
+      : [""];
+  const context: PortableHookCommandContext = {
+    pathEntries,
+    pathExtensions,
+    resolveRealPath: (path) => {
+      try {
+        if (!statSync(path).isFile()) {
+          return undefined;
+        }
+        return realpathSync(path);
+      } catch {
+        return undefined;
+      }
+    },
+  };
+
+  for (const directory of pathEntries) {
+    for (const extension of pathExtensions) {
+      const candidate = join(directory, `${BINARY_NAME}${extension}`);
+      try {
+        accessSync(candidate, constants.X_OK);
+      } catch {
+        continue;
+      }
+      if (context.resolveRealPath(candidate)) {
+        return { execPath: candidate, context };
+      }
+    }
+  }
+
+  throw new AxiError(
+    "Could not find an installed gh-axi executable on PATH",
+    "VALIDATION_ERROR",
+    ["Run `npm install -g gh-axi`, then retry `gh-axi setup hooks`"],
+  );
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,8 +1,7 @@
 import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { installSessionStartHooks, runAxiCli } = vi.hoisted(() => ({
-  installSessionStartHooks: vi.fn(),
+const { runAxiCli } = vi.hoisted(() => ({
   runAxiCli: vi.fn(),
 }));
 
@@ -11,7 +10,6 @@ vi.mock("axi-sdk-js", async () => {
     await vi.importActual<typeof import("axi-sdk-js")>("axi-sdk-js");
   return {
     ...actual,
-    installSessionStartHooks,
     runAxiCli,
   };
 });
@@ -177,19 +175,6 @@ describe("main CLI", () => {
     }
 
     expect(vi.mocked(runAxiCli).mock.calls[0]?.[0]).not.toHaveProperty("hooks");
-  });
-
-  it("installs session hooks from the explicit setup command", async () => {
-    await main();
-
-    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
-    const output = await options.commands.setup(["hooks"]);
-
-    expect(installSessionStartHooks).toHaveBeenCalledTimes(1);
-    expect(installSessionStartHooks).toHaveBeenCalledWith();
-    expect(output).toContain("hooks:");
-    expect(output).toContain("status: installed");
-    expect(output).toContain("Restart your agent session");
   });
 
   it("wires command help into the runtime", async () => {

--- a/test/commands/setup.test.ts
+++ b/test/commands/setup.test.ts
@@ -1,0 +1,128 @@
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const projectRoot = fileURLToPath(new URL("../..", import.meta.url));
+const sourceEntrypoint = join(projectRoot, "bin", "gh-axi.ts");
+const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
+
+let home: string | undefined;
+
+afterEach(() => {
+  if (home) {
+    rmSync(home, { recursive: true, force: true });
+    home = undefined;
+  }
+});
+
+describe("setup hooks", () => {
+  it("installs runnable, portable, idempotent hooks from the source entrypoint", () => {
+    home = mkdtempSync(join(tmpdir(), "gh-axi hooks-"));
+    const binDir = join(home, "bin");
+    createLauncher(binDir);
+    const env = {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+    };
+    const runSetup = () =>
+      execFileSync(
+        process.execPath,
+        [tsxCli, sourceEntrypoint, "setup", "hooks"],
+        { cwd: projectRoot, encoding: "utf8", env },
+      );
+
+    expect(runSetup()).toContain("status: installed");
+
+    const claudeSettingsPath = join(home, ".claude", "settings.json");
+    const codexHooksPath = join(home, ".codex", "hooks.json");
+    const codexConfigPath = join(home, ".codex", "config.toml");
+    const openCodePluginPath = join(
+      home,
+      ".config",
+      "opencode",
+      "plugins",
+      "axi-gh-axi.js",
+    );
+    const claudeSettings = JSON.parse(
+      readFileSync(claudeSettingsPath, "utf8"),
+    ) as {
+      hooks: {
+        SessionStart: Array<{
+          hooks: Array<{ command: string }>;
+        }>;
+      };
+    };
+    const command = claudeSettings.hooks.SessionStart[0]?.hooks[0]?.command;
+
+    expect(command).toBe("gh-axi");
+    expect(readFileSync(openCodePluginPath, "utf8")).toContain(
+      'const command = "gh-axi";',
+    );
+    expect(runHookCommand(env)).toMatch(/^\d+\.\d+\.\d+\n$/);
+
+    const installedFiles = [
+      claudeSettingsPath,
+      codexHooksPath,
+      codexConfigPath,
+      openCodePluginPath,
+    ];
+    const firstInstallation = installedFiles.map((path) =>
+      readFileSync(path, "utf8"),
+    );
+
+    expect(runSetup()).toContain("status: installed");
+    expect(installedFiles.map((path) => readFileSync(path, "utf8"))).toEqual(
+      firstInstallation,
+    );
+  });
+});
+
+function createLauncher(binDir: string): string {
+  mkdirSync(binDir, { recursive: true });
+
+  if (process.platform === "win32") {
+    const launcher = join(binDir, "gh-axi.cmd");
+    writeFileSync(
+      launcher,
+      `@echo off\r\n"${process.execPath}" "${tsxCli}" "${sourceEntrypoint}" %*\r\n`,
+      "utf8",
+    );
+    return launcher;
+  }
+
+  const launcher = join(binDir, "gh-axi");
+  writeFileSync(
+    launcher,
+    `#!/bin/sh\nexec ${shellQuote(process.execPath)} ${shellQuote(tsxCli)} ${shellQuote(sourceEntrypoint)} "$@"\n`,
+    "utf8",
+  );
+  chmodSync(launcher, 0o755);
+  return launcher;
+}
+
+function runHookCommand(env: NodeJS.ProcessEnv): string {
+  if (process.platform === "win32") {
+    return execFileSync("cmd.exe", ["/d", "/s", "/c", "gh-axi --version"], {
+      encoding: "utf8",
+      env,
+    });
+  }
+  return execFileSync("gh-axi", ["--version"], { encoding: "utf8", env });
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}


### PR DESCRIPTION
`pnpm dev setup hooks` no longer reports success while installing nothing. Setup now resolves the globally installed launcher from `PATH`, verifies the SDK will persist the portable `gh-axi` command (including Windows npm shims), and surfaces partial write failures instead of claiming success.

Regression coverage uses home and launcher paths containing spaces, checks the Claude Code, Codex, and OpenCode integrations, executes the installed command, and reruns setup to prove idempotence.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenAI Codex](https://img.shields.io/badge/OpenAI_Codex-000000)
