### PR TITLE
fix(commands): count filtered issue and pr lists through search

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The label, assignee, reviewer, and project flags of `issue create`/`edit` and `p
 A repeated flag with a missing or empty value (`--add-label` with nothing after it, or `--add-label=`) fails with a validation error instead of being silently dropped.
 
 In `gh-axi issue list` and `gh-axi pr list`, the `count: N of M total` line counts only what the filters you passed (`--label`, `--assignee`, `--author`, and the other list filters) match, not every issue or PR in the repository.
-When a total cannot be expressed faithfully — notably a numeric `--milestone`, since search matches milestone titles only — gh-axi omits it and falls back to `showing first N` rather than printing a number that does not match the query.
+When a total cannot be expressed faithfully — a numeric `--milestone`, since search matches milestone titles only, or a filter value containing a double quote, which search has no way to escape — gh-axi omits it and falls back to `showing first N` rather than printing a number that does not match the query.
 
 Long `run view --log` and `run view --log-failed` output shows the last 20,000 characters so CI failures stay visible.
 When truncation happens, gh-axi best-effort saves the complete log to a temp file, includes it as `full_log`, and prints a `help:` hint telling agents to grep that file for earlier context.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ The label, assignee, reviewer, and project flags of `issue create`/`edit` and `p
 `issue list` and `pr list` accept repeated `--label` filters the same way.
 A repeated flag with a missing or empty value (`--add-label` with nothing after it, or `--add-label=`) fails with a validation error instead of being silently dropped.
 
+In `gh-axi issue list` and `gh-axi pr list`, the `count: N of M total` line counts only what the filters you passed (`--label`, `--assignee`, `--author`, and the other list filters) match, not every issue or PR in the repository.
+When a total cannot be expressed faithfully — notably a numeric `--milestone`, since search matches milestone titles only — gh-axi omits it and falls back to `showing first N` rather than printing a number that does not match the query.
+
 Long `run view --log` and `run view --log-failed` output shows the last 20,000 characters so CI failures stay visible.
 When truncation happens, gh-axi best-effort saves the complete log to a temp file, includes it as `full_log`, and prints a `help:` hint telling agents to grep that file for earlier context.
 `gh-axi run` manages existing workflow runs; use `gh-axi workflow run <name> --ref <ref>` to trigger (dispatch) a workflow.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ A repeated flag with a missing or empty value (`--add-label` with nothing after 
 
 In `gh-axi issue list` and `gh-axi pr list`, the `count: N of M total` line counts only what the filters you passed (`--label`, `--assignee`, `--author`, and the other list filters) match, not every issue or PR in the repository.
 When a total cannot be expressed faithfully — a numeric `--milestone`, since search matches milestone titles only, or a filter value containing a double quote, which search has no way to escape — gh-axi omits it and falls back to `showing first N` rather than printing a number that does not match the query.
+A total smaller than the page it accompanies is dropped the same way, since GitHub's search index lags behind freshly created issues and pull requests and can undercount them.
 
 Long `run view --log` and `run view --log-failed` output shows the last 20,000 characters so CI failures stay visible.
 When truncation happens, gh-axi best-effort saves the complete log to a temp file, includes it as `full_log`, and prints a `help:` hint telling agents to grep that file for earlier context.

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -17,6 +17,11 @@ import { takeBody, truncateBody } from "../body.js";
 import { parseFields, type ExtraFieldSpec } from "../fields.js";
 import { formatCountLine } from "../format.js";
 import {
+  fetchSearchTotal,
+  searchQualifier,
+  stateQualifiers,
+} from "../totals.js";
+import {
   field,
   pluck,
   joinArray,
@@ -257,16 +262,39 @@ async function listIssues(args: string[], ctx?: RepoContext): Promise<string> {
   // If we hit the limit, fetch the true totalCount via GraphQL
   let totalCount: number | undefined;
   if (items.length === limit && ctx) {
-    try {
-      const ghState = (state ?? "open").toUpperCase();
-      const query = `{ repository(owner:"${ctx.owner}", name:"${ctx.name}") { issues(states:[${ghState}]) { totalCount } } }`;
-      const gqlResult = await ghRaw(["api", "graphql", "-f", `query=${query}`]);
-      if (gqlResult.exitCode === 0) {
-        const parsed = JSON.parse(gqlResult.stdout);
-        totalCount = parsed?.data?.repository?.issues?.totalCount ?? undefined;
+    const filters: string[] = [];
+    if (label) filters.push(searchQualifier("label", label));
+    if (assignee) filters.push(searchQualifier("assignee", assignee));
+    if (author) filters.push(searchQualifier("author", author));
+    if (milestone) filters.push(searchQualifier("milestone", milestone));
+
+    if (filters.length > 0) {
+      // Filtered listings must be counted through search; repository.issues
+      // totalCount ignores these filters and would report the repo-wide total.
+      totalCount = await fetchSearchTotal([
+        `repo:${ctx.nwo}`,
+        "is:issue",
+        ...stateQualifiers(state),
+        ...filters,
+      ]);
+    } else {
+      try {
+        const ghState = (state ?? "open").toUpperCase();
+        const query = `{ repository(owner:"${ctx.owner}", name:"${ctx.name}") { issues(states:[${ghState}]) { totalCount } } }`;
+        const gqlResult = await ghRaw([
+          "api",
+          "graphql",
+          "-f",
+          `query=${query}`,
+        ]);
+        if (gqlResult.exitCode === 0) {
+          const parsed = JSON.parse(gqlResult.stdout);
+          totalCount =
+            parsed?.data?.repository?.issues?.totalCount ?? undefined;
+        }
+      } catch {
+        // fall back to limit-based message
       }
-    } catch {
-      // fall back to limit-based message
     }
   }
   const countLine = formatCountLine({ count: items.length, limit, totalCount });

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -17,12 +17,9 @@ import { takeBody, truncateBody } from "../body.js";
 import { parseFields, type ExtraFieldSpec } from "../fields.js";
 import { formatCountLine } from "../format.js";
 import {
-  fetchRepositoryTotal,
-  fetchSearchTotal,
+  fetchListTotal,
   isSearchableMilestone,
-  searchQualifier,
-  searchQualifiers,
-  stateQualifiers,
+  type ListFilter,
 } from "../totals.js";
 import {
   field,
@@ -268,24 +265,13 @@ async function listIssues(args: string[], ctx?: RepoContext): Promise<string> {
   // can be counted for it — no total beats a wrong one.
   const countable = !milestone || isSearchableMilestone(milestone);
   if (items.length === limit && ctx && countable) {
-    const filters: string[] = [];
-    if (label) filters.push(...searchQualifiers("label", label));
-    if (assignee) filters.push(searchQualifier("assignee", assignee));
-    if (author) filters.push(searchQualifier("author", author));
-    if (milestone) filters.push(searchQualifier("milestone", milestone));
+    const filters: ListFilter[] = [];
+    if (label) filters.push({ key: "label", value: label, list: true });
+    if (assignee) filters.push({ key: "assignee", value: assignee });
+    if (author) filters.push({ key: "author", value: author });
+    if (milestone) filters.push({ key: "milestone", value: milestone });
 
-    if (filters.length > 0) {
-      // Filtered listings must be counted through search; repository.issues
-      // totalCount ignores these filters and would report the repo-wide total.
-      totalCount = await fetchSearchTotal([
-        `repo:${ctx.nwo}`,
-        "is:issue",
-        ...stateQualifiers(state),
-        ...filters,
-      ]);
-    } else {
-      totalCount = await fetchRepositoryTotal(ctx, "issues", state);
-    }
+    totalCount = await fetchListTotal(ctx, "issues", state, filters);
   }
   const countLine = formatCountLine({ count: items.length, limit, totalCount });
 

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -267,7 +267,8 @@ async function listIssues(args: string[], ctx?: RepoContext): Promise<string> {
   const countable = !milestone || isSearchableMilestone(milestone);
   if (items.length === limit && ctx && countable) {
     const filters: ListFilter[] = [];
-    if (label) filters.push({ key: "label", value: label, list: true });
+    for (const label of labels)
+      filters.push({ key: "label", value: label, list: true });
     if (assignee) filters.push({ key: "assignee", value: assignee });
     if (author) filters.push({ key: "author", value: author });
     if (milestone) filters.push({ key: "milestone", value: milestone });

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -17,8 +17,11 @@ import { takeBody, truncateBody } from "../body.js";
 import { parseFields, type ExtraFieldSpec } from "../fields.js";
 import { formatCountLine } from "../format.js";
 import {
+  fetchRepositoryTotal,
   fetchSearchTotal,
+  isSearchableMilestone,
   searchQualifier,
+  searchQualifiers,
   stateQualifiers,
 } from "../totals.js";
 import {
@@ -261,9 +264,12 @@ async function listIssues(args: string[], ctx?: RepoContext): Promise<string> {
 
   // If we hit the limit, fetch the true totalCount via GraphQL
   let totalCount: number | undefined;
-  if (items.length === limit && ctx) {
+  // A milestone number cannot be expressed as a search qualifier, so no total
+  // can be counted for it — no total beats a wrong one.
+  const countable = !milestone || isSearchableMilestone(milestone);
+  if (items.length === limit && ctx && countable) {
     const filters: string[] = [];
-    if (label) filters.push(searchQualifier("label", label));
+    if (label) filters.push(...searchQualifiers("label", label));
     if (assignee) filters.push(searchQualifier("assignee", assignee));
     if (author) filters.push(searchQualifier("author", author));
     if (milestone) filters.push(searchQualifier("milestone", milestone));
@@ -278,23 +284,7 @@ async function listIssues(args: string[], ctx?: RepoContext): Promise<string> {
         ...filters,
       ]);
     } else {
-      try {
-        const ghState = (state ?? "open").toUpperCase();
-        const query = `{ repository(owner:"${ctx.owner}", name:"${ctx.name}") { issues(states:[${ghState}]) { totalCount } } }`;
-        const gqlResult = await ghRaw([
-          "api",
-          "graphql",
-          "-f",
-          `query=${query}`,
-        ]);
-        if (gqlResult.exitCode === 0) {
-          const parsed = JSON.parse(gqlResult.stdout);
-          totalCount =
-            parsed?.data?.repository?.issues?.totalCount ?? undefined;
-        }
-      } catch {
-        // fall back to limit-based message
-      }
+      totalCount = await fetchRepositoryTotal(ctx, "issues", state);
     }
   }
   const countLine = formatCountLine({ count: items.length, limit, totalCount });

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -259,7 +259,8 @@ async function listIssues(args: string[], ctx?: RepoContext): Promise<string> {
   const items = await ghJson<IssueListItem[]>(ghArgs, ctx);
   const isEmpty = items.length === 0;
 
-  // If we hit the limit, fetch the true totalCount via GraphQL
+  // Only a page truncated by the limit needs a total; a short page already
+  // shows every match.
   let totalCount: number | undefined;
   // A milestone number cannot be expressed as a search qualifier, so no total
   // can be counted for it — no total beats a wrong one.

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -4,6 +4,11 @@ import { ghJson, ghExec, ghRaw } from "../gh.js";
 import { AxiError } from "../errors.js";
 import { takeBody, truncateBody } from "../body.js";
 import { formatCountLine } from "../format.js";
+import {
+  fetchSearchTotal,
+  searchQualifier,
+  stateQualifiers,
+} from "../totals.js";
 import { getSuggestions } from "../suggestions.js";
 import {
   takeFlag,
@@ -326,21 +331,45 @@ async function prList(args: string[], ctx?: RepoContext): Promise<string> {
   // If we hit the limit, fetch the true totalCount via GraphQL
   let totalCount: number | undefined;
   if (items.length === limitNum && ctx) {
-    try {
-      const ghState = state.toUpperCase();
-      const statesFilter =
-        ghState === "ALL"
-          ? ""
-          : `states:[${ghState === "CLOSED" ? "CLOSED,MERGED" : ghState}]`;
-      const query = `{ repository(owner:"${ctx.owner}", name:"${ctx.name}") { pullRequests(${statesFilter}) { totalCount } } }`;
-      const gqlResult = await ghRaw(["api", "graphql", "-f", `query=${query}`]);
-      if (gqlResult.exitCode === 0) {
-        const parsed = JSON.parse(gqlResult.stdout);
-        totalCount =
-          parsed?.data?.repository?.pullRequests?.totalCount ?? undefined;
+    const filters: string[] = [];
+    if (label) filters.push(searchQualifier("label", label));
+    if (assignee) filters.push(searchQualifier("assignee", assignee));
+    if (author) filters.push(searchQualifier("author", author));
+    if (base) filters.push(searchQualifier("base", base));
+    if (head) filters.push(searchQualifier("head", head));
+    if (draft) filters.push("draft:true");
+
+    if (filters.length > 0) {
+      // Filtered listings must be counted through search; pullRequests
+      // totalCount cannot express assignee, author or draft at all.
+      totalCount = await fetchSearchTotal([
+        `repo:${ctx.nwo}`,
+        "is:pr",
+        ...stateQualifiers(state),
+        ...filters,
+      ]);
+    } else {
+      try {
+        const ghState = state.toUpperCase();
+        const statesFilter =
+          ghState === "ALL"
+            ? ""
+            : `states:[${ghState === "CLOSED" ? "CLOSED,MERGED" : ghState}]`;
+        const query = `{ repository(owner:"${ctx.owner}", name:"${ctx.name}") { pullRequests(${statesFilter}) { totalCount } } }`;
+        const gqlResult = await ghRaw([
+          "api",
+          "graphql",
+          "-f",
+          `query=${query}`,
+        ]);
+        if (gqlResult.exitCode === 0) {
+          const parsed = JSON.parse(gqlResult.stdout);
+          totalCount =
+            parsed?.data?.repository?.pullRequests?.totalCount ?? undefined;
+        }
+      } catch {
+        // fall back to limit-based message
       }
-    } catch {
-      // fall back to limit-based message
     }
   }
   const countLine = formatCountLine({

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -324,7 +324,8 @@ async function prList(args: string[], ctx?: RepoContext): Promise<string> {
   const isEmpty = items.length === 0;
   const limitNum = Number(limit);
 
-  // If we hit the limit, fetch the true totalCount via GraphQL
+  // Only a page truncated by the limit needs a total; a short page already
+  // shows every match.
   let totalCount: number | undefined;
   if (items.length === limitNum && ctx) {
     const filters: ListFilter[] = [];

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -5,8 +5,10 @@ import { AxiError } from "../errors.js";
 import { takeBody, truncateBody } from "../body.js";
 import { formatCountLine } from "../format.js";
 import {
+  fetchRepositoryTotal,
   fetchSearchTotal,
   searchQualifier,
+  searchQualifiers,
   stateQualifiers,
 } from "../totals.js";
 import { getSuggestions } from "../suggestions.js";
@@ -332,7 +334,7 @@ async function prList(args: string[], ctx?: RepoContext): Promise<string> {
   let totalCount: number | undefined;
   if (items.length === limitNum && ctx) {
     const filters: string[] = [];
-    if (label) filters.push(searchQualifier("label", label));
+    if (label) filters.push(...searchQualifiers("label", label));
     if (assignee) filters.push(searchQualifier("assignee", assignee));
     if (author) filters.push(searchQualifier("author", author));
     if (base) filters.push(searchQualifier("base", base));
@@ -349,27 +351,7 @@ async function prList(args: string[], ctx?: RepoContext): Promise<string> {
         ...filters,
       ]);
     } else {
-      try {
-        const ghState = state.toUpperCase();
-        const statesFilter =
-          ghState === "ALL"
-            ? ""
-            : `states:[${ghState === "CLOSED" ? "CLOSED,MERGED" : ghState}]`;
-        const query = `{ repository(owner:"${ctx.owner}", name:"${ctx.name}") { pullRequests(${statesFilter}) { totalCount } } }`;
-        const gqlResult = await ghRaw([
-          "api",
-          "graphql",
-          "-f",
-          `query=${query}`,
-        ]);
-        if (gqlResult.exitCode === 0) {
-          const parsed = JSON.parse(gqlResult.stdout);
-          totalCount =
-            parsed?.data?.repository?.pullRequests?.totalCount ?? undefined;
-        }
-      } catch {
-        // fall back to limit-based message
-      }
+      totalCount = await fetchRepositoryTotal(ctx, "pullRequests", state);
     }
   }
   const countLine = formatCountLine({

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -4,13 +4,7 @@ import { ghJson, ghExec, ghRaw } from "../gh.js";
 import { AxiError } from "../errors.js";
 import { takeBody, truncateBody } from "../body.js";
 import { formatCountLine } from "../format.js";
-import {
-  fetchRepositoryTotal,
-  fetchSearchTotal,
-  searchQualifier,
-  searchQualifiers,
-  stateQualifiers,
-} from "../totals.js";
+import { fetchListTotal, type ListFilter } from "../totals.js";
 import { getSuggestions } from "../suggestions.js";
 import {
   takeFlag,
@@ -333,26 +327,15 @@ async function prList(args: string[], ctx?: RepoContext): Promise<string> {
   // If we hit the limit, fetch the true totalCount via GraphQL
   let totalCount: number | undefined;
   if (items.length === limitNum && ctx) {
-    const filters: string[] = [];
-    if (label) filters.push(...searchQualifiers("label", label));
-    if (assignee) filters.push(searchQualifier("assignee", assignee));
-    if (author) filters.push(searchQualifier("author", author));
-    if (base) filters.push(searchQualifier("base", base));
-    if (head) filters.push(searchQualifier("head", head));
-    if (draft) filters.push("draft:true");
+    const filters: ListFilter[] = [];
+    if (label) filters.push({ key: "label", value: label, list: true });
+    if (assignee) filters.push({ key: "assignee", value: assignee });
+    if (author) filters.push({ key: "author", value: author });
+    if (base) filters.push({ key: "base", value: base });
+    if (head) filters.push({ key: "head", value: head });
+    if (draft) filters.push({ key: "draft", value: "true" });
 
-    if (filters.length > 0) {
-      // Filtered listings must be counted through search; pullRequests
-      // totalCount cannot express assignee, author or draft at all.
-      totalCount = await fetchSearchTotal([
-        `repo:${ctx.nwo}`,
-        "is:pr",
-        ...stateQualifiers(state),
-        ...filters,
-      ]);
-    } else {
-      totalCount = await fetchRepositoryTotal(ctx, "pullRequests", state);
-    }
+    totalCount = await fetchListTotal(ctx, "pullRequests", state, filters);
   }
   const countLine = formatCountLine({
     count: items.length,

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -329,7 +329,8 @@ async function prList(args: string[], ctx?: RepoContext): Promise<string> {
   let totalCount: number | undefined;
   if (items.length === limitNum && ctx) {
     const filters: ListFilter[] = [];
-    if (label) filters.push({ key: "label", value: label, list: true });
+    for (const label of labels)
+      filters.push({ key: "label", value: label, list: true });
     if (assignee) filters.push({ key: "assignee", value: assignee });
     if (author) filters.push({ key: "author", value: author });
     if (base) filters.push({ key: "base", value: base });

--- a/src/format.ts
+++ b/src/format.ts
@@ -29,8 +29,10 @@ export function formatCountLine(opts: CountLineOptions): string {
     return `count: ${count}+ (GitHub search API limit reached)`;
   }
 
-  // Total count known from GraphQL or API
-  if (totalCount !== undefined && totalCount !== null) {
+  // Total count known from GraphQL or API. A total below the number of items
+  // on screen contradicts itself, so it is treated as unknown — the search
+  // index lags behind freshly created issues and can undercount.
+  if (totalCount !== undefined && totalCount !== null && totalCount >= count) {
     return `count: ${count} of ${totalCount} total`;
   }
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -3,7 +3,7 @@
  *
  * Standard phrases:
  *   count: N                                — simple count
- *   count: N of T total                     — when total is known
+ *   count: N of T total                     — when a total of at least N is known
  *   count: N (showing first N)              — when truncated by limit
  *   count: N+ (GitHub search API limit reached) — search API limit
  */

--- a/src/totals.ts
+++ b/src/totals.ts
@@ -1,0 +1,57 @@
+/**
+ * Filter-aware total counts for `issue list` and `pr list`.
+ *
+ * `repository.issues`/`repository.pullRequests` totalCount cannot express every
+ * filter these commands accept (notably assignee/author on pull requests, and
+ * `--draft` on either), so a filtered listing counted that way reports the
+ * repository-wide total and reads as though the filter matched far more than it
+ * did. The search API expresses all of them uniformly, so filtered listings are
+ * counted there instead.
+ */
+
+import { ghRaw } from "./gh.js";
+
+const SEARCH_TOTAL_QUERY =
+  "query($q: String!) { search(query: $q, type: ISSUE) { issueCount } }";
+
+/**
+ * Build a `key:"value"` search qualifier. The value is always quoted so labels
+ * and milestones containing spaces stay a single term rather than splitting
+ * into a stray free-text word.
+ */
+export function searchQualifier(key: string, value: string): string {
+  return `${key}:${JSON.stringify(value)}`;
+}
+
+/** Map a gh `--state` value onto its search qualifier; `all` has none. */
+export function stateQualifiers(state: string | undefined): string[] {
+  const normalized = (state ?? "open").toLowerCase();
+  return normalized === "all" ? [] : [`is:${normalized}`];
+}
+
+/**
+ * Total number of issues or pull requests matching every active filter.
+ *
+ * Returns undefined when the count cannot be determined, so callers fall back
+ * to the limit-based "showing first N" phrasing rather than printing a number
+ * that does not correspond to the query.
+ */
+export async function fetchSearchTotal(
+  qualifiers: string[],
+): Promise<number | undefined> {
+  try {
+    const result = await ghRaw([
+      "api",
+      "graphql",
+      "-f",
+      `query=${SEARCH_TOTAL_QUERY}`,
+      "-f",
+      `q=${qualifiers.join(" ")}`,
+    ]);
+    if (result.exitCode !== 0) return undefined;
+    const parsed = JSON.parse(result.stdout);
+    return parsed?.data?.search?.issueCount ?? undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/totals.ts
+++ b/src/totals.ts
@@ -18,10 +18,16 @@ const SEARCH_TOTAL_QUERY =
 /**
  * Build a `key:value` search qualifier.
  *
- * Values are quoted only when they contain whitespace, which keeps a label or
- * milestone with spaces a single term without stripping the meaning of search
- * sentinels such as `@me` — `assignee:"@me"` is read as a literal login and
- * matches nothing, while `assignee:@me` resolves to the current user.
+ * Values are quoted only when they contain whitespace, so a label or milestone
+ * with spaces stays a single term instead of splitting into a stray free-text
+ * word. Everything else is emitted verbatim, which keeps the qualifier byte
+ * identical to what the caller passed rather than JSON-escaped: search does not
+ * interpret `\"` or `\\` escape sequences, so quoting values that do not need it
+ * only risks mangling them.
+ *
+ * Sentinels such as `@me` survive either way — `assignee:@me` and
+ * `assignee:"@me"` both resolve to the authenticated user (verified against the
+ * live search API), so the quoting rule is about escaping, not sentinels.
  */
 export function searchQualifier(key: string, value: string): string {
   return /\s/.test(value) ? `${key}:"${value}"` : `${key}:${value}`;

--- a/src/totals.ts
+++ b/src/totals.ts
@@ -65,6 +65,20 @@ export function isSearchableMilestone(value: string): boolean {
 }
 
 /**
+ * Whether a gh flag value can be translated into a search qualifier at all.
+ *
+ * {@link searchQualifier} either wraps a value in double quotes or emits it
+ * verbatim, and search has no escape sequence for a double quote inside a
+ * quoted term, so an embedded `"` ends the term early and the rest of the value
+ * is reinterpreted as unrelated query text. The resulting count answers a
+ * different question than the listing did, so callers skip the total entirely,
+ * same as they do for a numeric milestone.
+ */
+export function isSearchableValue(value: string): boolean {
+  return !value.includes('"');
+}
+
+/**
  * Total number of issues or pull requests matching every active filter.
  *
  * Returns undefined when the count cannot be determined, so callers fall back
@@ -133,4 +147,51 @@ function statesArgument(
       ? "CLOSED,MERGED"
       : normalized;
   return `(states:[${states}])`;
+}
+
+/** One active gh list flag, before translation into a search qualifier. */
+export interface ListFilter {
+  key: string;
+  value: string;
+  /** Set for Cobra stringSlice flags such as `--label`, which gh reads as a list. */
+  list?: boolean;
+}
+
+const TYPE_QUALIFIER: Record<RepositoryEntity, string> = {
+  issues: "is:issue",
+  pullRequests: "is:pr",
+};
+
+/**
+ * Total for one `issue list`/`pr list` page, counted through whichever source
+ * can express the active filters.
+ *
+ * An unfiltered listing is counted through the `repository` connection, which
+ * is exact where search is eventually consistent. Any filter forces the count
+ * through search instead, because `repository.issues`/`repository.pullRequests`
+ * totalCount ignores the filters and would report the repository-wide total.
+ * Returns undefined when no source can answer the query.
+ */
+export async function fetchListTotal(
+  ctx: RepoContext,
+  entity: RepositoryEntity,
+  state: string | undefined,
+  filters: ListFilter[],
+): Promise<number | undefined> {
+  if (!filters.every((filter) => isSearchableValue(filter.value))) {
+    return undefined;
+  }
+  if (filters.length === 0) return fetchRepositoryTotal(ctx, entity, state);
+
+  const qualifiers = filters.flatMap((filter) =>
+    filter.list
+      ? searchQualifiers(filter.key, filter.value)
+      : [searchQualifier(filter.key, filter.value)],
+  );
+  return fetchSearchTotal([
+    `repo:${ctx.nwo}`,
+    TYPE_QUALIFIER[entity],
+    ...stateQualifiers(state),
+    ...qualifiers,
+  ]);
 }

--- a/src/totals.ts
+++ b/src/totals.ts
@@ -10,23 +10,52 @@
  */
 
 import { ghRaw } from "./gh.js";
+import type { RepoContext } from "./context.js";
 
 const SEARCH_TOTAL_QUERY =
   "query($q: String!) { search(query: $q, type: ISSUE) { issueCount } }";
 
 /**
- * Build a `key:"value"` search qualifier. The value is always quoted so labels
- * and milestones containing spaces stay a single term rather than splitting
- * into a stray free-text word.
+ * Build a `key:value` search qualifier.
+ *
+ * Values are quoted only when they contain whitespace, which keeps a label or
+ * milestone with spaces a single term without stripping the meaning of search
+ * sentinels such as `@me` — `assignee:"@me"` is read as a literal login and
+ * matches nothing, while `assignee:@me` resolves to the current user.
  */
 export function searchQualifier(key: string, value: string): string {
-  return `${key}:${JSON.stringify(value)}`;
+  return /\s/.test(value) ? `${key}:"${value}"` : `${key}:${value}`;
+}
+
+/**
+ * Build one qualifier per value of a gh flag that is a Cobra stringSlice, such
+ * as `--label`. gh reads `--label "bug,docs"` as two labels and requires both,
+ * so it must become two ANDed qualifiers; a single `label:"bug,docs"` matches a
+ * nonexistent label of that literal name.
+ */
+export function searchQualifiers(key: string, value: string): string[] {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .map((part) => searchQualifier(key, part));
 }
 
 /** Map a gh `--state` value onto its search qualifier; `all` has none. */
 export function stateQualifiers(state: string | undefined): string[] {
   const normalized = (state ?? "open").toLowerCase();
   return normalized === "all" ? [] : [`is:${normalized}`];
+}
+
+/**
+ * Whether a gh `--milestone` value can be translated into a search qualifier.
+ *
+ * gh accepts either a milestone number or its title, but search's `milestone:`
+ * qualifier only ever matches titles, so a numeric value would silently count
+ * zero. Callers skip the total entirely instead of reporting that zero.
+ */
+export function isSearchableMilestone(value: string): boolean {
+  return !/^\d+$/.test(value);
 }
 
 /**
@@ -54,4 +83,48 @@ export async function fetchSearchTotal(
   } catch {
     return undefined;
   }
+}
+
+/** The `repository` connection an unfiltered listing is counted through. */
+export type RepositoryEntity = "issues" | "pullRequests";
+
+/**
+ * Repository-wide total for an unfiltered listing, which is exact where search
+ * is eventually consistent. Returns undefined on any failure, same as
+ * {@link fetchSearchTotal}.
+ */
+export async function fetchRepositoryTotal(
+  ctx: RepoContext,
+  entity: RepositoryEntity,
+  state: string | undefined,
+): Promise<number | undefined> {
+  try {
+    const query = `{ repository(owner:"${ctx.owner}", name:"${ctx.name}") { ${entity}${statesArgument(entity, state)} { totalCount } } }`;
+    const result = await ghRaw(["api", "graphql", "-f", `query=${query}`]);
+    if (result.exitCode !== 0) return undefined;
+    const parsed = JSON.parse(result.stdout);
+    return parsed?.data?.repository?.[entity]?.totalCount ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The `(states:[...])` argument list, or an empty string for `--state all`.
+ * GraphQL rejects an empty argument list, so the parentheses are part of the
+ * value rather than the caller's template.
+ */
+function statesArgument(
+  entity: RepositoryEntity,
+  state: string | undefined,
+): string {
+  const normalized = (state ?? "open").toUpperCase();
+  if (normalized === "ALL") return "";
+  // gh's `--state closed` covers merged pull requests too, but the GraphQL
+  // enum splits them into distinct CLOSED and MERGED states.
+  const states =
+    entity === "pullRequests" && normalized === "CLOSED"
+      ? "CLOSED,MERGED"
+      : normalized;
+  return `(states:[${states}])`;
 }

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -182,7 +182,7 @@ describe("issueCommand", () => {
       expect(searchQuery).toContain("repo:octo/repo");
       expect(searchQuery).toContain("is:issue");
       expect(searchQuery).toContain("is:open");
-      expect(searchQuery).toContain('label:"ready-for-agent"');
+      expect(searchQuery).toContain("label:ready-for-agent");
       expect(result).toContain("count: 2 of 42 total");
     });
 
@@ -205,6 +205,64 @@ describe("issueCommand", () => {
       const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
       const searchQuery = gqlArgs.find((a) => a.startsWith("q="));
       expect(searchQuery).toContain('label:"help wanted"');
+    });
+
+    it("counts every label of a comma-separated --label list", async () => {
+      mockedGhJson.mockResolvedValue([
+        { number: 1, title: "A", state: "OPEN" },
+        { number: 2, title: "B", state: "OPEN" },
+      ]);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({ data: { search: { issueCount: 5 } } }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await issueCommand(
+        ["list", "--limit", "2", "--label", "bug,gh-licenses"],
+        ctx,
+      );
+
+      const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
+      const searchQuery = gqlArgs.find((a) => a.startsWith("q="));
+      expect(searchQuery).toContain("label:bug");
+      expect(searchQuery).toContain("label:gh-licenses");
+      expect(searchQuery).not.toContain("label:bug,gh-licenses");
+    });
+
+    it("keeps the @me sentinel unquoted so search resolves it", async () => {
+      mockedGhJson.mockResolvedValue([
+        { number: 1, title: "A", state: "OPEN" },
+        { number: 2, title: "B", state: "OPEN" },
+      ]);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({ data: { search: { issueCount: 8 } } }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await issueCommand(["list", "--limit", "2", "--assignee", "@me"], ctx);
+
+      const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
+      const searchQuery = gqlArgs.find((a) => a.startsWith("q="));
+      expect(searchQuery).toContain("assignee:@me");
+      expect(searchQuery).not.toContain('assignee:"@me"');
+    });
+
+    it("skips the total for a numeric --milestone search cannot match", async () => {
+      mockedGhJson.mockResolvedValue([
+        { number: 1, title: "A", state: "OPEN" },
+        { number: 2, title: "B", state: "OPEN" },
+      ]);
+
+      const result = await issueCommand(
+        ["list", "--limit", "2", "--milestone", "1"],
+        ctx,
+      );
+
+      expect(mockedGhRaw).not.toHaveBeenCalled();
+      expect(result).toContain("count: 2 (showing first 2)");
+      expect(result).not.toContain("total");
     });
 
     it("carries assignee, author and milestone into the filtered total", async () => {
@@ -235,9 +293,9 @@ describe("issueCommand", () => {
 
       const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
       const searchQuery = gqlArgs.find((a) => a.startsWith("q="));
-      expect(searchQuery).toContain('assignee:"octocat"');
-      expect(searchQuery).toContain('author:"hubot"');
-      expect(searchQuery).toContain('milestone:"v1.0"');
+      expect(searchQuery).toContain("assignee:octocat");
+      expect(searchQuery).toContain("author:hubot");
+      expect(searchQuery).toContain("milestone:v1.0");
     });
 
     it("uses the exact repository total when no filter is applied", async () => {
@@ -258,8 +316,33 @@ describe("issueCommand", () => {
       const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
       const query = gqlArgs.join(" ");
       expect(query).toContain("repository(");
+      expect(query).toContain("issues(states:[OPEN])");
       expect(query).not.toContain("search(");
       expect(result).toContain("count: 2 of 978 total");
+    });
+
+    it("omits the states argument for an unfiltered --state all total", async () => {
+      mockedGhJson.mockResolvedValue([
+        { number: 1, title: "A", state: "OPEN" },
+        { number: 2, title: "B", state: "CLOSED" },
+      ]);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({
+          data: { repository: { issues: { totalCount: 1200 } } },
+        }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      const result = await issueCommand(
+        ["list", "--limit", "2", "--state", "all"],
+        ctx,
+      );
+
+      const query = (mockedGhRaw.mock.calls[0][0] as string[]).join(" ");
+      expect(query).toContain("issues { totalCount }");
+      expect(query).not.toContain("states:");
+      expect(result).toContain("count: 2 of 1200 total");
     });
 
     it("omits the total rather than guessing when the count lookup fails", async () => {

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -265,6 +265,22 @@ describe("issueCommand", () => {
       expect(result).not.toContain("total");
     });
 
+    it("skips the total for a filter value containing a double quote", async () => {
+      mockedGhJson.mockResolvedValue([
+        { number: 1, title: "A", state: "OPEN" },
+        { number: 2, title: "B", state: "OPEN" },
+      ]);
+
+      const result = await issueCommand(
+        ["list", "--limit", "2", "--label", 'needs "design" input'],
+        ctx,
+      );
+
+      expect(mockedGhRaw).not.toHaveBeenCalled();
+      expect(result).toContain("count: 2 (showing first 2)");
+      expect(result).not.toContain("total");
+    });
+
     it("carries assignee, author and milestone into the filtered total", async () => {
       mockedGhJson.mockResolvedValue([
         { number: 1, title: "A", state: "OPEN" },

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -230,7 +230,7 @@ describe("issueCommand", () => {
       expect(searchQuery).not.toContain("label:bug,gh-licenses");
     });
 
-    it("keeps the @me sentinel unquoted so search resolves it", async () => {
+    it("passes the @me sentinel through unquoted", async () => {
       mockedGhJson.mockResolvedValue([
         { number: 1, title: "A", state: "OPEN" },
         { number: 2, title: "B", state: "OPEN" },

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -161,6 +161,149 @@ describe("issueCommand", () => {
       expect(result).toContain("bug");
     });
 
+    it("counts only filtered issues when --label is applied", async () => {
+      mockedGhJson.mockResolvedValue([
+        { number: 1, title: "A", state: "OPEN" },
+        { number: 2, title: "B", state: "OPEN" },
+      ]);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({ data: { search: { issueCount: 42 } } }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      const result = await issueCommand(
+        ["list", "--limit", "2", "--label", "ready-for-agent"],
+        ctx,
+      );
+
+      const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
+      const searchQuery = gqlArgs.find((a) => a.startsWith("q="));
+      expect(searchQuery).toContain("repo:octo/repo");
+      expect(searchQuery).toContain("is:issue");
+      expect(searchQuery).toContain("is:open");
+      expect(searchQuery).toContain('label:"ready-for-agent"');
+      expect(result).toContain("count: 2 of 42 total");
+    });
+
+    it("quotes filter values containing spaces", async () => {
+      mockedGhJson.mockResolvedValue([
+        { number: 1, title: "A", state: "OPEN" },
+        { number: 2, title: "B", state: "OPEN" },
+      ]);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({ data: { search: { issueCount: 7 } } }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await issueCommand(
+        ["list", "--limit", "2", "--label", "help wanted"],
+        ctx,
+      );
+
+      const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
+      const searchQuery = gqlArgs.find((a) => a.startsWith("q="));
+      expect(searchQuery).toContain('label:"help wanted"');
+    });
+
+    it("carries assignee, author and milestone into the filtered total", async () => {
+      mockedGhJson.mockResolvedValue([
+        { number: 1, title: "A", state: "OPEN" },
+        { number: 2, title: "B", state: "OPEN" },
+      ]);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({ data: { search: { issueCount: 3 } } }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await issueCommand(
+        [
+          "list",
+          "--limit",
+          "2",
+          "--assignee",
+          "octocat",
+          "--author",
+          "hubot",
+          "--milestone",
+          "v1.0",
+        ],
+        ctx,
+      );
+
+      const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
+      const searchQuery = gqlArgs.find((a) => a.startsWith("q="));
+      expect(searchQuery).toContain('assignee:"octocat"');
+      expect(searchQuery).toContain('author:"hubot"');
+      expect(searchQuery).toContain('milestone:"v1.0"');
+    });
+
+    it("uses the exact repository total when no filter is applied", async () => {
+      mockedGhJson.mockResolvedValue([
+        { number: 1, title: "A", state: "OPEN" },
+        { number: 2, title: "B", state: "OPEN" },
+      ]);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({
+          data: { repository: { issues: { totalCount: 978 } } },
+        }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      const result = await issueCommand(["list", "--limit", "2"], ctx);
+
+      const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
+      const query = gqlArgs.join(" ");
+      expect(query).toContain("repository(");
+      expect(query).not.toContain("search(");
+      expect(result).toContain("count: 2 of 978 total");
+    });
+
+    it("omits the total rather than guessing when the count lookup fails", async () => {
+      mockedGhJson.mockResolvedValue([
+        { number: 1, title: "A", state: "OPEN" },
+        { number: 2, title: "B", state: "OPEN" },
+      ]);
+      mockedGhRaw.mockResolvedValue({
+        stdout: "",
+        stderr: "boom",
+        exitCode: 1,
+      });
+
+      const result = await issueCommand(
+        ["list", "--limit", "2", "--label", "bug"],
+        ctx,
+      );
+
+      expect(result).toContain("count: 2 (showing first 2)");
+      expect(result).not.toContain("total");
+    });
+
+    it("drops the state qualifier when --state all is requested", async () => {
+      mockedGhJson.mockResolvedValue([
+        { number: 1, title: "A", state: "OPEN" },
+        { number: 2, title: "B", state: "CLOSED" },
+      ]);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({ data: { search: { issueCount: 9 } } }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await issueCommand(
+        ["list", "--limit", "2", "--state", "all", "--label", "bug"],
+        ctx,
+      );
+
+      const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
+      const searchQuery = gqlArgs.find((a) => a.startsWith("q="));
+      expect(searchQuery).not.toContain("is:open");
+      expect(searchQuery).not.toContain("is:closed");
+    });
+
     it("throws VALIDATION_ERROR for unknown --fields", async () => {
       await expect(
         issueCommand(["list", "--fields", "nonexistent"], ctx),

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -230,6 +230,28 @@ describe("issueCommand", () => {
       expect(searchQuery).not.toContain("label:bug,gh-licenses");
     });
 
+    it("counts every value of a repeated --label flag", async () => {
+      mockedGhJson.mockResolvedValue([
+        { number: 1, title: "A", state: "OPEN" },
+        { number: 2, title: "B", state: "OPEN" },
+      ]);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({ data: { search: { issueCount: 4 } } }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await issueCommand(
+        ["list", "--limit", "2", "--label", "bug", "--label", "help wanted"],
+        ctx,
+      );
+
+      const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
+      const searchQuery = gqlArgs.find((a) => a.startsWith("q="));
+      expect(searchQuery).toContain("label:bug");
+      expect(searchQuery).toContain('label:"help wanted"');
+    });
+
     it("passes the @me sentinel through unquoted", async () => {
       mockedGhJson.mockResolvedValue([
         { number: 1, title: "A", state: "OPEN" },

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -9,13 +9,14 @@ vi.mock("../../src/gh.js", () => ({
   ghRaw: vi.fn(),
 }));
 
-import { ghJson, ghExec } from "../../src/gh.js";
+import { ghJson, ghExec, ghRaw } from "../../src/gh.js";
 import { prCommand, PR_HELP } from "../../src/commands/pr.js";
 import { AxiError } from "../../src/errors.js";
 import type { RepoContext } from "../../src/context.js";
 
 const mockedGhJson = vi.mocked(ghJson);
 const mockedGhExec = vi.mocked(ghExec);
+const mockedGhRaw = vi.mocked(ghRaw);
 
 const ctx: RepoContext = {
   owner: "octo",
@@ -57,6 +58,105 @@ describe("prCommand", () => {
     it("returns error for unknown subcommand", async () => {
       const result = await prCommand(["unknown"]);
       expect(result).toContain("Unknown pr subcommand: unknown");
+    });
+  });
+
+  describe("list filtered totals", () => {
+    const twoPrs = [
+      { number: 1, title: "A", state: "OPEN", isDraft: false },
+      { number: 2, title: "B", state: "OPEN", isDraft: true },
+    ];
+
+    it("counts only filtered PRs when --label is applied", async () => {
+      mockedGhJson.mockResolvedValue(twoPrs);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({ data: { search: { issueCount: 12 } } }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      const result = await prCommand(
+        ["list", "--limit", "2", "--label", "bug"],
+        ctx,
+      );
+
+      const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
+      const searchQuery = gqlArgs.find((a) => a.startsWith("q="));
+      expect(searchQuery).toContain("repo:octo/repo");
+      expect(searchQuery).toContain("is:pr");
+      expect(searchQuery).toContain("is:open");
+      expect(searchQuery).toContain('label:"bug"');
+      expect(result).toContain("count: 2 of 12 total");
+    });
+
+    it("carries assignee, author, base, head and draft into the total", async () => {
+      mockedGhJson.mockResolvedValue(twoPrs);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({ data: { search: { issueCount: 4 } } }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await prCommand(
+        [
+          "list",
+          "--limit",
+          "2",
+          "--assignee",
+          "octocat",
+          "--author",
+          "hubot",
+          "--base",
+          "main",
+          "--head",
+          "feature",
+          "--draft",
+        ],
+        ctx,
+      );
+
+      const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
+      const searchQuery = gqlArgs.find((a) => a.startsWith("q="));
+      expect(searchQuery).toContain('assignee:"octocat"');
+      expect(searchQuery).toContain('author:"hubot"');
+      expect(searchQuery).toContain('base:"main"');
+      expect(searchQuery).toContain('head:"feature"');
+      expect(searchQuery).toContain("draft:true");
+    });
+
+    it("uses the exact repository total when no filter is applied", async () => {
+      mockedGhJson.mockResolvedValue(twoPrs);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({
+          data: { repository: { pullRequests: { totalCount: 310 } } },
+        }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      const result = await prCommand(["list", "--limit", "2"], ctx);
+
+      const query = (mockedGhRaw.mock.calls[0][0] as string[]).join(" ");
+      expect(query).toContain("repository(");
+      expect(query).not.toContain("search(");
+      expect(result).toContain("count: 2 of 310 total");
+    });
+
+    it("omits the total rather than guessing when the count lookup fails", async () => {
+      mockedGhJson.mockResolvedValue(twoPrs);
+      mockedGhRaw.mockResolvedValue({
+        stdout: "",
+        stderr: "boom",
+        exitCode: 1,
+      });
+
+      const result = await prCommand(
+        ["list", "--limit", "2", "--label", "bug"],
+        ctx,
+      );
+
+      expect(result).toContain("count: 2 (showing first 2)");
+      expect(result).not.toContain("total");
     });
   });
 

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -85,7 +85,7 @@ describe("prCommand", () => {
       expect(searchQuery).toContain("repo:octo/repo");
       expect(searchQuery).toContain("is:pr");
       expect(searchQuery).toContain("is:open");
-      expect(searchQuery).toContain('label:"bug"');
+      expect(searchQuery).toContain("label:bug");
       expect(result).toContain("count: 2 of 12 total");
     });
 
@@ -117,10 +117,10 @@ describe("prCommand", () => {
 
       const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
       const searchQuery = gqlArgs.find((a) => a.startsWith("q="));
-      expect(searchQuery).toContain('assignee:"octocat"');
-      expect(searchQuery).toContain('author:"hubot"');
-      expect(searchQuery).toContain('base:"main"');
-      expect(searchQuery).toContain('head:"feature"');
+      expect(searchQuery).toContain("assignee:octocat");
+      expect(searchQuery).toContain("author:hubot");
+      expect(searchQuery).toContain("base:main");
+      expect(searchQuery).toContain("head:feature");
       expect(searchQuery).toContain("draft:true");
     });
 
@@ -138,8 +138,63 @@ describe("prCommand", () => {
 
       const query = (mockedGhRaw.mock.calls[0][0] as string[]).join(" ");
       expect(query).toContain("repository(");
+      expect(query).toContain("pullRequests(states:[OPEN])");
       expect(query).not.toContain("search(");
       expect(result).toContain("count: 2 of 310 total");
+    });
+
+    it("counts merged PRs alongside closed ones in the repository total", async () => {
+      mockedGhJson.mockResolvedValue(twoPrs);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({
+          data: { repository: { pullRequests: { totalCount: 88 } } },
+        }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await prCommand(["list", "--limit", "2", "--state", "closed"], ctx);
+
+      const query = (mockedGhRaw.mock.calls[0][0] as string[]).join(" ");
+      expect(query).toContain("pullRequests(states:[CLOSED,MERGED])");
+    });
+
+    it("omits the states argument for an unfiltered --state all total", async () => {
+      mockedGhJson.mockResolvedValue(twoPrs);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({
+          data: { repository: { pullRequests: { totalCount: 500 } } },
+        }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      const result = await prCommand(
+        ["list", "--limit", "2", "--state", "all"],
+        ctx,
+      );
+
+      const query = (mockedGhRaw.mock.calls[0][0] as string[]).join(" ");
+      expect(query).toContain("pullRequests { totalCount }");
+      expect(query).not.toContain("states:");
+      expect(result).toContain("count: 2 of 500 total");
+    });
+
+    it("counts every label of a comma-separated --label list", async () => {
+      mockedGhJson.mockResolvedValue(twoPrs);
+      mockedGhRaw.mockResolvedValue({
+        stdout: JSON.stringify({ data: { search: { issueCount: 6 } } }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await prCommand(["list", "--limit", "2", "--label", "bug,docs"], ctx);
+
+      const gqlArgs = mockedGhRaw.mock.calls[0][0] as string[];
+      const searchQuery = gqlArgs.find((a) => a.startsWith("q="));
+      expect(searchQuery).toContain("label:bug");
+      expect(searchQuery).toContain("label:docs");
+      expect(searchQuery).not.toContain("label:bug,docs");
     });
 
     it("omits the total rather than guessing when the count lookup fails", async () => {

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,45 +1,69 @@
-import { describe, it, expect } from 'vitest';
-import { formatCountLine } from '../src/format.js';
+import { describe, it, expect } from "vitest";
+import { formatCountLine } from "../src/format.js";
 
-describe('formatCountLine', () => {
-  it('returns simple count when no truncation', () => {
-    expect(formatCountLine({ count: 5 })).toBe('count: 5');
+describe("formatCountLine", () => {
+  it("returns simple count when no truncation", () => {
+    expect(formatCountLine({ count: 5 })).toBe("count: 5");
   });
 
-  it('returns count with total when totalCount is provided', () => {
-    expect(formatCountLine({ count: 30, totalCount: 150 })).toBe('count: 30 of 150 total');
+  it("returns count with total when totalCount is provided", () => {
+    expect(formatCountLine({ count: 30, totalCount: 150 })).toBe(
+      "count: 30 of 150 total",
+    );
   });
 
-  it('returns showing first N when truncated (count equals limit)', () => {
-    expect(formatCountLine({ count: 30, limit: 30 })).toBe('count: 30 (showing first 30)');
+  it("returns showing first N when truncated (count equals limit)", () => {
+    expect(formatCountLine({ count: 30, limit: 30 })).toBe(
+      "count: 30 (showing first 30)",
+    );
   });
 
-  it('returns count with total even when truncated if totalCount is known', () => {
+  it("returns count with total even when truncated if totalCount is known", () => {
     // totalCount takes priority over limit-based truncation message
-    expect(formatCountLine({ count: 30, limit: 30, totalCount: 200 })).toBe('count: 30 of 200 total');
+    expect(formatCountLine({ count: 30, limit: 30, totalCount: 200 })).toBe(
+      "count: 30 of 200 total",
+    );
   });
 
-  it('returns simple count when count is less than limit', () => {
-    expect(formatCountLine({ count: 5, limit: 30 })).toBe('count: 5');
+  it("returns simple count when count is less than limit", () => {
+    expect(formatCountLine({ count: 5, limit: 30 })).toBe("count: 5");
   });
 
-  it('returns count with API limit note for search', () => {
-    expect(formatCountLine({ count: 1000, apiLimitHit: true })).toBe('count: 1000+ (GitHub search API limit reached)');
+  it("returns count with API limit note for search", () => {
+    expect(formatCountLine({ count: 1000, apiLimitHit: true })).toBe(
+      "count: 1000+ (GitHub search API limit reached)",
+    );
   });
 
-  it('returns showing first N when displayLimit truncates results', () => {
-    expect(formatCountLine({ count: 50, displayLimit: 30 })).toBe('count: 50 (showing first 30)');
+  it("returns showing first N when displayLimit truncates results", () => {
+    expect(formatCountLine({ count: 50, displayLimit: 30 })).toBe(
+      "count: 50 (showing first 30)",
+    );
   });
 
-  it('returns simple count when displayLimit is not exceeded', () => {
-    expect(formatCountLine({ count: 20, displayLimit: 30 })).toBe('count: 20');
+  it("returns simple count when displayLimit is not exceeded", () => {
+    expect(formatCountLine({ count: 20, displayLimit: 30 })).toBe("count: 20");
   });
 
-  it('handles zero count', () => {
-    expect(formatCountLine({ count: 0 })).toBe('count: 0');
+  it("ignores a total below the number of items shown", () => {
+    // A search index lagging behind freshly created issues can undercount;
+    // "30 of 12 total" contradicts itself, so fall back to the limit phrasing.
+    expect(formatCountLine({ count: 30, limit: 30, totalCount: 12 })).toBe(
+      "count: 30 (showing first 30)",
+    );
   });
 
-  it('handles zero count with limit', () => {
-    expect(formatCountLine({ count: 0, limit: 30 })).toBe('count: 0');
+  it("still reports a total equal to the number of items shown", () => {
+    expect(formatCountLine({ count: 30, limit: 30, totalCount: 30 })).toBe(
+      "count: 30 of 30 total",
+    );
+  });
+
+  it("handles zero count", () => {
+    expect(formatCountLine({ count: 0 })).toBe("count: 0");
+  });
+
+  it("handles zero count with limit", () => {
+    expect(formatCountLine({ count: 0, limit: 30 })).toBe("count: 0");
   });
 });

--- a/test/totals.test.ts
+++ b/test/totals.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isSearchableMilestone,
+  isSearchableValue,
   searchQualifier,
   searchQualifiers,
   stateQualifiers,
@@ -69,5 +70,19 @@ describe("isSearchableMilestone", () => {
   it("rejects a milestone number, which search matches by title only", () => {
     expect(isSearchableMilestone("1")).toBe(false);
     expect(isSearchableMilestone("42")).toBe(false);
+  });
+});
+
+describe("isSearchableValue", () => {
+  it("accepts values search can express", () => {
+    expect(isSearchableValue("bug")).toBe(true);
+    expect(isSearchableValue("help wanted")).toBe(true);
+    expect(isSearchableValue("@me")).toBe(true);
+    expect(isSearchableValue("bug,gh-licenses")).toBe(true);
+  });
+
+  it("rejects a value containing a double quote search cannot escape", () => {
+    expect(isSearchableValue('needs "design" input')).toBe(false);
+    expect(isSearchableValue('"needs,triage"')).toBe(false);
   });
 });

--- a/test/totals.test.ts
+++ b/test/totals.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  isSearchableMilestone,
+  searchQualifier,
+  searchQualifiers,
+  stateQualifiers,
+} from "../src/totals.js";
+
+describe("searchQualifier", () => {
+  it("leaves a plain value unquoted", () => {
+    expect(searchQualifier("label", "bug")).toBe("label:bug");
+  });
+
+  it("quotes a value containing whitespace", () => {
+    expect(searchQualifier("label", "help wanted")).toBe('label:"help wanted"');
+  });
+
+  it("keeps the @me sentinel usable", () => {
+    expect(searchQualifier("assignee", "@me")).toBe("assignee:@me");
+    expect(searchQualifier("author", "@me")).toBe("author:@me");
+  });
+});
+
+describe("searchQualifiers", () => {
+  it("returns one qualifier for a single value", () => {
+    expect(searchQualifiers("label", "bug")).toEqual(["label:bug"]);
+  });
+
+  it("splits a comma-separated list into one qualifier per value", () => {
+    expect(searchQualifiers("label", "bug,gh-licenses")).toEqual([
+      "label:bug",
+      "label:gh-licenses",
+    ]);
+  });
+
+  it("trims and quotes each value independently", () => {
+    expect(searchQualifiers("label", "bug, help wanted")).toEqual([
+      "label:bug",
+      'label:"help wanted"',
+    ]);
+  });
+
+  it("drops empty segments", () => {
+    expect(searchQualifiers("label", "bug,,")).toEqual(["label:bug"]);
+    expect(searchQualifiers("label", ",")).toEqual([]);
+  });
+});
+
+describe("stateQualifiers", () => {
+  it("defaults to open", () => {
+    expect(stateQualifiers(undefined)).toEqual(["is:open"]);
+  });
+
+  it("maps a state onto its qualifier", () => {
+    expect(stateQualifiers("CLOSED")).toEqual(["is:closed"]);
+  });
+
+  it("has no qualifier for all", () => {
+    expect(stateQualifiers("all")).toEqual([]);
+  });
+});
+
+describe("isSearchableMilestone", () => {
+  it("accepts a milestone title", () => {
+    expect(isSearchableMilestone("v1.0")).toBe(true);
+    expect(isSearchableMilestone("1.0")).toBe(true);
+  });
+
+  it("rejects a milestone number, which search matches by title only", () => {
+    expect(isSearchableMilestone("1")).toBe(false);
+    expect(isSearchableMilestone("42")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What Changed

- `issue list` and `pr list` no longer report the repository-wide `totalCount` on a filtered page. A new `src/totals.ts` translates the active list flags (`--label`, `--assignee`, `--author`, `--milestone`, `--base`, `--head`, `--draft`) into search qualifiers and counts through `search(type: ISSUE)`; unfiltered listings still use the exact `repository.issues`/`repository.pullRequests` connection. Live before/after runs show e.g. `gh-axi issue list -R cli/cli --label bug` going from 978 to the correct 246, and `--state all` no longer emitting an invalid `states:[ALL]` query.
- Totals are omitted rather than guessed when they cannot be expressed faithfully: a numeric `--milestone` (search matches titles only), any filter value containing a `"` (search has no escape for it), and any total smaller than the page it accompanies (`formatCountLine` now requires `totalCount >= count`, since the search index lags fresh items). These fall back to the existing `count: N (showing first N)` phrasing.
- Added `test/totals.test.ts` plus new coverage in the issue, pr, and format suites for qualifier translation, list-flag splitting, state mapping, and each skip case; documented the filter-aware totals and the omission fallback in the README behavior notes.

## Risk Assessment

✅ Low: The follow-up commit applied all three round-1 findings exactly as directed — a single `isSearchableValue` skip rule instead of an escaper, gh byte-parity quoting left untouched, and both call sites collapsed into `fetchListTotal` with new unit and command-level tests — leaving only a cosmetic unused-export nit in an otherwise well-bounded, gracefully-degrading change.

## Testing

Ran the full vitest suite (642 tests, all green) plus a focused 134-test run over the totals/format/issue/pr files, then produced the real product-level evidence: a live before/after CLI transcript running the published gh-axi 0.1.27 (base behavior) and this branch side by side against public repos, with every new total cross-checked against an independent GitHub search count. All 12 scenarios behave as intended — filtered totals now match the filters exactly (e.g. `--label bug` on cli/cli goes from a misleading `3 of 978` to a correct `3 of 246`), unfiltered listings still use the exact repository totals, and the unexpressible cases (numeric `--milestone`) correctly omit the total rather than printing a wrong one. This is a CLI-output change with no rendered UI surface, so the reviewer-visible artifact is the CLI transcript rather than a screenshot; the two paths not reproducible against live GitHub (a filter value containing a double quote, which gh's own flag parser rejects first, and the search-index-lag guard where the total undercounts the page) are covered by unit tests. No failures, no flakes, and the worktree is clean.

<details>
<summary>Evidence: Live before/after CLI transcript (12 scenarios, with independent ground-truth counts)</summary>

<code>gh-axi filtered list totals — before/after, live against public repos&#10;BEFORE = published gh-axi 0.1.27 (base behavior). AFTER = this branch.&#10;GROUND TRUTH = independent GitHub search count for the same filters.&#10;&#10;### issue list ###############################################&#10;&#10;1. No filters — repository-wide total, deliberately unchanged&#10;$ gh-axi issue list -R cli/cli --limit 3&#10;BEFORE (gh-axi 0.1.27) : count: 3 of 978 total&#10;AFTER (this branch) : count: 3 of 978 total&#10;&#10;2. --label bug &lt;- the bug reported in issue #76&#10;$ gh-axi issue list -R cli/cli --label bug --limit 3&#10;BEFORE (gh-axi 0.1.27) : count: 3 of 978 total&#10;AFTER (this branch) : count: 3 of 246 total&#10;GROUND TRUTH : 246 (search: repo:cli/cli is:issue is:open label:bug)&#10;&#10;3. --label with spaces — stays one quoted qualifier, not two words&#10;$ gh-axi issue list -R microsoft/vscode --label &#34;help wanted&#34; --limit 3&#10;BEFORE (gh-axi 0.1.27) : count: 3 of 17129 total&#10;AFTER (this branch) : count: 3 of 485 total&#10;GROUND TRUTH : 485&#10;&#10;4. --label a,b — gh ANDs both labels, so the total must too&#10;$ gh-axi issue list -R cli/cli --label bug,needs-investigation --limit 3&#10;BEFORE (gh-axi 0.1.27) : count: 3 of 978 total&#10;AFTER (this branch) : count: 3 of 10 total&#10;GROUND TRUTH : 10&#10;&#10;5. --author&#10;$ gh-axi issue list -R cli/cli --author vilmibm --limit 3&#10;BEFORE (gh-axi 0.1.27) : count: 3 of 978 total&#10;AFTER (this branch) : count: 3 of 15 total&#10;GROUND TRUTH : 15&#10;&#10;6. --state all --label bug (BEFORE emitted an invalid states:[ALL] query)&#10;$ gh-axi issue list -R cli/cli --state all --label bug --limit 3&#10;BEFORE (gh-axi 0.1.27) : count: 3 (showing first 3)&#10;AFTER (this branch) : count: 3 of 2224 total&#10;GROUND TRUTH : 2224&#10;&#10;7. --milestone by title (has spaces)&#10;$ gh-axi issue list -R microsoft/TypeScript --milestone &#34;TypeScript 5.7.0&#34; --limit 3&#10;BEFORE (gh-axi 0.1.27) : count: 3 of 5035 total&#10;AFTER (this branch) : count: 3 of 199 total&#10;GROUND TRUTH : 199&#10;&#10;8. --milestone by NUMBER — search matches titles only, so no total at all&#10;$ gh-axi issue list -R microsoft/TypeScript --milestone 208 --limit 3&#10;BEFORE (gh-axi 0.1.27) : count: 3 of 5035 total&#10;AFTER (this branch) : count: 3 (showing first 3)&#10;&#10;### pr list ##################################################&#10;&#10;9. No filters — repository-wide total, deliberately unchanged&#10;$ gh-axi pr list -R cli/cli --limit 3&#10;BEFORE (gh-axi 0.1.27) : count: 3 of 58 total&#10;AFTER (this branch) : count: 3 of 58 total&#10;&#10;10. --draft — repository.pullRequests cannot express this filter at all&#10;$ gh-axi pr list -R cli/cli --draft --limit 3&#10;BEFORE (gh-axi 0.1.27) : count: 3 of 58 total&#10;AFTER (this branch) : count: 3 of 14 total&#10;GROUND TRUTH : 14&#10;&#10;11. --base trunk --label dependencies&#10;$ gh-axi pr list -R cli/cli --base trunk --label dependencies --limit 3&#10;BEFORE (gh-axi 0.1.27) : count: 3 of 58 total&#10;AFTER (this branch) : count: 3 of 7 total&#10;GROUND TRUTH : 7&#10;&#10;12. --state all --label dependencies&#10;$ gh-axi pr list -R cli/cli --state all --label dependencies --limit 3&#10;BEFORE (gh-axi 0.1.27) : count: 3 (showing first 3)&#10;AFTER (this branch) : count: 3 of 296 total&#10;GROUND TRUTH : 296</code>

```text
gh-axi filtered list totals — before/after, live against public repos
BEFORE = published gh-axi 0.1.27 (base behavior).  AFTER = this branch.
GROUND TRUTH = independent GitHub search count for the same filters.

### issue list ###############################################

==============================================================
1. No filters — repository-wide total, deliberately unchanged
$ gh-axi issue list -R cli/cli --limit 3
--------------------------------------------------------------
  BEFORE (gh-axi 0.1.27) : count: 3 of 978 total
  AFTER  (this branch)   : count: 3 of 978 total

==============================================================
2. --label bug  <- the bug reported in issue #76
$ gh-axi issue list -R cli/cli --label bug --limit 3
--------------------------------------------------------------
  BEFORE (gh-axi 0.1.27) : count: 3 of 978 total
  AFTER  (this branch)   : count: 3 of 246 total
  GROUND TRUTH           : 246   (search: repo:cli/cli is:issue is:open label:bug)

==============================================================
3. --label with spaces — stays one quoted qualifier, not two words
$ gh-axi issue list -R microsoft/vscode --label help wanted --limit 3
--------------------------------------------------------------
  BEFORE (gh-axi 0.1.27) : count: 3 of 17129 total
  AFTER  (this branch)   : count: 3 of 485 total
  GROUND TRUTH           : 485   (search: repo:microsoft/vscode is:issue is:open label:\"help wanted\")

==============================================================
4. --label a,b — gh ANDs both labels, so the total must too
$ gh-axi issue list -R cli/cli --label bug,needs-investigation --limit 3
--------------------------------------------------------------
  BEFORE (gh-axi 0.1.27) : count: 3 of 978 total
  AFTER  (this branch)   : count: 3 of 10 total
  GROUND TRUTH           : 10   (search: repo:cli/cli is:issue is:open label:bug label:needs-investigation)

==============================================================
5. --author
$ gh-axi issue list -R cli/cli --author vilmibm --limit 3
--------------------------------------------------------------
  BEFORE (gh-axi 0.1.27) : count: 3 of 978 total
  AFTER  (this branch)   : count: 3 of 15 total
  GROUND TRUTH           : 15   (search: repo:cli/cli is:issue is:open author:vilmibm)

==============================================================
6. --state all --label bug (BEFORE emitted an invalid states:[ALL] query)
$ gh-axi issue list -R cli/cli --state all --label bug --limit 3
--------------------------------------------------------------
  BEFORE (gh-axi 0.1.27) : count: 3 (showing first 3)
  AFTER  (this branch)   : count: 3 of 2224 total
  GROUND TRUTH           : 2224   (search: repo:cli/cli is:issue label:bug)

==============================================================
7. --milestone by title (has spaces)
$ gh-axi issue list -R microsoft/TypeScript --milestone TypeScript 5.7.0 --limit 3
--------------------------------------------------------------
  BEFORE (gh-axi 0.1.27) : count: 3 of 5035 total
  AFTER  (this branch)   : count: 3 of 199 total
  GROUND TRUTH           : 199   (search: repo:microsoft/TypeScript is:issue is:open milestone:\"TypeScript 5.7.0\")

==============================================================
8. --milestone by NUMBER — search matches titles only, so no total at all
$ gh-axi issue list -R microsoft/TypeScript --milestone 208 --limit 3
--------------------------------------------------------------
  BEFORE (gh-axi 0.1.27) : count: 3 of 5035 total
  AFTER  (this branch)   : count: 3 (showing first 3)

### pr list ##################################################

==============================================================
9. No filters — repository-wide total, deliberately unchanged
$ gh-axi pr list -R cli/cli --limit 3
--------------------------------------------------------------
  BEFORE (gh-axi 0.1.27) : count: 3 of 58 total
  AFTER  (this branch)   : count: 3 of 58 total

==============================================================
10. --draft — repository.pullRequests cannot express this filter at all
$ gh-axi pr list -R cli/cli --draft --limit 3
--------------------------------------------------------------
  BEFORE (gh-axi 0.1.27) : count: 3 of 58 total
  AFTER  (this branch)   : count: 3 of 14 total
  GROUND TRUTH           : 14   (search: repo:cli/cli is:pr is:open draft:true)

==============================================================
11. --base trunk --label dependencies
$ gh-axi pr list -R cli/cli --base trunk --label dependencies --limit 3
--------------------------------------------------------------
  BEFORE (gh-axi 0.1.27) : count: 3 of 58 total
  AFTER  (this branch)   : count: 3 of 7 total
  GROUND TRUTH           : 7   (search: repo:cli/cli is:pr is:open base:trunk label:dependencies)

==============================================================
12. --state all --label dependencies
$ gh-axi pr list -R cli/cli --state all --label dependencies --limit 3
--------------------------------------------------------------
  BEFORE (gh-axi 0.1.27) : count: 3 (showing first 3)
  AFTER  (this branch)   : count: 3 of 296 total
  GROUND TRUTH           : 296   (search: repo:cli/cli is:pr label:dependencies)
```
</details>
<details>
<summary>Evidence: Targeted vitest run (totals, format, issue, pr) — verbose</summary>

<code>✓ test/totals.test.ts &gt; isSearchableMilestone &gt; rejects a milestone number, which search matches by title only&#10;✓ test/totals.test.ts &gt; isSearchableValue &gt; rejects a value containing a double quote search cannot escape&#10;✓ test/format.test.ts &gt; formatCountLine &gt; ignores a total below the number of items shown&#10;✓ test/commands/issue.test.ts &gt; list &gt; skips the total for a numeric --milestone search cannot match&#10;✓ test/commands/issue.test.ts &gt; list &gt; skips the total for a filter value containing a double quote&#10;✓ test/commands/pr.test.ts &gt; list filtered totals &gt; carries assignee, author, base, head and draft into the total&#10;&#10;Test Files 4 passed (4)&#10;Tests 134 passed (134)</code>

```text

 RUN  v3.2.4 /Users/bautista/.no-mistakes/worktrees/5a450c443633/01KY2ND8DEAJ4M3A61ZYVB3SY6

 ✓ test/format.test.ts > formatCountLine > returns simple count when no truncation 1ms
 ✓ test/format.test.ts > formatCountLine > returns count with total when totalCount is provided 0ms
 ✓ test/format.test.ts > formatCountLine > returns showing first N when truncated (count equals limit) 0ms
 ✓ test/format.test.ts > formatCountLine > returns count with total even when truncated if totalCount is known 0ms
 ✓ test/format.test.ts > formatCountLine > returns simple count when count is less than limit 0ms
 ✓ test/format.test.ts > formatCountLine > returns count with API limit note for search 0ms
 ✓ test/format.test.ts > formatCountLine > returns showing first N when displayLimit truncates results 0ms
 ✓ test/format.test.ts > formatCountLine > returns simple count when displayLimit is not exceeded 0ms
 ✓ test/format.test.ts > formatCountLine > ignores a total below the number of items shown 0ms
 ✓ test/format.test.ts > formatCountLine > still reports a total equal to the number of items shown 0ms
 ✓ test/format.test.ts > formatCountLine > handles zero count 0ms
 ✓ test/format.test.ts > formatCountLine > handles zero count with limit 0ms
 ✓ test/totals.test.ts > searchQualifier > leaves a plain value unquoted 1ms
 ✓ test/totals.test.ts > searchQualifier > quotes a value containing whitespace 0ms
 ✓ test/totals.test.ts > searchQualifier > keeps the @me sentinel usable 0ms
 ✓ test/totals.test.ts > searchQualifiers > returns one qualifier for a single value 0ms
 ✓ test/totals.test.ts > searchQualifiers > splits a comma-separated list into one qualifier per value 0ms
 ✓ test/totals.test.ts > searchQualifiers > trims and quotes each value independently 0ms
 ✓ test/totals.test.ts > searchQualifiers > drops empty segments 0ms
 ✓ test/totals.test.ts > stateQualifiers > defaults to open 0ms
 ✓ test/totals.test.ts > stateQualifiers > maps a state onto its qualifier 0ms
 ✓ test/totals.test.ts > stateQualifiers > has no qualifier for all 0ms
 ✓ test/totals.test.ts > isSearchableMilestone > accepts a milestone title 0ms
 ✓ test/totals.test.ts > isSearchableMilestone > rejects a milestone number, which search matches by title only 0ms
 ✓ test/totals.test.ts > isSearchableValue > accepts values search can express 0ms
 ✓ test/totals.test.ts > isSearchableValue > rejects a value containing a double quote search cannot escape 0ms
 ✓ test/commands/issue.test.ts > issueCommand > router > returns help when --help is passed 3ms
 ✓ test/commands/issue.test.ts > issueCommand > router > returns subissue help for subissue --help 0ms
 ✓ test/commands/issue.test.ts > issueCommand > router > returns help when no subcommand is given 0ms
 ✓ test/commands/issue.test.ts > issueCommand > router > returns error for unknown subcommand (not throw) 3ms
 ✓ test/commands/issue.test.ts > issueCommand > list > returns list with count 4ms
 ✓ test/commands/issue.test.ts > issueCommand > list > uses default compact --json fields when --fields is not passed 0ms
 ✓ test/commands/issue.test.ts > issueCommand > list > extends --json and schema when --fields is passed 0ms
 ✓ test/commands/issue.test.ts > issueCommand > list > counts only filtered issues when --label is applied 1ms
 ✓ test/commands/issue.test.ts > issueCommand > list > quotes filter values containing spaces 0ms
 ✓ test/commands/issue.test.ts > issueCommand > list > counts every label of a comma-separated --label list 0ms
 ✓ test/commands/issue.test.ts > issueCommand > list > passes the @me sentinel through unquoted 0ms
 ✓ test/commands/issue.test.ts > issueCommand > list > skips the total for a numeric --milestone search cannot match 0ms
 ✓ test/commands/issue.test.ts > issueCommand > list > skips the total for a filter value containing a double quote 0ms
 ✓ test/commands/issue.test.ts > issueCommand > list > carries assignee, author and milestone into the filtered total 1ms
 ✓ test/commands/issue.test.ts > issueCommand > list > uses the exact repository total when no filter is applied 1ms
 ✓ test/commands/issue.test.ts > issueCommand > list > omits the states argument for an unfiltered --state all total 1ms
 ✓ test/commands/issue.test.ts > issueCommand > list > omits the total rather than guessing when the count lookup fails 0ms
 ✓ test/commands/issue.test.ts > issueCommand > list > drops the state qualifier when --state all is requested 0ms
 ✓ test/commands/issue.test.ts > issueCommand > list > throws VALIDATION_ERROR for unknown --fields 2ms
 ✓ test/commands/issue.test.ts > issueCommand > view > returns detail 0ms
 ✓ test/commands/issue.test.ts > issueCommand > view > includes issueType in the --json field list and renders type 0ms
 ✓ test/commands/issue.test.ts > issueCommand > view > renders type as none when no issueType is set 0ms
 ✓ test/commands/issue.test.ts > issueCommand > view > falls back when gh does not support the issueType field 0ms
 ✓ test/commands/issue.test.ts > issueCommand > view > omits help suggestions from detail view 3ms
 ✓ test/commands/issue.test.ts > issueCommand > create > requires --title 1ms
 ✓ test/commands/issue.test.ts > issueCommand > create > returns created issue 11ms
 ✓ test/commands/issue.test.ts > issueCommand > create > applies --type via graphql mutation and renders the type 1ms
 ✓ test/commands/issue.test.ts > issueCommand > create > matches --type case-insensitively 0ms
 ✓ test/commands/issue.test.ts > issueCommand > create > rejects unknown --type with a hint listing supported types 1ms
 ✓ test/commands/issue.test.ts > issueCommand > create > rejects --type without a value 1ms
 ✓ test/commands/issue.test.ts > issueCommand > create > passes all repeated --label flags to gh issue create (two labels) 3ms
 ✓ test/commands/issue.test.ts > issueCommand > create > passes all repeated --label flags to gh issue create (three labels) 5ms
 ✓ test/commands/issue.test.ts > issueCommand > create > still passes a single --label flag correctly (no regression) 1ms
 ✓ test/commands/issue.test.ts > issueCommand > edit with --type > applies --type via graphql mutation 1ms
 ✓ test/commands/issue.test.ts > issueCommand > edit with --type > clears the type when --no-type is passed 1ms
 ✓ test/commands/issue.test.ts > issueCommand > edit with --type > rejects --type without a value 0ms
 ✓ test/commands/issue.test.ts > issueCommand > --body-file > uses file contents for issue create 2ms
 ✓ test/commands/issue.test.ts > issueCommand > --body-file > uses file contents for issue edit 1ms
 ✓ test/commands/issue.test.ts > issueCommand > --body-file > uses file contents for issue comment 1ms
 ✓ test/commands/issue.test.ts > issueCommand > close > returns already closed when issue is already closed (idempotent) 0ms
 ✓ test/commands/issue.test.ts > issueCommand > lock > returns already locked when issue is already locked (idempotent) 0ms
 ✓ test/commands/issue.test.ts > issueCommand > transfer > requires --to-repo 0ms
 ✓ test/commands/issue.test.ts > issueCommand > transfer > transfers to the destination repo provided by --to-repo 0ms
 ✓ test/commands/issue.test.ts > issueCommand > transfer > builds the fallback URL on the configured host when the follow-up view fails 0ms
 ✓ test/commands/issue.test.ts > issueCommand > transfer > builds the fallback URL on github.com by default 0ms
 ✓ test/commands/issue.test.ts > issueCommand > view with sub-issue relationships > includes parent and subissues when the GraphQL augmentation returns data 0ms
 ✓ test/commands/issue.test.ts > issueCommand > view with sub-issue relationships > omits parent and subissues fields when neither is present 0ms
 ✓ test/commands/issue.test.ts > issueCommand > view with sub-issue relationships > still renders the issue when the sub-issue GraphQL call fails 0ms
 ✓ test/commands/issue.test.ts > issueCommand > subissue > rejects unknown subissue subcommand 0ms
 ✓ test/commands/issue.test.ts > issueCommand > subissue > returns help when no subissue subcommand given 0ms
 ✓ test/commands/issue.test.ts > issueCommand > subissue > add > issues one addSubIssue mutation per child 1ms
 ✓ test/commands/issue.test.ts > issueCommand > subissue > add > requires at least one child 0ms
 ✓ test/commands/issue.test.ts > issueCommand > subissue > add > requires a parent argument 0ms
 ✓ test/commands/issue.test.ts > issueCommand > subissue > add > reports already added children when a later add fails 0ms
 ✓ test/commands/issue.test.ts > issueCommand > subissue > remove > sends a single removeSubIssue mutation 1ms
 ✓ test/commands/issue.test.ts > issueCommand > subissue > remove > requires both parent and child 1ms
 ✓ test/commands/issue.test.ts > issueCommand > subissue > list > lists sub-issues of a parent 1ms
 ✓ test/commands/issue.test.ts > issueCommand > subissue > list > renders count: 0 when there are no sub-issues 0ms
 ✓ test/commands/issue.test.ts > issueCommand > subissue > list > requires a parent argument 4ms
 ✓ test/commands/pr.test.ts > prCommand > router > returns help when --help is passed 3ms
 ✓ test/commands/pr.test.ts > prCommand > router > returns help when no subcommand is given 0ms
 ✓ test/commands/pr.test.ts > prCommand > router > returns error for unknown subcommand 1ms
 ✓ test/commands/pr.test.ts > prCommand > list filtered totals > counts only filtered PRs when --label is applied 1ms
 ✓ test/commands/pr.test.ts > prCommand > list filtered totals > carries assignee, author, base, head and draft into the total 0ms
 ✓ test/commands/pr.test.ts > prCommand > list filtered totals > uses the exact repository total when no filter is applied 1ms
 ✓ test/commands/pr.test.ts > prCommand > list filtered totals > counts merged PRs alongside closed ones in the repository total 1ms
 ✓ test/commands/pr.test.ts > prCommand > list filtered totals > omits the states argument for an unfiltered --state all total 0ms
 ✓ test/commands/pr.test.ts > prCommand > list filtered totals > counts every label of a comma-separated --label list 0ms
 ✓ test/commands/pr.test.ts > prCommand > list filtered totals > omits the total rather than guessing when the count lookup fails 0ms
 ✓ test/commands/pr.test.ts > prCommand > list > returns list with count line 2ms
 ✓ test/commands/pr.test.ts > prCommand > list > uses default compact --json fields when --fields is not passed 0ms
 ✓ test/commands/pr.test.ts > prCommand > list > extends --json and schema when --fields is passed 1ms
 ✓ test/commands/pr.test.ts > prCommand > list > throws VALIDATION_ERROR for unknown --fields 3ms
 ✓ test/commands/pr.test.ts > prCommand > view > returns detail with schema fields 2ms
 ✓ test/commands/pr.test.ts > prCommand > view > omits help suggestions from detail view 0ms
 ✓ test/commands/pr.test.ts > prCommand > view > shows review_count summary when --reviews is not passed 0ms
 ✓ test/commands/pr.test.ts > prCommand > view > lists review submissions and inline comments with --reviews 1ms
 ✓ test/commands/pr.test.ts > prCommand > view > uses explicit REST paths without repo context for review fetches 1ms
 ✓ test/commands/pr.test.ts > prCommand > view > flattens paginated review and inline comment pages 0ms
 ✓ test/commands/pr.test.ts > prCommand > view > skips inline-comment fetch when there are no reviews 0ms
 ✓ test/commands/pr.test.ts > prCommand > view > renders both comments and reviews when --comments --reviews are combined 1ms
 ✓ test/commands/pr.test.ts > prCommand > close > returns already closed when PR is already closed (idempotent) 3ms
 ✓ test/commands/pr.test.ts > prCommand > merge > returns already merged when PR is already merged (idempotent) 2ms
 ✓ test/commands/pr.test.ts > prCommand > merge > maps --squash shorthand to a gh merge method flag 2ms
 ✓ test/commands/pr.test.ts > prCommand > merge > maps --merge shorthand to a gh merge method flag 0ms
 ✓ test/commands/pr.test.ts > prCommand > merge > maps --rebase shorthand to a gh merge method flag 0ms
 ✓ test/commands/pr.test.ts > prCommand > merge > keeps --method working 0ms
 ✓ test/commands/pr.test.ts > prCommand > --body-file > uses file contents for pr create 17ms
 ✓ test/commands/pr.test.ts > prCommand > --body-file > uses file contents for pr edit 2ms
 ✓ test/commands/pr.test.ts > prCommand > --body-file > uses file contents for pr merge 2ms
 ✓ test/commands/pr.test.ts > prCommand > --body-file > uses file contents for pr review 2ms
 ✓ test/commands/pr.test.ts > prCommand > --body-file > uses file contents for pr comment 2ms
 ✓ test/commands/pr.test.ts > prCommand > --body-file > rejects --body and --body-file together before calling gh 5ms
 ✓ test/commands/pr.test.ts > prCommand > checks > returns message when no checks configured 0ms
 ✓ test/commands/pr.test.ts > prCommand > checks > returns check summary with checks 2ms
 ✓ test/commands/pr.test.ts > prCommand > checks > keeps an unfinished check run pending 0ms
 ✓ test/commands/pr.test.ts > prCommand > checks > classifies a successful legacy status context as passing 1ms
 ✓ test/commands/pr.test.ts > prCommand > checks > classifies a failing legacy status context as failing 0ms
 ✓ test/commands/pr.test.ts > prCommand > checks > classifies an errored legacy status context as failing 1ms
 ✓ test/commands/pr.test.ts > prCommand > checks > keeps a pending legacy status context pending 0ms
 ✓ test/commands/pr.test.ts > prCommand > checks > classifies a check run that failed to start as failing 0ms
 ✓ test/commands/pr.test.ts > prCommand > checks > classifies a stale check run as failing 0ms
 ✓ test/commands/pr.test.ts > prCommand > checks > classifies a cancelled check run as failing 1ms
 ✓ test/commands/pr.test.ts > prCommand > checks > keeps a skipped check run skipped 0ms
 ✓ test/commands/pr.test.ts > prCommand > checks > counts a mix of check runs and legacy status contexts 1ms
 ✓ test/commands/pr.test.ts > prCommand > diff > wraps diff output in TOON envelope 1ms
 ✓ test/commands/pr.test.ts > prCommand > diff > truncates large diffs with metadata and --full escape hatch 0ms
 ✓ test/commands/pr.test.ts > prCommand > diff > skips truncation with --full flag 0ms

 Test Files  4 passed (4)
      Tests  134 passed (134)
   Start at  12:57:10
   Duration  1.16s (transform 1.12s, setup 0ms, collect 1.66s, tests 149ms, environment 0ms, prepare 606ms)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `src/totals.ts:33` - `searchQualifier` quotes values containing whitespace but never escapes or rejects an embedded `&#34;`, so such a value terminates the quoted term early and the count query stops expressing the filter that was passed to gh. `gh-axi issue list --label &#39;needs &#34;design&#34; input&#39; --limit 2` on a full page emits `label:&#34;needs &#34;design&#34; input&#34;`, which search tokenizes as `label:&#34;needs &#34;` plus free text, so the printed `N of M total` does not correspond to the label filter. The same shape lets a value inject an unrelated qualifier: `--author &#39;x&#34; is:closed&#39;` emits `author:&#34;x&#34; is:closed&#34;`, silently ANDing `is:closed` into the count. The new `totalCount &gt;= count` guard in src/format.ts only suppresses undercounts, so an overcount is still printed. Following the branch&#39;s own &#34;no total beats a wrong one&#34; rule (`isSearchableMilestone`), a value containing `&#34;` should make the listing non-countable.
- ℹ️ `src/commands/issue.ts:269` - The build-filters / branch-to-search-or-repository block is duplicated near-verbatim in `listIssues` (src/commands/issue.ts:269-287) and `prList` (src/commands/pr.ts:329-349), including the `repo:&lt;nwo&gt;` prefix, the `is:issue`/`is:pr` type qualifier, the state qualifiers and the empty-filters fallback. A future change to total selection has to be applied identically in both places or issue and PR totals silently diverge. A single `fetchListTotal(ctx, &#39;issues&#39; | &#39;pullRequests&#39;, state, filters)` in src/totals.ts would leave each call site with only its own flag-to-qualifier mapping.
- ℹ️ `src/totals.ts:44` - `searchQualifiers` splits on a bare comma, but gh parses `--label` as a Cobra stringSlice using CSV rules, so a label whose name legitimately contains a comma is one label to gh and two malformed qualifiers here. `gh-axi issue list --label &#39;&#34;needs,triage&#34;&#39; --limit 2` passes `&#34;needs,triage&#34;` to gh, which CSV-parses it into the single label `needs,triage`, while `searchQualifiers` yields `label:&#34;needs` and `label:triage&#34;`. Same unescaped-value class as the quote finding; the `totalCount &gt;= count` guard usually degrades this to a dropped total rather than a wrong one, so it is follow-up material.

🔧 Fix: skip list totals for unquotable filter values; extract fetchListTotal
1 info still open:
- ℹ️ `src/totals.ts:88` - After `fetchListTotal` absorbed both call sites, `fetchSearchTotal` (src/totals.ts:88) and `fetchRepositoryTotal` (src/totals.ts:116) are only called from inside totals.ts and are imported by nothing — not src/commands/issue.ts, not src/commands/pr.ts, not test/totals.test.ts. The `export` keyword on both is now dead public surface: it widens the module API for no consumer and makes a future signature change look like a breaking change to a caller that does not exist. Dropping `export` on the two leaves `fetchListTotal` as the single entry point this refactor was meant to establish.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm test` — full suite, 642 tests across 30 files, all passing</code>
- <code>`pnpm exec vitest run test/totals.test.ts test/format.test.ts test/commands/issue.test.ts test/commands/pr.test.ts --reporter=verbose` — 134 targeted tests covering search-qualifier translation, filtered totals, and the skip cases</code>
- <code>Live before/after CLI transcript: `/opt/homebrew/bin/gh-axi` (published 0.1.27 = base) vs `tsx bin/gh-axi.ts` (this branch) over 12 scenarios against `cli/cli` and `microsoft/TypeScript`/`microsoft/vscode`</code>
- <code>`gh-axi issue list -R cli/cli --label bug --limit 3` — 978 → 246</code>
- <code>`gh-axi issue list -R microsoft/vscode --label &#34;help wanted&#34; --limit 3` — 17129 → 485 (spaces stay one quoted qualifier)</code>
- <code>`gh-axi issue list -R cli/cli --label bug,needs-investigation --limit 3` — 978 → 10 (both labels ANDed)</code>
- <code>`gh-axi issue list -R cli/cli --state all --label bug --limit 3` — `showing first 3` → 2224 (base emitted an invalid `states:[ALL]` query)</code>
- <code>`gh-axi issue list -R microsoft/TypeScript --milestone 208 --limit 3` — numeric milestone correctly falls back to `count: 3 (showing first 3)`</code>
- <code>`gh-axi pr list -R cli/cli --draft --limit 3` — 58 → 14 (a filter `repository.pullRequests` cannot express at all)</code>
- <code>`gh-axi pr list -R cli/cli --base trunk --label dependencies --limit 3` — 58 → 7</code>
- <code>Independent ground-truth verification of every new total via `gh api graphql -f &#39;query={ search(query:&#34;...&#34;, type: ISSUE){issueCount} }&#39;`</code>
- <code>Unfiltered `gh-axi issue list -R cli/cli --limit 3` and `gh-axi pr list -R cli/cli --limit 3` — confirmed repository-connection totals (978 / 58) unchanged from base</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `.prettierignore` - Pre-existing, change-unrelated Prettier drift: `pnpm exec prettier --check .` flags 18 files (CHANGELOG.md, eslint.config.mjs, src/commands/{api,label,repo,workflow}.ts, src/{fields,toon}.ts, several tests, plus generated artifacts under .no-mistakes/evidence/). None are touched by this change, and CI does not run Prettier, so nothing here blocks. Worth a separate follow-up: add a .prettierignore for CHANGELOG.md (release-please-generated, guarded) and .no-mistakes/evidence/, then format the remaining source files in one dedicated commit.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
