### PR TITLE
fix(commands): apply every repeated label, assignee, reviewer and project flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,14 @@ Instead, `resolveOwner()` defaults `--owner` to the current repo's owner (`ctx?.
 Since Projects v2 items carry per-project custom fields (Status, Priority, ...) with no fixed schema, `item-list`/`field-list` render through bespoke functions (`renderProjectItems`/`renderProjectFields`) that flatten any unknown scalar top-level key into its own column, rather than a fixed `FieldDef` schema.
 Requires the `project` (or `read:project`) OAuth scope on the `gh` token; `src/errors.ts` matches gh's literal `"authentication token is missing required scopes [...]"` stderr (verified against a live token missing the scope) and maps it to `FORBIDDEN` with a `gh auth refresh -s <scope>` suggestion — this pattern is generic, not project-specific, so it also covers other gh features gated by OAuth scopes.
 
+## Repeatable flags (`src/args.ts`)
+
+`gh` accepts `--label`, `--assignee`, `--reviewer`, `--project`, and the `--add-*`/`--remove-*` variants once per value, so gh-axi must collect _every_ occurrence.
+Use `getAllFlags`/`takeAllFlags` plus `pushRepeated`; `getFlag`/`takeFlag` keep only the first occurrence and silently discard the rest, which is the bug that recurred as #55, #57, and #75.
+Both collectors reject a dangling (`--label` with nothing after it) or blank (`--label=`) value with a `VALIDATION_ERROR` instead of dropping it.
+Pick the collector that matches the surrounding file: `issue.ts` reads args non-destructively (`getAllFlags`), `pr.ts` consumes them (`takeAllFlags`).
+When a flag becomes repeatable, mark it `(repeatable)` in that command's `*_HELP` string.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ gh-axi                          # dashboard - live state, no args needed
 gh-axi issue list               # list issues in current repo
 gh-axi issue subissue list 16   # list sub-issues for issue #16
 gh-axi pr view 42               # view pull request #42
+gh-axi issue edit 42 --add-label bug --add-label chore  # repeat a flag per value
 gh-axi run list -R owner/repo   # list workflow runs for a specific repo
 gh-axi issue list --hostname git.example.com  # target a GitHub Enterprise host
 gh-axi run view 123456 --job 789012       # inspect a single job within a run
@@ -102,6 +103,10 @@ gh-axi update                   # upgrade a global install
 For multi-line issue, PR, review, or comment text, write Markdown to a UTF-8 file and pass `--body-file <path>` on the relevant command.
 For releases, `--body` and `--body-file` are aliases for release notes, alongside `--notes` and `--notes-file`.
 For multi-line variable values, pipe stdin to `gh-axi variable set <name>`; `--body`/`-b` is for inline values only.
+
+The label, assignee, reviewer, and project flags of `issue create`/`edit` and `pr create`/`edit` are repeatable: pass the flag once per value and every value reaches `gh`.
+`issue list` and `pr list` accept repeated `--label` filters the same way.
+A repeated flag with a missing or empty value (`--add-label` with nothing after it, or `--add-label=`) fails with a validation error instead of being silently dropped.
 
 Long `run view --log` and `run view --log-failed` output shows the last 20,000 characters so CI failures stay visible.
 When truncation happens, gh-axi best-effort saves the complete log to a temp file, includes it as `full_log`, and prints a `help:` hint telling agents to grep that file for earlier context.

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -53,6 +53,7 @@ Run `npx -y gh-axi --help` for global flags, or `npx -y gh-axi <command> --help`
 - Truncated workflow logs keep the final 20,000 characters and may include a temp `full_log` path for targeted grep searches.
 - Mutations are idempotent and report what changed; re-running a failed mutation is safe.
 - For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass `--body-file <path>` or the release `--notes-file <path>` alias on commands that support file-backed text.
+- Label, assignee, reviewer, and project flags repeat: pass the flag once per value, e.g. `issue edit 42 --add-label bug --add-label chore`, and every value is applied. A repeated flag with a missing or blank value is rejected, never silently dropped.
 - Secret values are stdin-only: `echo -n "<value>" | npx -y gh-axi secret set <name>`.
 - Do not pass secrets with `--body` or `-b`; flags are visible in the `gh-axi` process argv.
 - Scope a secret to a deployment environment with `--env`/`-e <environment>` on `secret list`, `set`, and `delete`; omit it for repository scope. Other `gh secret` scopes (`--org`, `--user`, `--app`) are rejected, not silently ignored.

--- a/src/args.ts
+++ b/src/args.ts
@@ -68,8 +68,8 @@ function collectAllFlags(
   let i = 0;
   while (i < args.length) {
     const arg = args[i];
-    if (arg === flag && i + 1 < args.length) {
-      result.push(requireFlagValue(args[i + 1], flag));
+    if (arg === flag) {
+      result.push(requireFlagValue(args[i + 1] ?? "", flag));
       if (consume) args.splice(i, 2);
       else i += 2;
     } else if (arg.startsWith(equalsPrefix)) {

--- a/src/args.ts
+++ b/src/args.ts
@@ -83,12 +83,16 @@ function collectAllFlags(
   return result;
 }
 
-/** Collect all values for a repeatable flag in --flag value or --flag=value form. */
+/**
+ * Collect all values for a repeatable flag in --flag value or --flag=value form
+ * without modifying args. Throws VALIDATION_ERROR if any occurrence has a
+ * missing or blank value, rather than silently dropping it.
+ */
 export function getAllFlags(args: string[], flag: string): string[] {
   return collectAllFlags(args, flag, false);
 }
 
-/** Collect all values for a repeatable flag and remove them from args. */
+/** Like getAllFlags, but also removes every occurrence from args. */
 export function takeAllFlags(args: string[], flag: string): string[] {
   return collectAllFlags(args, flag, true);
 }

--- a/src/args.ts
+++ b/src/args.ts
@@ -52,20 +52,48 @@ export function takeBoolFlag(args: string[], flag: string): boolean {
   return true;
 }
 
-/** Collect all values for a repeatable flag in --flag value or --flag=value form. */
-export function getAllFlags(args: string[], flag: string): string[] {
+function collectAllFlags(
+  args: string[],
+  flag: string,
+  consume: boolean,
+): string[] {
   const result: string[] = [];
   const equalsPrefix = flagEqualsPrefix(flag);
-  for (let i = 0; i < args.length; i++) {
+  let i = 0;
+  while (i < args.length) {
     const arg = args[i];
     if (arg === flag && i + 1 < args.length) {
       result.push(args[i + 1]);
-      i++;
+      if (consume) args.splice(i, 2);
+      else i += 2;
     } else if (arg.startsWith(equalsPrefix)) {
       result.push(arg.slice(equalsPrefix.length));
+      if (consume) args.splice(i, 1);
+      else i++;
+    } else {
+      i++;
     }
   }
   return result;
+}
+
+/** Collect all values for a repeatable flag in --flag value or --flag=value form. */
+export function getAllFlags(args: string[], flag: string): string[] {
+  return collectAllFlags(args, flag, false);
+}
+
+/** Collect all values for a repeatable flag and remove them from args. */
+export function takeAllFlags(args: string[], flag: string): string[] {
+  return collectAllFlags(args, flag, true);
+}
+
+/** Append a repeatable flag once per value onto a gh argv array. */
+export function pushRepeated(
+  ghArgs: string[],
+  flag: string,
+  values: string[],
+): void {
+  for (const value of values) ghArgs.push(flag, value);
 }
 
 /** Get the first positional arg (non-flag) starting from startIndex. */

--- a/src/args.ts
+++ b/src/args.ts
@@ -52,6 +52,12 @@ export function takeBoolFlag(args: string[], flag: string): boolean {
   return true;
 }
 
+function requireFlagValue(value: string, flag: string): string {
+  if (value.trim() === "")
+    throw new AxiError(`${flag} requires a value`, "VALIDATION_ERROR");
+  return value;
+}
+
 function collectAllFlags(
   args: string[],
   flag: string,
@@ -63,11 +69,11 @@ function collectAllFlags(
   while (i < args.length) {
     const arg = args[i];
     if (arg === flag && i + 1 < args.length) {
-      result.push(args[i + 1]);
+      result.push(requireFlagValue(args[i + 1], flag));
       if (consume) args.splice(i, 2);
       else i += 2;
     } else if (arg.startsWith(equalsPrefix)) {
-      result.push(arg.slice(equalsPrefix.length));
+      result.push(requireFlagValue(arg.slice(equalsPrefix.length), flag));
       if (consume) args.splice(i, 1);
       else i++;
     } else {

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -66,7 +66,7 @@ flags{view}:
 flags{create}:
   --title <text> (required), --body <text> or --body-file <path>, --assignee <login>, --label <name> (repeatable), --milestone <name>, --type <name>
 flags{edit}:
-  --title, --body <text> or --body-file <path>, --add-label, --remove-label, --add-assignee, --remove-assignee, --milestone, --type <name>, --no-type
+  --title, --body <text> or --body-file <path>, --add-label <name> (repeatable), --remove-label <name> (repeatable), --add-assignee <login> (repeatable), --remove-assignee <login> (repeatable), --milestone, --type <name>, --no-type
 flags{close}:
   --reason <completed|not_planned>, --comment <text>
 flags{comment}:
@@ -535,10 +535,10 @@ async function editIssue(args: string[], ctx?: RepoContext): Promise<string> {
 
   const title = getFlag(args, "--title");
   const body = takeBody(args);
-  const addLabel = getFlag(args, "--add-label");
-  const removeLabel = getFlag(args, "--remove-label");
-  const addAssignee = getFlag(args, "--add-assignee");
-  const removeAssignee = getFlag(args, "--remove-assignee");
+  const addLabels = getAllFlags(args, "--add-label");
+  const removeLabels = getAllFlags(args, "--remove-label");
+  const addAssignees = getAllFlags(args, "--add-assignee");
+  const removeAssignees = getAllFlags(args, "--remove-assignee");
   const milestone = getFlag(args, "--milestone");
   const clearType = takeBoolFlag(args, "--no-type");
   const typeName = getOptionalRequiredFlag(args, "--type");
@@ -553,10 +553,11 @@ async function editIssue(args: string[], ctx?: RepoContext): Promise<string> {
   const ghArgs = ["issue", "edit", String(num)];
   if (title) ghArgs.push("--title", title);
   if (body !== undefined) ghArgs.push("--body", body);
-  if (addLabel) ghArgs.push("--add-label", addLabel);
-  if (removeLabel) ghArgs.push("--remove-label", removeLabel);
-  if (addAssignee) ghArgs.push("--add-assignee", addAssignee);
-  if (removeAssignee) ghArgs.push("--remove-assignee", removeAssignee);
+  for (const label of addLabels) ghArgs.push("--add-label", label);
+  for (const label of removeLabels) ghArgs.push("--remove-label", label);
+  for (const assignee of addAssignees) ghArgs.push("--add-assignee", assignee);
+  for (const assignee of removeAssignees)
+    ghArgs.push("--remove-assignee", assignee);
   if (milestone) ghArgs.push("--milestone", milestone);
 
   // Only call `gh issue edit` if there is a non-type field to update; otherwise

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -61,7 +61,7 @@ export const ISSUE_HELP = `usage: gh-axi issue <subcommand> [flags]
 subcommands[14]:
   list, view <number>, create, edit <number>, close <number>, reopen <number>, comment <number>, delete <number>, lock <number>, unlock <number>, pin <number>, unpin <number>, transfer <number>, subissue <add|remove|list>
 flags{list}:
-  --state <open|closed|all>, --label <name>, --assignee <login>, --author <login>, --milestone <name>, --sort <created|updated|comments>, --limit <n> (default 30), --fields <a,b,c>
+  --state <open|closed|all>, --label <name> (repeatable), --assignee <login>, --author <login>, --milestone <name>, --sort <created|updated|comments>, --limit <n> (default 30), --fields <a,b,c>
 flags{view}:
   --comments, --full (show complete body without truncation)
 flags{create}:
@@ -223,7 +223,7 @@ async function listIssues(args: string[], ctx?: RepoContext): Promise<string> {
     ISSUE_LIST_EXTRA_FIELDS,
   );
   const state = getFlag(args, "--state");
-  const label = getFlag(args, "--label");
+  const labels = getAllFlags(args, "--label");
   const assignee = getFlag(args, "--assignee");
   const author = getFlag(args, "--author");
   const milestone = getFlag(args, "--milestone");
@@ -245,7 +245,7 @@ async function listIssues(args: string[], ctx?: RepoContext): Promise<string> {
     String(limit),
   ];
   if (state) ghArgs.push("--state", state);
-  if (label) ghArgs.push("--label", label);
+  pushRepeated(ghArgs, "--label", labels);
   if (assignee) ghArgs.push("--assignee", assignee);
   if (author) ghArgs.push("--author", author);
   if (milestone) ghArgs.push("--milestone", milestone);
@@ -478,7 +478,7 @@ async function createIssue(args: string[], ctx?: RepoContext): Promise<string> {
   const assignees = getAllFlags(args, "--assignee");
   const labels = getAllFlags(args, "--label");
   const milestone = getFlag(args, "--milestone");
-  const project = getFlag(args, "--project");
+  const projects = getAllFlags(args, "--project");
   const typeName = getOptionalRequiredFlag(args, "--type");
 
   // Resolve type up front so an invalid value fails before creating the issue.
@@ -492,7 +492,7 @@ async function createIssue(args: string[], ctx?: RepoContext): Promise<string> {
   pushRepeated(ghArgs, "--assignee", assignees);
   pushRepeated(ghArgs, "--label", labels);
   if (milestone) ghArgs.push("--milestone", milestone);
-  if (project) ghArgs.push("--project", project);
+  pushRepeated(ghArgs, "--project", projects);
 
   // gh issue create outputs the URL; use --json to get structured data
   // Unfortunately gh issue create doesn't support --json, so we parse the URL

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -65,7 +65,7 @@ flags{list}:
 flags{view}:
   --comments, --full (show complete body without truncation)
 flags{create}:
-  --title <text> (required), --body <text> or --body-file <path>, --assignee <login> (repeatable), --label <name> (repeatable), --milestone <name>, --type <name>
+  --title <text> (required), --body <text> or --body-file <path>, --assignee <login> (repeatable), --label <name> (repeatable), --milestone <name>, --project <name> (repeatable), --type <name>
 flags{edit}:
   --title, --body <text> or --body-file <path>, --add-label <name> (repeatable), --remove-label <name> (repeatable), --add-assignee <login> (repeatable), --remove-assignee <login> (repeatable), --milestone, --type <name>, --no-type
 flags{close}:

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -7,6 +7,7 @@ import {
   hasFlag,
   getFlag,
   getAllFlags,
+  pushRepeated,
   getPositional,
   requireNumber,
   takeFlag,
@@ -64,7 +65,7 @@ flags{list}:
 flags{view}:
   --comments, --full (show complete body without truncation)
 flags{create}:
-  --title <text> (required), --body <text> or --body-file <path>, --assignee <login>, --label <name> (repeatable), --milestone <name>, --type <name>
+  --title <text> (required), --body <text> or --body-file <path>, --assignee <login> (repeatable), --label <name> (repeatable), --milestone <name>, --type <name>
 flags{edit}:
   --title, --body <text> or --body-file <path>, --add-label <name> (repeatable), --remove-label <name> (repeatable), --add-assignee <login> (repeatable), --remove-assignee <login> (repeatable), --milestone, --type <name>, --no-type
 flags{close}:
@@ -474,7 +475,7 @@ async function createIssue(args: string[], ctx?: RepoContext): Promise<string> {
   if (!title) throw new AxiError("--title is required", "VALIDATION_ERROR");
 
   const body = takeBody(args);
-  const assignee = getFlag(args, "--assignee");
+  const assignees = getAllFlags(args, "--assignee");
   const labels = getAllFlags(args, "--label");
   const milestone = getFlag(args, "--milestone");
   const project = getFlag(args, "--project");
@@ -488,8 +489,8 @@ async function createIssue(args: string[], ctx?: RepoContext): Promise<string> {
 
   const ghArgs = ["issue", "create", "--title", title];
   if (body !== undefined) ghArgs.push("--body", body);
-  if (assignee) ghArgs.push("--assignee", assignee);
-  for (const l of labels) ghArgs.push("--label", l);
+  pushRepeated(ghArgs, "--assignee", assignees);
+  pushRepeated(ghArgs, "--label", labels);
   if (milestone) ghArgs.push("--milestone", milestone);
   if (project) ghArgs.push("--project", project);
 
@@ -553,11 +554,10 @@ async function editIssue(args: string[], ctx?: RepoContext): Promise<string> {
   const ghArgs = ["issue", "edit", String(num)];
   if (title) ghArgs.push("--title", title);
   if (body !== undefined) ghArgs.push("--body", body);
-  for (const label of addLabels) ghArgs.push("--add-label", label);
-  for (const label of removeLabels) ghArgs.push("--remove-label", label);
-  for (const assignee of addAssignees) ghArgs.push("--add-assignee", assignee);
-  for (const assignee of removeAssignees)
-    ghArgs.push("--remove-assignee", assignee);
+  pushRepeated(ghArgs, "--add-label", addLabels);
+  pushRepeated(ghArgs, "--remove-label", removeLabels);
+  pushRepeated(ghArgs, "--add-assignee", addAssignees);
+  pushRepeated(ghArgs, "--remove-assignee", removeAssignees);
   if (milestone) ghArgs.push("--milestone", milestone);
 
   // Only call `gh issue edit` if there is a non-type field to update; otherwise

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -249,7 +249,7 @@ export const PR_HELP = `usage: gh-axi pr <subcommand> [flags]
 subcommands[15]:
   list, view <number>, create, edit <number>, close <number>, merge <number>, review <number>, checks <number>, diff <number>, checkout <number>, ready <number>, reopen <number>, comment <number>, update-branch <number>, revert <number>
 flags{list}:
-  --state <open|closed|all>, --label, --assignee, --author, --base, --head, --draft, --limit <n> (default 30), --fields <a,b,c>
+  --state <open|closed|all>, --label (repeatable), --assignee, --author, --base, --head, --draft, --limit <n> (default 30), --fields <a,b,c>
 flags{view}:
   --comments, --reviews (show review submissions and inline review comments), --full (show complete body without truncation)
 flags{create}:
@@ -290,7 +290,7 @@ async function prList(args: string[], ctx?: RepoContext): Promise<string> {
     PR_LIST_EXTRA_FIELDS,
   );
   const state = takeFlag(args, "--state") ?? "open";
-  const label = takeFlag(args, "--label");
+  const labels = takeAllFlags(args, "--label");
   const assignee = takeFlag(args, "--assignee");
   const author = takeFlag(args, "--author");
   const base = takeFlag(args, "--base");
@@ -312,7 +312,7 @@ async function prList(args: string[], ctx?: RepoContext): Promise<string> {
     "--limit",
     limit,
   ];
-  if (label) ghArgs.push("--label", label);
+  pushRepeated(ghArgs, "--label", labels);
   if (assignee) ghArgs.push("--assignee", assignee);
   if (author) ghArgs.push("--author", author);
   if (base) ghArgs.push("--base", base);
@@ -460,7 +460,7 @@ async function prCreate(args: string[], ctx?: RepoContext): Promise<string> {
   const reviewers = takeAllFlags(args, "--reviewer");
   const labels = takeAllFlags(args, "--label");
   const milestone = takeFlag(args, "--milestone");
-  const project = takeFlag(args, "--project");
+  const projects = takeAllFlags(args, "--project");
 
   const ghArgs = ["pr", "create", "--title", title];
   if (body !== undefined) ghArgs.push("--body", body);
@@ -471,7 +471,7 @@ async function prCreate(args: string[], ctx?: RepoContext): Promise<string> {
   pushRepeated(ghArgs, "--reviewer", reviewers);
   pushRepeated(ghArgs, "--label", labels);
   if (milestone) ghArgs.push("--milestone", milestone);
-  if (project) ghArgs.push("--project", project);
+  pushRepeated(ghArgs, "--project", projects);
 
   const stdout = await ghExec(ghArgs, ctx);
   // Parse PR number from the emitted URL: https://<host>/OWNER/REPO/pull/123

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -5,7 +5,13 @@ import { AxiError } from "../errors.js";
 import { takeBody, truncateBody } from "../body.js";
 import { formatCountLine } from "../format.js";
 import { getSuggestions } from "../suggestions.js";
-import { takeFlag, takeBoolFlag, takeNumber, getAllFlags } from "../args.js";
+import {
+  takeFlag,
+  takeBoolFlag,
+  takeNumber,
+  takeAllFlags,
+  pushRepeated,
+} from "../args.js";
 import { parseFields, type ExtraFieldSpec } from "../fields.js";
 import {
   field,
@@ -247,7 +253,7 @@ flags{list}:
 flags{view}:
   --comments, --reviews (show review submissions and inline review comments), --full (show complete body without truncation)
 flags{create}:
-  --title <text> (required), --body <text> or --body-file <path>, --base, --head, --draft, --assignee, --reviewer, --label <name> (repeatable), --milestone
+  --title <text> (required), --body <text> or --body-file <path>, --base, --head, --draft, --assignee <login> (repeatable), --reviewer <login> (repeatable), --label <name> (repeatable), --milestone
 flags{edit}:
   --title <text>, --body <text> or --body-file <path>, --add-label <name> (repeatable), --remove-label <name> (repeatable), --add-assignee <login> (repeatable), --remove-assignee <login> (repeatable), --add-reviewer <login> (repeatable), --remove-reviewer <login> (repeatable), --milestone
 flags{merge}:
@@ -450,9 +456,9 @@ async function prCreate(args: string[], ctx?: RepoContext): Promise<string> {
   const base = takeFlag(args, "--base");
   const head = takeFlag(args, "--head");
   const draft = takeBoolFlag(args, "--draft");
-  const assignee = takeFlag(args, "--assignee");
-  const reviewer = takeFlag(args, "--reviewer");
-  const labels = getAllFlags(args, "--label");
+  const assignees = takeAllFlags(args, "--assignee");
+  const reviewers = takeAllFlags(args, "--reviewer");
+  const labels = takeAllFlags(args, "--label");
   const milestone = takeFlag(args, "--milestone");
   const project = takeFlag(args, "--project");
 
@@ -461,9 +467,9 @@ async function prCreate(args: string[], ctx?: RepoContext): Promise<string> {
   if (base) ghArgs.push("--base", base);
   if (head) ghArgs.push("--head", head);
   if (draft) ghArgs.push("--draft");
-  if (assignee) ghArgs.push("--assignee", assignee);
-  if (reviewer) ghArgs.push("--reviewer", reviewer);
-  for (const l of labels) ghArgs.push("--label", l);
+  pushRepeated(ghArgs, "--assignee", assignees);
+  pushRepeated(ghArgs, "--reviewer", reviewers);
+  pushRepeated(ghArgs, "--label", labels);
   if (milestone) ghArgs.push("--milestone", milestone);
   if (project) ghArgs.push("--project", project);
 
@@ -488,26 +494,24 @@ async function prEdit(args: string[], ctx?: RepoContext): Promise<string> {
   const num = takeNumber(args, "PR");
   const title = takeFlag(args, "--title");
   const body = takeBody(args);
-  const addLabels = getAllFlags(args, "--add-label");
-  const removeLabels = getAllFlags(args, "--remove-label");
-  const addAssignees = getAllFlags(args, "--add-assignee");
-  const removeAssignees = getAllFlags(args, "--remove-assignee");
-  const addReviewers = getAllFlags(args, "--add-reviewer");
-  const removeReviewers = getAllFlags(args, "--remove-reviewer");
+  const addLabels = takeAllFlags(args, "--add-label");
+  const removeLabels = takeAllFlags(args, "--remove-label");
+  const addAssignees = takeAllFlags(args, "--add-assignee");
+  const removeAssignees = takeAllFlags(args, "--remove-assignee");
+  const addReviewers = takeAllFlags(args, "--add-reviewer");
+  const removeReviewers = takeAllFlags(args, "--remove-reviewer");
   const milestone = takeFlag(args, "--milestone");
   const base = takeFlag(args, "--base");
 
   const ghArgs = ["pr", "edit", String(num)];
   if (title) ghArgs.push("--title", title);
   if (body !== undefined) ghArgs.push("--body", body);
-  for (const label of addLabels) ghArgs.push("--add-label", label);
-  for (const label of removeLabels) ghArgs.push("--remove-label", label);
-  for (const assignee of addAssignees) ghArgs.push("--add-assignee", assignee);
-  for (const assignee of removeAssignees)
-    ghArgs.push("--remove-assignee", assignee);
-  for (const reviewer of addReviewers) ghArgs.push("--add-reviewer", reviewer);
-  for (const reviewer of removeReviewers)
-    ghArgs.push("--remove-reviewer", reviewer);
+  pushRepeated(ghArgs, "--add-label", addLabels);
+  pushRepeated(ghArgs, "--remove-label", removeLabels);
+  pushRepeated(ghArgs, "--add-assignee", addAssignees);
+  pushRepeated(ghArgs, "--remove-assignee", removeAssignees);
+  pushRepeated(ghArgs, "--add-reviewer", addReviewers);
+  pushRepeated(ghArgs, "--remove-reviewer", removeReviewers);
   if (milestone) ghArgs.push("--milestone", milestone);
   if (base) ghArgs.push("--base", base);
 

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -249,7 +249,7 @@ flags{view}:
 flags{create}:
   --title <text> (required), --body <text> or --body-file <path>, --base, --head, --draft, --assignee, --reviewer, --label <name> (repeatable), --milestone
 flags{edit}:
-  --title <text>, --body <text> or --body-file <path>, --add-label, --remove-label, --add-assignee, --remove-assignee, --add-reviewer, --remove-reviewer, --milestone
+  --title <text>, --body <text> or --body-file <path>, --add-label <name> (repeatable), --remove-label <name> (repeatable), --add-assignee <login> (repeatable), --remove-assignee <login> (repeatable), --add-reviewer <login> (repeatable), --remove-reviewer <login> (repeatable), --milestone
 flags{merge}:
   --method <merge|squash|rebase>, --merge, --squash, --rebase, --auto, --delete-branch, --body <text> or --body-file <path>, --subject
 flags{review}:
@@ -488,24 +488,26 @@ async function prEdit(args: string[], ctx?: RepoContext): Promise<string> {
   const num = takeNumber(args, "PR");
   const title = takeFlag(args, "--title");
   const body = takeBody(args);
-  const addLabel = takeFlag(args, "--add-label");
-  const removeLabel = takeFlag(args, "--remove-label");
-  const addAssignee = takeFlag(args, "--add-assignee");
-  const removeAssignee = takeFlag(args, "--remove-assignee");
-  const addReviewer = takeFlag(args, "--add-reviewer");
-  const removeReviewer = takeFlag(args, "--remove-reviewer");
+  const addLabels = getAllFlags(args, "--add-label");
+  const removeLabels = getAllFlags(args, "--remove-label");
+  const addAssignees = getAllFlags(args, "--add-assignee");
+  const removeAssignees = getAllFlags(args, "--remove-assignee");
+  const addReviewers = getAllFlags(args, "--add-reviewer");
+  const removeReviewers = getAllFlags(args, "--remove-reviewer");
   const milestone = takeFlag(args, "--milestone");
   const base = takeFlag(args, "--base");
 
   const ghArgs = ["pr", "edit", String(num)];
   if (title) ghArgs.push("--title", title);
   if (body !== undefined) ghArgs.push("--body", body);
-  if (addLabel) ghArgs.push("--add-label", addLabel);
-  if (removeLabel) ghArgs.push("--remove-label", removeLabel);
-  if (addAssignee) ghArgs.push("--add-assignee", addAssignee);
-  if (removeAssignee) ghArgs.push("--remove-assignee", removeAssignee);
-  if (addReviewer) ghArgs.push("--add-reviewer", addReviewer);
-  if (removeReviewer) ghArgs.push("--remove-reviewer", removeReviewer);
+  for (const label of addLabels) ghArgs.push("--add-label", label);
+  for (const label of removeLabels) ghArgs.push("--remove-label", label);
+  for (const assignee of addAssignees) ghArgs.push("--add-assignee", assignee);
+  for (const assignee of removeAssignees)
+    ghArgs.push("--remove-assignee", assignee);
+  for (const reviewer of addReviewers) ghArgs.push("--add-reviewer", reviewer);
+  for (const reviewer of removeReviewers)
+    ghArgs.push("--remove-reviewer", reviewer);
   if (milestone) ghArgs.push("--milestone", milestone);
   if (base) ghArgs.push("--base", base);
 

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -253,7 +253,7 @@ flags{list}:
 flags{view}:
   --comments, --reviews (show review submissions and inline review comments), --full (show complete body without truncation)
 flags{create}:
-  --title <text> (required), --body <text> or --body-file <path>, --base, --head, --draft, --assignee <login> (repeatable), --reviewer <login> (repeatable), --label <name> (repeatable), --milestone
+  --title <text> (required), --body <text> or --body-file <path>, --base, --head, --draft, --assignee <login> (repeatable), --reviewer <login> (repeatable), --label <name> (repeatable), --milestone, --project <name> (repeatable)
 flags{edit}:
   --title <text>, --body <text> or --body-file <path>, --add-label <name> (repeatable), --remove-label <name> (repeatable), --add-assignee <login> (repeatable), --remove-assignee <login> (repeatable), --add-reviewer <login> (repeatable), --remove-reviewer <login> (repeatable), --milestone
 flags{merge}:

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -102,6 +102,7 @@ Run \`npx -y gh-axi --help\` for global flags, or \`npx -y gh-axi <command> --he
 - Truncated workflow logs keep the final 20,000 characters and may include a temp \`full_log\` path for targeted grep searches.
 - Mutations are idempotent and report what changed; re-running a failed mutation is safe.
 - For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass \`--body-file <path>\` or the release \`--notes-file <path>\` alias on commands that support file-backed text.
+- Label, assignee, reviewer, and project flags repeat: pass the flag once per value, e.g. \`issue edit 42 --add-label bug --add-label chore\`, and every value is applied. A repeated flag with a missing or blank value is rejected, never silently dropped.
 - Secret values are stdin-only: \`echo -n "<value>" | npx -y gh-axi secret set <name>\`.
 - Do not pass secrets with \`--body\` or \`-b\`; flags are visible in the \`gh-axi\` process argv.
 - Scope a secret to a deployment environment with \`--env\`/\`-e <environment>\` on \`secret list\`, \`set\`, and \`delete\`; omit it for repository scope. Other \`gh secret\` scopes (\`--org\`, \`--user\`, \`--app\`) are rejected, not silently ignored.

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -5,6 +5,8 @@ import {
   hasFlag,
   takeBoolFlag,
   getAllFlags,
+  takeAllFlags,
+  pushRepeated,
   getPositional,
   requireNumber,
 } from "../src/args.js";
@@ -125,6 +127,73 @@ describe("getAllFlags", () => {
   it("skips flag at end of array with no value", () => {
     const args = ["--label", "bug", "--label"];
     expect(getAllFlags(args, "--label")).toEqual(["bug"]);
+  });
+
+  it("leaves args untouched", () => {
+    const args = ["--label", "bug", "--state", "open"];
+    getAllFlags(args, "--label");
+    expect(args).toEqual(["--label", "bug", "--state", "open"]);
+  });
+});
+
+describe("takeAllFlags", () => {
+  it("collects all values and removes them from args", () => {
+    const args = [
+      "--label",
+      "bug",
+      "--state",
+      "open",
+      "--label",
+      "help wanted",
+    ];
+    expect(takeAllFlags(args, "--label")).toEqual(["bug", "help wanted"]);
+    expect(args).toEqual(["--state", "open"]);
+  });
+
+  it("removes repeated --flag=value occurrences", () => {
+    const args = ["--label=bug", "--state", "open", "--label=help wanted"];
+    expect(takeAllFlags(args, "--label")).toEqual(["bug", "help wanted"]);
+    expect(args).toEqual(["--state", "open"]);
+  });
+
+  it("removes mixed --flag value and --flag=value occurrences", () => {
+    const args = ["--label", "bug", "--label=chore", "--state", "open"];
+    expect(takeAllFlags(args, "--label")).toEqual(["bug", "chore"]);
+    expect(args).toEqual(["--state", "open"]);
+  });
+
+  it("returns empty array and leaves args alone when flag is absent", () => {
+    const args = ["--state", "open"];
+    expect(takeAllFlags(args, "--label")).toEqual([]);
+    expect(args).toEqual(["--state", "open"]);
+  });
+
+  it("skips flag at end of array with no value", () => {
+    const args = ["--label", "bug", "--label"];
+    expect(takeAllFlags(args, "--label")).toEqual(["bug"]);
+    expect(args).toEqual(["--label"]);
+  });
+});
+
+describe("pushRepeated", () => {
+  it("appends the flag once per value", () => {
+    const ghArgs = ["issue", "edit", "1"];
+    pushRepeated(ghArgs, "--add-label", ["bug", "chore"]);
+    expect(ghArgs).toEqual([
+      "issue",
+      "edit",
+      "1",
+      "--add-label",
+      "bug",
+      "--add-label",
+      "chore",
+    ]);
+  });
+
+  it("appends nothing for an empty value list", () => {
+    const ghArgs = ["issue", "edit", "1"];
+    pushRepeated(ghArgs, "--add-label", []);
+    expect(ghArgs).toEqual(["issue", "edit", "1"]);
   });
 });
 

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -134,6 +134,24 @@ describe("getAllFlags", () => {
     getAllFlags(args, "--label");
     expect(args).toEqual(["--label", "bug", "--state", "open"]);
   });
+
+  it("throws on an empty --flag= value", () => {
+    expect(() => getAllFlags(["--label="], "--label")).toThrow(
+      "--label requires a value",
+    );
+  });
+
+  it("throws on an empty --flag value", () => {
+    expect(() =>
+      getAllFlags(["--label", "", "--state", "open"], "--label"),
+    ).toThrow("--label requires a value");
+  });
+
+  it("throws when only one of several occurrences is empty", () => {
+    expect(() =>
+      getAllFlags(["--label", "bug", "--label="], "--label"),
+    ).toThrow(AxiError);
+  });
 });
 
 describe("takeAllFlags", () => {
@@ -172,6 +190,12 @@ describe("takeAllFlags", () => {
     const args = ["--label", "bug", "--label"];
     expect(takeAllFlags(args, "--label")).toEqual(["bug"]);
     expect(args).toEqual(["--label"]);
+  });
+
+  it("throws on an empty value instead of silently dropping it", () => {
+    expect(() => takeAllFlags(["--add-label", ""], "--add-label")).toThrow(
+      "--add-label requires a value",
+    );
   });
 });
 

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -124,9 +124,11 @@ describe("getAllFlags", () => {
     expect(getAllFlags([], "--label")).toEqual([]);
   });
 
-  it("skips flag at end of array with no value", () => {
+  it("throws on a dangling flag at end of array with no value", () => {
     const args = ["--label", "bug", "--label"];
-    expect(getAllFlags(args, "--label")).toEqual(["bug"]);
+    expect(() => getAllFlags(args, "--label")).toThrow(
+      "--label requires a value",
+    );
   });
 
   it("leaves args untouched", () => {
@@ -186,10 +188,11 @@ describe("takeAllFlags", () => {
     expect(args).toEqual(["--state", "open"]);
   });
 
-  it("skips flag at end of array with no value", () => {
+  it("throws on a dangling flag at end of array with no value", () => {
     const args = ["--label", "bug", "--label"];
-    expect(takeAllFlags(args, "--label")).toEqual(["bug"]);
-    expect(args).toEqual(["--label"]);
+    expect(() => takeAllFlags(args, "--label")).toThrow(
+      "--label requires a value",
+    );
   });
 
   it("throws on an empty value instead of silently dropping it", () => {

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -669,6 +669,15 @@ describe("issueCommand", () => {
         "bug",
       ]);
     });
+
+    it("rejects a dangling --add-label instead of editing nothing", async () => {
+      mockEditedIssue();
+
+      await expect(
+        issueCommand(["edit", "276", "--add-label"], ctx),
+      ).rejects.toThrow("--add-label requires a value");
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
   });
 
   describe("create with repeatable flags", () => {

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -478,6 +478,62 @@ describe("issueCommand", () => {
     });
   });
 
+  describe("list and create with repeatable flags", () => {
+    it("passes all repeated --label filters to gh issue list", async () => {
+      mockedGhJson.mockResolvedValue([]);
+
+      await issueCommand(["list", "--label", "bug", "--label", "chore"], ctx);
+
+      expect(mockedGhJson.mock.calls[0][0]).toEqual([
+        "issue",
+        "list",
+        "--json",
+        "number,title,state,author,createdAt",
+        "--limit",
+        "30",
+        "--label",
+        "bug",
+        "--label",
+        "chore",
+      ]);
+    });
+
+    it("passes all repeated --project flags to gh issue create", async () => {
+      mockedGhExec.mockResolvedValue(
+        "https://github.com/octo/repo/issues/102\n",
+      );
+      mockedGhJson.mockResolvedValue({
+        number: 102,
+        title: "T",
+        state: "OPEN",
+        url: "https://github.com/octo/repo/issues/102",
+      });
+
+      await issueCommand(
+        ["create", "--title", "T", "--project", "Roadmap", "--project", "Q3"],
+        ctx,
+      );
+
+      expect(mockedGhExec.mock.calls[0][0]).toEqual([
+        "issue",
+        "create",
+        "--title",
+        "T",
+        "--project",
+        "Roadmap",
+        "--project",
+        "Q3",
+      ]);
+    });
+
+    it("rejects an empty --label value instead of dropping it", async () => {
+      await expect(issueCommand(["list", "--label="], ctx)).rejects.toThrow(
+        "--label requires a value",
+      );
+      expect(mockedGhJson).not.toHaveBeenCalled();
+    });
+  });
+
   describe("edit with repeatable flags", () => {
     function mockEditedIssue(): void {
       mockedGhExec.mockResolvedValue("");

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -478,6 +478,114 @@ describe("issueCommand", () => {
     });
   });
 
+  describe("edit with repeatable flags", () => {
+    function mockEditedIssue(): void {
+      mockedGhExec.mockResolvedValue("");
+      mockedGhJson.mockResolvedValue({
+        number: 276,
+        title: "X",
+        state: "OPEN",
+        labels: [],
+        assignees: [],
+        id: "I_node276",
+      });
+    }
+
+    it("passes all repeated --add-label flags to gh issue edit", async () => {
+      mockEditedIssue();
+
+      await issueCommand(
+        ["edit", "276", "--add-label", "bug", "--add-label", "ready-for-agent"],
+        ctx,
+      );
+
+      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
+      expect(callArgs.filter((a) => a === "--add-label")).toHaveLength(2);
+      expect(callArgs).toContain("bug");
+      expect(callArgs).toContain("ready-for-agent");
+    });
+
+    it("passes all repeated --remove-label flags to gh issue edit", async () => {
+      mockEditedIssue();
+
+      await issueCommand(
+        [
+          "edit",
+          "276",
+          "--remove-label",
+          "needs-triage",
+          "--remove-label",
+          "needs-info",
+        ],
+        ctx,
+      );
+
+      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
+      expect(callArgs.filter((a) => a === "--remove-label")).toHaveLength(2);
+      expect(callArgs).toContain("needs-triage");
+      expect(callArgs).toContain("needs-info");
+    });
+
+    it("applies adds and removes together without dropping any", async () => {
+      mockEditedIssue();
+
+      await issueCommand(
+        [
+          "edit",
+          "276",
+          "--add-label",
+          "bug",
+          "--add-label",
+          "ready-for-agent",
+          "--remove-label",
+          "needs-triage",
+        ],
+        ctx,
+      );
+
+      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
+      expect(callArgs.filter((a) => a === "--add-label")).toHaveLength(2);
+      expect(callArgs.filter((a) => a === "--remove-label")).toHaveLength(1);
+      expect(callArgs).toContain("ready-for-agent");
+    });
+
+    it("passes all repeated assignee flags to gh issue edit", async () => {
+      mockEditedIssue();
+
+      await issueCommand(
+        [
+          "edit",
+          "276",
+          "--add-assignee",
+          "octocat",
+          "--add-assignee",
+          "hubot",
+          "--remove-assignee",
+          "monalisa",
+          "--remove-assignee",
+          "ghost",
+        ],
+        ctx,
+      );
+
+      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
+      expect(callArgs.filter((a) => a === "--add-assignee")).toHaveLength(2);
+      expect(callArgs.filter((a) => a === "--remove-assignee")).toHaveLength(2);
+      expect(callArgs).toContain("hubot");
+      expect(callArgs).toContain("ghost");
+    });
+
+    it("still passes a single --add-label correctly (no regression)", async () => {
+      mockEditedIssue();
+
+      await issueCommand(["edit", "276", "--add-label", "bug"], ctx);
+
+      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
+      expect(callArgs.filter((a) => a === "--add-label")).toHaveLength(1);
+      expect(callArgs).toContain("bug");
+    });
+  });
+
   describe("edit with --type", () => {
     it("applies --type via graphql mutation", async () => {
       // 1) resolve type

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -499,10 +499,15 @@ describe("issueCommand", () => {
         ctx,
       );
 
-      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
-      expect(callArgs.filter((a) => a === "--add-label")).toHaveLength(2);
-      expect(callArgs).toContain("bug");
-      expect(callArgs).toContain("ready-for-agent");
+      expect(mockedGhExec.mock.calls[0][0]).toEqual([
+        "issue",
+        "edit",
+        "276",
+        "--add-label",
+        "bug",
+        "--add-label",
+        "ready-for-agent",
+      ]);
     });
 
     it("passes all repeated --remove-label flags to gh issue edit", async () => {
@@ -520,10 +525,15 @@ describe("issueCommand", () => {
         ctx,
       );
 
-      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
-      expect(callArgs.filter((a) => a === "--remove-label")).toHaveLength(2);
-      expect(callArgs).toContain("needs-triage");
-      expect(callArgs).toContain("needs-info");
+      expect(mockedGhExec.mock.calls[0][0]).toEqual([
+        "issue",
+        "edit",
+        "276",
+        "--remove-label",
+        "needs-triage",
+        "--remove-label",
+        "needs-info",
+      ]);
     });
 
     it("applies adds and removes together without dropping any", async () => {
@@ -543,10 +553,17 @@ describe("issueCommand", () => {
         ctx,
       );
 
-      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
-      expect(callArgs.filter((a) => a === "--add-label")).toHaveLength(2);
-      expect(callArgs.filter((a) => a === "--remove-label")).toHaveLength(1);
-      expect(callArgs).toContain("ready-for-agent");
+      expect(mockedGhExec.mock.calls[0][0]).toEqual([
+        "issue",
+        "edit",
+        "276",
+        "--add-label",
+        "bug",
+        "--add-label",
+        "ready-for-agent",
+        "--remove-label",
+        "needs-triage",
+      ]);
     });
 
     it("passes all repeated assignee flags to gh issue edit", async () => {
@@ -568,11 +585,19 @@ describe("issueCommand", () => {
         ctx,
       );
 
-      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
-      expect(callArgs.filter((a) => a === "--add-assignee")).toHaveLength(2);
-      expect(callArgs.filter((a) => a === "--remove-assignee")).toHaveLength(2);
-      expect(callArgs).toContain("hubot");
-      expect(callArgs).toContain("ghost");
+      expect(mockedGhExec.mock.calls[0][0]).toEqual([
+        "issue",
+        "edit",
+        "276",
+        "--add-assignee",
+        "octocat",
+        "--add-assignee",
+        "hubot",
+        "--remove-assignee",
+        "monalisa",
+        "--remove-assignee",
+        "ghost",
+      ]);
     });
 
     it("still passes a single --add-label correctly (no regression)", async () => {
@@ -580,9 +605,50 @@ describe("issueCommand", () => {
 
       await issueCommand(["edit", "276", "--add-label", "bug"], ctx);
 
-      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
-      expect(callArgs.filter((a) => a === "--add-label")).toHaveLength(1);
-      expect(callArgs).toContain("bug");
+      expect(mockedGhExec.mock.calls[0][0]).toEqual([
+        "issue",
+        "edit",
+        "276",
+        "--add-label",
+        "bug",
+      ]);
+    });
+  });
+
+  describe("create with repeatable flags", () => {
+    it("passes all repeated --assignee flags to gh issue create", async () => {
+      mockedGhExec.mockResolvedValue("https://github.com/o/r/issues/276\n");
+      mockedGhJson.mockResolvedValue({
+        number: 276,
+        title: "T",
+        state: "OPEN",
+        url: "https://github.com/o/r/issues/276",
+        id: "I_node276",
+      });
+
+      await issueCommand(
+        [
+          "create",
+          "--title",
+          "T",
+          "--assignee",
+          "octocat",
+          "--assignee",
+          "hubot",
+        ],
+        ctx,
+      );
+
+      expect(mockedGhExec.mock.calls[0][0]).toEqual([
+        "issue",
+        "create",
+        "--title",
+        "T",
+        "--assignee",
+        "octocat",
+        "--assignee",
+        "hubot",
+      ]);
     });
   });
 

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -459,6 +459,90 @@ describe("prCommand", () => {
     });
   });
 
+  describe("edit with repeatable flags", () => {
+    it("passes all repeated --add-label flags to gh pr edit", async () => {
+      mockedGhExec.mockResolvedValue("");
+
+      await prCommand(
+        ["edit", "42", "--add-label", "bug", "--add-label", "ready-for-agent"],
+        ctx,
+      );
+
+      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
+      expect(callArgs.filter((a) => a === "--add-label")).toHaveLength(2);
+      expect(callArgs).toContain("bug");
+      expect(callArgs).toContain("ready-for-agent");
+    });
+
+    it("passes all repeated --remove-label flags to gh pr edit", async () => {
+      mockedGhExec.mockResolvedValue("");
+
+      await prCommand(
+        [
+          "edit",
+          "42",
+          "--remove-label",
+          "needs-triage",
+          "--remove-label",
+          "needs-info",
+        ],
+        ctx,
+      );
+
+      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
+      expect(callArgs.filter((a) => a === "--remove-label")).toHaveLength(2);
+      expect(callArgs).toContain("needs-triage");
+      expect(callArgs).toContain("needs-info");
+    });
+
+    it("passes all repeated assignee and reviewer flags to gh pr edit", async () => {
+      mockedGhExec.mockResolvedValue("");
+
+      await prCommand(
+        [
+          "edit",
+          "42",
+          "--add-assignee",
+          "octocat",
+          "--add-assignee",
+          "hubot",
+          "--remove-assignee",
+          "monalisa",
+          "--remove-assignee",
+          "ghost",
+          "--add-reviewer",
+          "alice",
+          "--add-reviewer",
+          "bob",
+          "--remove-reviewer",
+          "carol",
+          "--remove-reviewer",
+          "dave",
+        ],
+        ctx,
+      );
+
+      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
+      expect(callArgs.filter((a) => a === "--add-assignee")).toHaveLength(2);
+      expect(callArgs.filter((a) => a === "--remove-assignee")).toHaveLength(2);
+      expect(callArgs.filter((a) => a === "--add-reviewer")).toHaveLength(2);
+      expect(callArgs.filter((a) => a === "--remove-reviewer")).toHaveLength(2);
+      expect(callArgs).toContain("hubot");
+      expect(callArgs).toContain("bob");
+      expect(callArgs).toContain("dave");
+    });
+
+    it("still passes a single --add-label correctly (no regression)", async () => {
+      mockedGhExec.mockResolvedValue("");
+
+      await prCommand(["edit", "42", "--add-label", "bug"], ctx);
+
+      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
+      expect(callArgs.filter((a) => a === "--add-label")).toHaveLength(1);
+      expect(callArgs).toContain("bug");
+    });
+  });
+
   describe("close", () => {
     it("returns already closed when PR is already closed (idempotent)", async () => {
       mockedGhJson.mockResolvedValue({ state: "CLOSED" });

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -459,6 +459,56 @@ describe("prCommand", () => {
     });
   });
 
+  describe("list and create with repeatable flags", () => {
+    it("passes all repeated --label filters to gh pr list", async () => {
+      mockedGhJson.mockResolvedValue([]);
+
+      await prCommand(["list", "--label", "bug", "--label", "chore"], ctx);
+
+      expect(mockedGhJson.mock.calls[0][0]).toEqual([
+        "pr",
+        "list",
+        "--json",
+        "number,title,state,author,isDraft,reviewDecision",
+        "--state",
+        "open",
+        "--limit",
+        "30",
+        "--label",
+        "bug",
+        "--label",
+        "chore",
+      ]);
+    });
+
+    it("passes all repeated --project flags to gh pr create", async () => {
+      mockedGhExec.mockResolvedValue("https://github.com/octo/repo/pull/7\n");
+
+      await prCommand(
+        ["create", "--title", "T", "--project", "Roadmap", "--project", "Q3"],
+        ctx,
+      );
+
+      expect(mockedGhExec.mock.calls[0][0]).toEqual([
+        "pr",
+        "create",
+        "--title",
+        "T",
+        "--project",
+        "Roadmap",
+        "--project",
+        "Q3",
+      ]);
+    });
+
+    it("rejects an empty --label value instead of dropping it", async () => {
+      await expect(prCommand(["list", "--label="], ctx)).rejects.toThrow(
+        "--label requires a value",
+      );
+      expect(mockedGhJson).not.toHaveBeenCalled();
+    });
+  });
+
   describe("edit with repeatable flags", () => {
     it("passes all repeated --add-label flags to gh pr edit", async () => {
       mockedGhExec.mockResolvedValue("");

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -468,10 +468,15 @@ describe("prCommand", () => {
         ctx,
       );
 
-      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
-      expect(callArgs.filter((a) => a === "--add-label")).toHaveLength(2);
-      expect(callArgs).toContain("bug");
-      expect(callArgs).toContain("ready-for-agent");
+      expect(mockedGhExec.mock.calls[0][0]).toEqual([
+        "pr",
+        "edit",
+        "42",
+        "--add-label",
+        "bug",
+        "--add-label",
+        "ready-for-agent",
+      ]);
     });
 
     it("passes all repeated --remove-label flags to gh pr edit", async () => {
@@ -489,10 +494,15 @@ describe("prCommand", () => {
         ctx,
       );
 
-      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
-      expect(callArgs.filter((a) => a === "--remove-label")).toHaveLength(2);
-      expect(callArgs).toContain("needs-triage");
-      expect(callArgs).toContain("needs-info");
+      expect(mockedGhExec.mock.calls[0][0]).toEqual([
+        "pr",
+        "edit",
+        "42",
+        "--remove-label",
+        "needs-triage",
+        "--remove-label",
+        "needs-info",
+      ]);
     });
 
     it("passes all repeated assignee and reviewer flags to gh pr edit", async () => {
@@ -522,14 +532,27 @@ describe("prCommand", () => {
         ctx,
       );
 
-      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
-      expect(callArgs.filter((a) => a === "--add-assignee")).toHaveLength(2);
-      expect(callArgs.filter((a) => a === "--remove-assignee")).toHaveLength(2);
-      expect(callArgs.filter((a) => a === "--add-reviewer")).toHaveLength(2);
-      expect(callArgs.filter((a) => a === "--remove-reviewer")).toHaveLength(2);
-      expect(callArgs).toContain("hubot");
-      expect(callArgs).toContain("bob");
-      expect(callArgs).toContain("dave");
+      expect(mockedGhExec.mock.calls[0][0]).toEqual([
+        "pr",
+        "edit",
+        "42",
+        "--add-assignee",
+        "octocat",
+        "--add-assignee",
+        "hubot",
+        "--remove-assignee",
+        "monalisa",
+        "--remove-assignee",
+        "ghost",
+        "--add-reviewer",
+        "alice",
+        "--add-reviewer",
+        "bob",
+        "--remove-reviewer",
+        "carol",
+        "--remove-reviewer",
+        "dave",
+      ]);
     });
 
     it("still passes a single --add-label correctly (no regression)", async () => {
@@ -537,9 +560,51 @@ describe("prCommand", () => {
 
       await prCommand(["edit", "42", "--add-label", "bug"], ctx);
 
-      const callArgs = mockedGhExec.mock.calls[0][0] as string[];
-      expect(callArgs.filter((a) => a === "--add-label")).toHaveLength(1);
-      expect(callArgs).toContain("bug");
+      expect(mockedGhExec.mock.calls[0][0]).toEqual([
+        "pr",
+        "edit",
+        "42",
+        "--add-label",
+        "bug",
+      ]);
+    });
+  });
+
+  describe("create with repeatable flags", () => {
+    it("passes all repeated --assignee and --reviewer flags to gh pr create", async () => {
+      mockedGhExec.mockResolvedValue("https://github.com/o/r/pull/42\n");
+
+      await prCommand(
+        [
+          "create",
+          "--title",
+          "T",
+          "--assignee",
+          "octocat",
+          "--assignee",
+          "hubot",
+          "--reviewer",
+          "alice",
+          "--reviewer",
+          "bob",
+        ],
+        ctx,
+      );
+
+      expect(mockedGhExec.mock.calls[0][0]).toEqual([
+        "pr",
+        "create",
+        "--title",
+        "T",
+        "--assignee",
+        "octocat",
+        "--assignee",
+        "hubot",
+        "--reviewer",
+        "alice",
+        "--reviewer",
+        "bob",
+      ]);
     });
   });
 


### PR DESCRIPTION
## What Changed

- Reworked `src/args.ts` flag collection: `getAllFlags` and a new consuming `takeAllFlags` now share a `collectAllFlags` core, and a new `pushRepeated` helper appends a flag once per value onto the `gh` argv. A repeated flag with a dangling (`--add-label` with nothing after it) or blank (`--add-label=`) value now throws a `VALIDATION_ERROR` instead of being silently dropped.
- Routed the repeatable flags on `issue`/`pr` through the new collectors so every occurrence reaches `gh`: `--add-label`/`--remove-label`/`--add-assignee`/`--remove-assignee` (plus `--add-reviewer`/`--remove-reviewer` on `pr edit`) on the edit paths, `--assignee`/`--label`/`--project` (and `--reviewer` on `pr create`) on the create paths, and `--label` on `issue list`/`pr list`. Previously only the first value of each was applied.
- Marked the affected flags `(repeatable)` in `ISSUE_HELP`/`PR_HELP`, added the previously undocumented `--project` to both `create` help lines, and documented the behavior in `README.md`, `AGENTS.md`, and the generated `skills/gh-axi/SKILL.md` (via `src/skill.ts`).

Review flagged four issues across the branch, three of which were auto-fixed in follow-up commits (extending repeatability to the list/create paths, adding `pushRepeated` to collapse the duplicated push loops, and rejecting dangling flag values); the Document stage left one pre-existing, unrelated note that `PR_HELP`'s `flags{edit}` line still omits `--base`.

## Risk Assessment

✅ Low: The change is a well-bounded argv-parsing consolidation behind one shared helper, every call site and the two untouched helper consumers were traced for ordering and index hazards, the user-visible behavior changes (repeat forwarding, empty/dangling rejection) match `gh`'s own pflag semantics, and the new tests pin exact `gh` argv arrays.

## Testing

<code>Ran the full vitest suite (29 files, 638 tests, all green) plus the targeted args/issue/pr/help-example files, then built a product-level check that unit tests can&#39;t give: a stub `gh` on PATH recording the exact argv gh-axi forwards, driven by the real CLI entrypoint against both the base commit and the branch. The resulting transcript shows the bug concretely — before, `issue edit --add-label bug --add-label triage` reached `gh` as a single `--add-label bug`; after, every repeated label, assignee, reviewer and project flag is forwarded across issue/pr edit, create and list, dangling or empty values now fail with `--&lt;flag&gt; requires a value` / VALIDATION_ERROR at exit 2 instead of being silently dropped at exit 0, and the help text advertises which flags are repeatable. No regressions found and the worktree was left clean (temp base checkout removed).</code>

<details>
<summary>Evidence: Before/after CLI transcript: what the wrapped `gh` actually receives</summary>

<code>$ gh-axi issue edit 276 --add-label bug --add-label triage --remove-label stale --remove-label wontfix --add-assignee alice --add-assignee bob -R acme/widgets&#10;BEFORE (291fc1af) — gh received:&#10;gh issue edit 276 --add-label bug --remove-label stale --add-assignee alice --repo acme/widgets&#10;AFTER (3ea8b2d) — gh received:&#10;gh issue edit 276 --add-label bug --add-label triage --remove-label stale --remove-label wontfix --add-assignee alice --add-assignee bob --repo acme/widgets&#10;&#10;$ gh-axi pr edit 482 --add-label bug --add-label triage --add-reviewer alice --add-reviewer bob --remove-assignee carol --remove-assignee dave -R acme/widgets&#10;BEFORE (291fc1af) — gh received:&#10;gh pr edit 482 --add-label bug --remove-assignee carol --add-reviewer alice --repo acme/widgets&#10;AFTER (3ea8b2d) — gh received:&#10;gh pr edit 482 --add-label bug --add-label triage --remove-assignee carol --remove-assignee dave --add-reviewer alice --add-reviewer bob --repo acme/widgets&#10;&#10;$ gh-axi issue list --label bug --label p1 -R acme/widgets&#10;BEFORE (291fc1af) — gh received:&#10;gh issue list --json number,title,state,author,createdAt --limit 30 --label bug --repo acme/widgets&#10;AFTER (3ea8b2d) — gh received:&#10;gh issue list --json number,title,state,author,createdAt --limit 30 --label bug --label p1 --repo acme/widgets&#10;&#10;$ gh-axi pr edit 482 --add-reviewer= -R acme/widgets&#10;BEFORE (291fc1af) — gh received:&#10;gh pr edit 482 --repo acme/widgets&#10;AFTER (3ea8b2d) — gh received:&#10;exit 2&#10;error: &#34;--add-reviewer requires a value&#34;&#10;code: VALIDATION_ERROR&#10;&#10;$ gh-axi issue edit 276 --add-label bug --add-label triage --add-label p1 -R acme/widgets&#10;issue:&#10;number: 276&#10;title: Flaky checkout test&#10;state: open&#10;labels: &#34;bug,triage,p1&#34;&#10;assignees: &#34;alice,bob&#34;&#10;help[1]:&#10;Run `gh-axi issue view 276 -R acme/widgets` to see updated issue&#10;&#10;(underlying call: gh issue edit 276 --add-label bug --add-label triage --add-label p1 --repo acme/widgets)</code>

```text
===================================================================
 gh-axi repeatable-flag fix — end-to-end CLI transcript
===================================================================
A stub `gh` on PATH records the exact argv gh-axi hands to it, so each
block shows what the real GitHub CLI would have been asked to do.
Repo context pinned with -R acme/widgets.

### 1. Repeated flags are now all forwarded (issue #75)

────────────────────────────────────────────────────────────────────
$ gh-axi issue edit 276 --add-label bug --add-label triage --remove-label stale --remove-label wontfix --add-assignee alice --add-assignee bob -R acme/widgets
  # two --add-label, two --remove-label, two --add-assignee
  BEFORE (291fc1af) — gh received:
      gh issue edit 276 --add-label bug --remove-label stale --add-assignee alice --repo acme/widgets
  AFTER  (3ea8b2d)  — gh received:
      gh issue edit 276 --add-label bug --add-label triage --remove-label stale --remove-label wontfix --add-assignee alice --add-assignee bob --repo acme/widgets

────────────────────────────────────────────────────────────────────
$ gh-axi pr edit 482 --add-label bug --add-label triage --add-reviewer alice --add-reviewer bob --remove-assignee carol --remove-assignee dave -R acme/widgets
  # two --add-label, two --add-reviewer, two --remove-assignee
  BEFORE (291fc1af) — gh received:
      gh pr edit 482 --add-label bug --remove-assignee carol --add-reviewer alice --repo acme/widgets
  AFTER  (3ea8b2d)  — gh received:
      gh pr edit 482 --add-label bug --add-label triage --remove-assignee carol --remove-assignee dave --add-reviewer alice --add-reviewer bob --repo acme/widgets

────────────────────────────────────────────────────────────────────
$ gh-axi issue create --title Flaky checkout test --assignee alice --assignee bob --label bug --label p1 --project Roadmap --project Q3 -R acme/widgets
  # repeated --assignee / --label / --project on create
  BEFORE (291fc1af) — gh received:
      gh issue create --title Flaky\ checkout\ test --assignee alice --label bug --label p1 --project Roadmap --repo acme/widgets
  AFTER  (3ea8b2d)  — gh received:
      gh issue create --title Flaky\ checkout\ test --assignee alice --assignee bob --label bug --label p1 --project Roadmap --project Q3 --repo acme/widgets

────────────────────────────────────────────────────────────────────
$ gh-axi pr create --title Fix flaky checkout --reviewer alice --reviewer bob --assignee carol --label bug --label p1 --project Roadmap -R acme/widgets
  # repeated --reviewer / --assignee / --label / --project on create
  BEFORE (291fc1af) — gh received:
      gh pr create --title Fix\ flaky\ checkout --assignee carol --reviewer alice --label bug --label p1 --project Roadmap --repo acme/widgets
  AFTER  (3ea8b2d)  — gh received:
      gh pr create --title Fix\ flaky\ checkout --assignee carol --reviewer alice --reviewer bob --label bug --label p1 --project Roadmap --repo acme/widgets

────────────────────────────────────────────────────────────────────
$ gh-axi issue list --label bug --label p1 -R acme/widgets
  # repeated --label filter on list
  BEFORE (291fc1af) — gh received:
      gh issue list --json number,title,state,author,createdAt --limit 30 --label bug --repo acme/widgets
  AFTER  (3ea8b2d)  — gh received:
      gh issue list --json number,title,state,author,createdAt --limit 30 --label bug --label p1 --repo acme/widgets

────────────────────────────────────────────────────────────────────
$ gh-axi pr list --label bug --label p1 -R acme/widgets
  # repeated --label filter on list
  BEFORE (291fc1af) — gh received:
      gh pr list --json number,title,state,author,isDraft,reviewDecision --state open --limit 30 --label bug --repo acme/widgets
  AFTER  (3ea8b2d)  — gh received:
      gh pr list --json number,title,state,author,isDraft,reviewDecision --state open --limit 30 --label bug --label p1 --repo acme/widgets

────────────────────────────────────────────────────────────────────
$ gh-axi issue edit 276 --add-label=bug --add-label triage --add-label=p1 -R acme/widgets
  # mixed --flag=value and --flag value forms on one command
  BEFORE (291fc1af) — gh received:
      gh issue edit 276 --add-label bug --repo acme/widgets
  AFTER  (3ea8b2d)  — gh received:
      gh issue edit 276 --add-label bug --add-label triage --add-label p1 --repo acme/widgets

### 2. Dangling / empty repeatable flags now fail loudly instead of silently dropping

────────────────────────────────────────────────────────────────────
$ gh-axi issue edit 276 --add-label bug --add-label -R acme/widgets
  # trailing --add-label with no value
  BEFORE (291fc1af) — gh received:
      gh issue edit 276 --add-label bug --repo acme/widgets
  AFTER  (3ea8b2d)  — gh received:
      exit 2
      error: "--add-label requires a value"
      code: VALIDATION_ERROR

────────────────────────────────────────────────────────────────────
$ gh-axi pr edit 482 --add-reviewer= -R acme/widgets
  # empty --add-reviewer= value
  BEFORE (291fc1af) — gh received:
      gh pr edit 482 --repo acme/widgets
  AFTER  (3ea8b2d)  — gh received:
      exit 2
      error: "--add-reviewer requires a value"
      code: VALIDATION_ERROR

────────────────────────────────────────────────────────────────────
$ gh-axi issue create --title T --label     -R acme/widgets
  # whitespace-only --label value on create
  BEFORE (291fc1af) — gh received:
      gh issue create --title T --label \ \ \  --repo acme/widgets
  AFTER  (3ea8b2d)  — gh received:
      exit 2
      error: "--label requires a value"
      code: VALIDATION_ERROR

### 3. What the operator actually sees on a successful multi-label edit (AFTER)

$ gh-axi issue edit 276 --add-label bug --add-label triage --add-label p1 -R acme/widgets
  issue:
    number: 276
    title: Flaky checkout test
    state: open
    labels: "bug,triage,p1"
    assignees: "alice,bob"
  help[1]:
    Run `gh-axi issue view 276 -R acme/widgets` to see updated issue

  (underlying call: gh issue edit 276 --add-label bug --add-label triage --add-label p1 --repo acme/widgets)

### 4. Help text now documents which flags are repeatable (AFTER)

  flags{list}:
    --state <open|closed|all>, --label <name> (repeatable), --assignee <login>, --author <login>, --milestone <name>, --sort <created|updated|comments>, --limit <n> (default 30), --fields <a,b,c>
  flags{view}:
    --comments, --full (show complete body without truncation)
  flags{create}:
    --title <text> (required), --body <text> or --body-file <path>, --assignee <login> (repeatable), --label <name> (repeatable), --milestone <name>, --project <name> (repeatable), --type <name>
  flags{edit}:
    --title, --body <text> or --body-file <path>, --add-label <name> (repeatable), --remove-label <name> (repeatable), --add-assignee <login> (repeatable), --remove-assignee <login> (repeatable), --milestone, --type <name>, --no-type
  flags{close}:
```
</details>
<details>
<summary>Evidence: Stub `gh` used to record forwarded argv (evidence harness, not source)</summary>

```text
#!/usr/bin/env bash
# Fake `gh` used only for evidence capture: records the exact argv gh-axi passes
# through, then returns canned JSON so gh-axi renders its normal output.
{
  printf 'gh'
  for a in "$@"; do printf ' %q' "$a"; done
  printf '\n'
} >> "$GH_ARGV_LOG"

case "$1 $2" in
  "issue edit"|"pr edit") exit 0 ;;
  "issue create") echo "https://github.com/acme/widgets/issues/276"; exit 0 ;;
  "pr create")    echo "https://github.com/acme/widgets/pull/482";  exit 0 ;;
  "issue view")
    echo '{"number":276,"title":"Flaky checkout test","state":"OPEN","id":"I_kw1","labels":[{"name":"bug"},{"name":"triage"},{"name":"p1"}],"assignees":[{"login":"alice"},{"login":"bob"}]}'
    exit 0 ;;
  "pr view")
    echo '{"number":482,"title":"Fix flaky checkout","state":"OPEN","labels":[{"name":"bug"},{"name":"triage"}],"assignees":[{"login":"alice"}],"reviewGroups":[]}'
    exit 0 ;;
  "issue list")
    echo '[{"number":276,"title":"Flaky checkout test","state":"OPEN","labels":[{"name":"bug"},{"name":"p1"}],"assignees":[],"createdAt":"2026-07-20T10:00:00Z","updatedAt":"2026-07-20T10:00:00Z","author":{"login":"alice"}}]'
    exit 0 ;;
  *) echo '[]'; exit 0 ;;
esac
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (3) ✅</summary>

- ⚠️ `src/commands/pr.ts:491` - `prEdit` previously drained every flag from `args` via the consuming `takeFlag`; the six add/remove flags now use the non-consuming `getAllFlags`, so their flag/value pairs stay in `args` while `--milestone` and `--base` are still parsed with the consuming `takeFlag` afterwards. Nothing inspects leftover args today, so there is no behavioral bug now — but the function silently violates the file&#39;s take-*/consume convention, and any future leftover-arg or unknown-flag validation added to this path would immediately reject every `--add-label`/`--add-assignee`/`--add-reviewer` invocation. Suggest adding a consuming `takeAllFlags` to src/args.ts and using it here (issue.ts&#39;s `editIssue` is consistent, since it already parses with the non-consuming `getFlag`).
- ℹ️ `src/commands/pr.ts:503` - The same `for (const v of values) ghArgs.push(flag, v)` loop is written ten times across `prEdit` (6x, src/commands/pr.ts:503-511) and `editIssue` (4x, src/commands/issue.ts:556-561), with two of them wrapped awkwardly by the formatter. A one-line helper — e.g. `pushRepeated(ghArgs, &#34;--add-label&#34;, addLabels)` in src/args.ts, or iterating a `[flag, values]` pair list — collapses all ten call sites and makes adding the next repeatable flag a single line. Purely non-functional.
- ℹ️ `src/commands/pr.ts:453` - The same silent-drop bug class remains on the create paths: `pr create --assignee`/`--reviewer` (src/commands/pr.ts:453-454) and `issue create --assignee` (src/commands/issue.ts:477) use `takeFlag`/`getFlag`, so a second occurrence is silently discarded even though `gh` accepts repeats for all three. `--label` was already fixed there. This now reads as inconsistent: `edit --add-assignee` is repeatable but `create --assignee` is not, with no error to tell the user which is which. Out of the stated scope of this fix (issue #75 is edit-only), so confirm whether extending it is wanted before changing user-facing behavior.
- ℹ️ `test/commands/pr.test.ts:473` - The new tests assert `callArgs.filter(a =&gt; a === &#34;--add-label&#34;).length` plus `toContain(value)` separately, which cannot detect mis-pairing or ordering — an implementation emitting `[&#34;--add-label&#34;, &#34;--add-label&#34;, &#34;bug&#34;, &#34;ready-for-agent&#34;]` passes every assertion while producing a command `gh` would reject. Asserting the full expected `ghArgs` array with `toEqual` (or at least the contiguous `[flag, value]` slices) would pin the actual contract these tests exist to protect. Same pattern in test/commands/issue.test.ts:481-587.

🔧 Fix: make repeated assignee, reviewer and label flags repeatable everywhere
3 infos still open:
- ℹ️ `src/commands/issue.ts:226` - The commit subject says these flags are now repeatable &#34;everywhere&#34;, but four sites of the same silent-drop bug class remain, all for flags `gh` declares as repeatable (`strings`) slices: `issue list --label` (src/commands/issue.ts:226), `pr list --label` (src/commands/pr.ts:293), `issue create --project` (src/commands/issue.ts:481) and `pr create --project` (src/commands/pr.ts:463) all use `getFlag`/`takeFlag`, so a second occurrence is discarded with no error. The list case is the more visible one now: after this change `gh-axi issue create --label a --label b` applies both labels while `gh-axi issue list --label a --label b` silently filters on `a` only, and the help text (`flags{list}` vs `flags{create}`) makes the asymmetry visible without explaining it. Out of the stated scope of issue #75, so confirm before changing user-facing filter/create behavior.
- ℹ️ `src/args.ts:91` - `pushRepeated` has no truthiness guard, whereas the `if (addLabel) ghArgs.push(...)` lines it replaced did. So `--add-label=`, `--add-assignee=`, `--reviewer=` etc. (explicit empty value) now reach `gh` as an empty argument and fail there, where they were previously dropped silently — and in `editIssue` an empty-only edit previously short-circuited entirely via the `ghArgs.length &gt; 3` guard (src/commands/issue.ts:560) and made no `gh` call at all. Failing loudly is arguably the better behavior and matches the repo&#39;s defensive style, but it is an undocumented, untested behavior change; if it is intended, a test pinning it would be worth having, otherwise filter empties in `collectAllFlags`.
- ℹ️ `src/args.ts:65` - `collectAllFlags` skips a trailing flag with no value (`i + 1 &lt; args.length` fails) and, in consume mode, leaves it in `args` — test/args.test.ts:171 pins this (`expect(args).toEqual([&#34;--label&#34;])`). `takeFlag` by contrast splices the dangling flag out and returns `undefined`. I verified this is inert today: nothing in `src/cli.ts` or the pr/issue command bodies inspects leftover args, and `takeNumber` runs before every `takeAllFlags` call in `prEdit`, so the residue can never be misread as a PR number. Noting it only because the divergence from `takeFlag`&#39;s contract is now enshrined in a test; no action needed.

🔧 Fix: make list/create label and project flags repeatable, reject empty values
4 issues (1 warning, 3 infos) still open:
- ⚠️ `src/args.ts:71` - `collectAllFlags`&#39;s `arg === flag &amp;&amp; i + 1 &lt; args.length` guard skips a trailing flag that has no following value, so it is silently discarded. Concretely, `gh-axi issue edit 276 --add-label` (value forgotten) produces `addLabels = []`, leaving `ghArgs.length === 3`, which fails the `if (ghArgs.length &gt; 3)` guard at src/commands/issue.ts:565 — no `gh` call is made at all, yet the command still renders a successful `edited` detail block. `gh-axi pr edit 5 --add-label` likewise emits a bare `gh pr edit 5`. This is the same silent-drop class issue #75 was filed about, and it now directly contradicts the intent of this commit: `--add-label=` throws `--add-label requires a value`, while `--add-label` (the more likely typo) succeeds as a no-op. Making the dangling case throw the same VALIDATION_ERROR would close it, but test/args.test.ts:171 deliberately pins the current behavior (`expect(args).toEqual([&#34;--label&#34;])`), so confirm the intent before changing it.
- ℹ️ `src/args.ts:56` - `requireFlagValue` only guards flags routed through `getAllFlags`/`takeAllFlags`. On the very same command, sibling flags still parsed with `getFlag`/`takeFlag` keep the old silent-drop behavior: `gh-axi issue list --label=` now errors, while `gh-axi issue list --assignee=` / `--author=` / `--milestone=` are silently ignored by the `if (assignee)` guards at src/commands/issue.ts:249-251 (same for `pr list` at src/commands/pr.ts:316-319). Users get two different responses to the identical mistake with no way to predict which. Either route the single-value flags through the same validation or accept the asymmetry deliberately.
- ℹ️ `src/commands/api.ts:59` - The new `requireFlagValue` throw applies to every `getAllFlags` caller, including two command families untouched by this diff: `api --field`/`--header` (src/commands/api.ts:59,64) and `workflow run --field` (src/commands/workflow.ts:97). `gh-axi api repos/o/r --field=` and `gh-axi workflow run x --field &#34;&#34;` now fail with `--field requires a value` where they previously forwarded an empty string. I checked those values are `key=value`-shaped in practice, so the change is benign and arguably correct, and no existing test asserts the old behavior — noting it only because the commit message scopes the change to label/assignee/reviewer/project flags.
- ℹ️ `src/commands/issue.ts:481` - `--project` was made repeatable on both create paths (src/commands/issue.ts:481 and src/commands/pr.ts:463) with dedicated tests, but it appears in neither `ISSUE_HELP`&#39;s `flags{create}` nor `PR_HELP`&#39;s `flags{create}` — and this same diff added `(repeatable)` annotations to every other flag on those lines. For an agent-ergonomic CLI whose help output is the discovery surface, a supported-and-now-tested flag that no help text mentions is effectively invisible. Pre-existing gap, but this change is the natural moment to close it.

🔧 Fix: reject dangling repeatable flags, document --project on create
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm test` — full suite, 29 files / 638 tests passing, including `test/skill.test.ts` (SKILL.md regen sync) and `test/help-examples.test.ts` (help-text guards)</code>
- <code>`npx vitest run test/args.test.ts test/commands/issue.test.ts test/commands/pr.test.ts test/help-examples.test.ts` — targeted files carrying the new repeatable-flag cases</code>
- <code>Manual end-to-end: stub `gh` placed first on PATH recording its argv; ran `tsx bin/gh-axi.ts issue edit 276 --add-label bug --add-label triage --remove-label stale --remove-label wontfix --add-assignee alice --add-assignee bob -R acme/widgets` against both base commit 291fc1af and branch 3ea8b2d</code>
- <code>Manual end-to-end same before/after for `pr edit 482 --add-label ... --add-reviewer ... --remove-assignee ...`, `issue create --assignee/--label/--project repeated`, `pr create --reviewer/--label/--project repeated`, `issue list --label bug --label p1`, `pr list --label bug --label p1`</code>
- <code>Manual end-to-end mixed-form check: `issue edit 276 --add-label=bug --add-label triage --add-label=p1`</code>
- <code>Manual validation checks: `issue edit 276 --add-label bug --add-label` (dangling), `pr edit 482 --add-reviewer=` (empty), `issue create --title T --label &#34; &#34;` (whitespace-only) — all now exit 2 with VALIDATION_ERROR</code>
- <code>`gh-axi issue --help` rendered to confirm the (repeatable) annotations users now see</code>
- <code>`grep -rn &#34;nknown flag&#34; src/` to confirm the new consuming `takeAllFlags` cannot break leftover-arg validation (only `secret.ts` does that, untouched)</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `src/commands/pr.ts:258` - Pre-existing and unrelated to this change: `prEdit` accepts `--base` (src/commands/pr.ts:504,516) but PR_HELP&#39;s `flags{edit}` line never lists it, so `gh-axi pr --help` hides a supported flag. Left unfixed to keep this pass scoped to the repeatable-flag change; a maintainer should decide whether to append `--base &lt;branch&gt;` to that help line.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
