### PR TITLE
fix(commands): stop api from silently dropping --jq and unknown flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Other `gh secret` scopes (`--org`, `--user`, `--app`) are rejected with a clear 
 `gh-axi project` wraps GitHub Projects (v2) and requires the `project` (or `read:project`) OAuth scope; if a call fails on a missing scope, gh-axi tells you the `gh auth refresh -s <scope>` command to run.
 `--owner` defaults to the current repo's owner, falling back to explicit `@me` for the authenticated user.
 
+`gh-axi api` accepts `--field`, `--header`, `--paginate`, `--jq <expression>`, and `--template <format>`; any other flag, an extra positional argument, or a repeated `--jq`/`--template` is rejected with a clear error instead of being silently dropped.
+JSON responses are normally stripped of noisy fields before TOON encoding, but a response you shaped yourself with `--jq` or `--template` keeps every key and value verbatim — only over-long strings are still truncated so one field cannot flood an agent's context.
+
 ### Commands
 
 | Command    | Description                                                                 |

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -2,7 +2,6 @@ import { encode } from '@toon-format/toon';
 import type { RepoContext } from '../context.js';
 import { ghExec } from '../gh.js';
 import { AxiError } from '../errors.js';
-import { hasFlag, getFlag, getAllFlags } from '../args.js';
 import { cleanBody } from '../body.js';
 
 export const API_HELP = `usage: gh-axi api [<method>] <path>
@@ -19,11 +18,16 @@ examples:
 
 const HTTP_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD']);
 
-/** Flags that consume the following argument as their value. */
-const VALUE_FLAGS = new Set(['--field', '--header', '--jq', '--template']);
+/** Value flags that may be given more than once, each occurrence forwarded to gh. */
+const REPEATABLE_VALUE_FLAGS = new Set(['--field', '--header']);
+
+/** Value flags that gh accepts only one of, so a repeat is a caller mistake. */
+const SINGLE_VALUE_FLAGS = new Set(['--jq', '--template']);
 
 /** Flags that stand alone and must not consume the following argument. */
 const BOOL_FLAGS = new Set(['--paginate']);
+
+const SUPPORTED_FLAGS = [...REPEATABLE_VALUE_FLAGS, ...SINGLE_VALUE_FLAGS, ...BOOL_FLAGS];
 
 /** The flag's name without any `=value` suffix, so errors never echo a value. */
 function flagName(arg: string): string {
@@ -31,44 +35,79 @@ function flagName(arg: string): string {
   return equals === -1 ? arg : arg.slice(0, equals);
 }
 
+interface ParsedApiArgs {
+  positionals: string[];
+  fields: string[];
+  headers: string[];
+  jq?: string;
+  template?: string;
+  paginate: boolean;
+}
+
 /**
- * Split args into positionals, rejecting anything unrecognised.
+ * Walk args once, collecting positionals and flag values and rejecting anything
+ * unrecognised.
  *
  * Unknown flags used to be skipped along with the following argument, so a flag
  * `gh-axi api` did not implement — `--jq` above all — silently vanished together
  * with its value and the caller got an unfiltered response that looked plausible.
  * Only flags known to take a value consume the next argument, which also keeps
  * `--paginate <path>` from swallowing the path.
+ *
+ * This single pass is also the only place that decides which flags consume a
+ * value: re-scanning args afterwards gave a second, value-blind notion of the
+ * same thing, so `--header --jq=.x` both consumed `--jq=.x` as the header value
+ * and forwarded it as a jq expression.
  */
-function parsePositionals(args: string[]): string[] {
-  const positionals: string[] = [];
+function parseArgs(args: string[]): ParsedApiArgs {
+  const parsed: ParsedApiArgs = {
+    positionals: [],
+    fields: [],
+    headers: [],
+    paginate: false,
+  };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (!arg.startsWith('-')) {
-      positionals.push(arg);
+      parsed.positionals.push(arg);
       continue;
     }
     const name = flagName(arg);
     if (BOOL_FLAGS.has(name)) {
       if (name !== arg)
         throw new AxiError(`${name} does not take a value`, 'VALIDATION_ERROR');
+      parsed.paginate = true;
       continue;
     }
-    if (VALUE_FLAGS.has(name)) {
-      // `--flag=value` carries its own value; `--flag value` consumes the next arg.
-      if (name === arg) {
-        if (i + 1 >= args.length)
-          throw new AxiError(`${name} requires a value`, 'VALIDATION_ERROR');
-        i++;
-      }
-      continue;
+    if (!REPEATABLE_VALUE_FLAGS.has(name) && !SINGLE_VALUE_FLAGS.has(name)) {
+      throw new AxiError(
+        `unknown flag ${name} for gh-axi api. Supported flags: ${SUPPORTED_FLAGS.join(', ')}`,
+        'VALIDATION_ERROR',
+      );
     }
-    throw new AxiError(
-      `unknown flag ${name} for gh-axi api. Supported flags: ${[...VALUE_FLAGS, ...BOOL_FLAGS].join(', ')}`,
-      'VALIDATION_ERROR',
-    );
+    // `--flag=value` carries its own value; `--flag value` consumes the next arg.
+    let value: string;
+    if (name === arg) {
+      if (i + 1 >= args.length)
+        throw new AxiError(`${name} requires a value`, 'VALIDATION_ERROR');
+      value = args[++i];
+    } else {
+      value = arg.slice(name.length + 1);
+    }
+    if (name === '--field') {
+      parsed.fields.push(value);
+    } else if (name === '--header') {
+      parsed.headers.push(value);
+    } else {
+      // gh takes the last occurrence; discarding the earlier expression silently
+      // is the same failure this parser exists to prevent, so reject instead.
+      const key = name === '--jq' ? 'jq' : 'template';
+      if (parsed[key] !== undefined)
+        throw new AxiError(`${name} may only be given once`, 'VALIDATION_ERROR');
+      parsed[key] = value;
+    }
   }
-  return positionals;
+  return parsed;
 }
 
 /** Maximum length for raw (non-JSON) API output before truncation. */
@@ -84,8 +123,7 @@ const STRING_VALUE_TRUNCATION_LIMIT = 2000;
 export async function apiCommand(args: string[], ctx?: RepoContext): Promise<string> {
   if (args[0] === '--help' || args.length === 0) return API_HELP;
 
-  // Parse method and path from positional args
-  const positionals = parsePositionals(args);
+  const { positionals, fields, headers, jq, template, paginate } = parseArgs(args);
 
   let method: string;
   let path: string;
@@ -102,34 +140,31 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
 
   const ghArgs = ['api', path, '--method', method];
 
-  const fields = getAllFlags(args, '--field');
   for (const f of fields) {
     ghArgs.push('--field', f);
   }
 
-  const headers = getAllFlags(args, '--header');
   for (const h of headers) {
     ghArgs.push('--header', h);
   }
 
-  if (hasFlag(args, '--paginate')) ghArgs.push('--paginate');
+  if (paginate) ghArgs.push('--paginate');
 
-  const jq = getFlag(args, '--jq');
   if (jq !== undefined) ghArgs.push('--jq', jq);
 
-  const template = getFlag(args, '--template');
   if (template !== undefined) ghArgs.push('--template', template);
 
   // A caller who wrote a jq expression or template already chose the exact shape
   // they want, so noisy-field stripping would silently delete fields they asked
-  // for by name (`url`, `node_id`, ...).
+  // for by name (`url`, `node_id`, ...). The length clamp still applies, so a
+  // selected field cannot blow the caller's context with an unbounded blob.
   const callerShapedOutput = jq !== undefined || template !== undefined;
 
   // Try to parse as JSON, strip noisy fields, encode to TOON; fall back to raw output
   const raw = await ghExec(ghArgs, ctx);
   try {
     const data = JSON.parse(raw);
-    const cleaned = callerShapedOutput ? data : stripNoisyFields(data);
+    const cleaned = callerShapedOutput ? clampStrings(data) : stripNoisyFields(data);
     return encode(cleaned);
   } catch {
     // Not JSON — wrap in TOON envelope with truncation metadata
@@ -182,6 +217,34 @@ function collapseRepo(obj: Record<string, unknown>): Record<string, unknown> {
   return obj;
 }
 
+/** Clean and truncate a long string value (e.g. bodies, comments, blobs). */
+function clampString(value: string): string {
+  if (value.length <= LONG_STRING_CLEANUP_THRESHOLD) return value;
+  const cleaned = cleanBody(value);
+  if (cleaned.length > STRING_VALUE_TRUNCATION_LIMIT) {
+    return cleaned.slice(0, STRING_VALUE_TRUNCATION_LIMIT) + '... (truncated)';
+  }
+  return cleaned;
+}
+
+/**
+ * Bound string values without touching keys, for output the caller shaped with
+ * --jq/--template.
+ */
+function clampStrings(obj: unknown, depth = 0): unknown {
+  if (depth > 8) return obj;
+  if (Array.isArray(obj)) return obj.map((item) => clampStrings(item, depth + 1));
+  if (obj !== null && typeof obj === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+      result[key] = clampStrings(value, depth + 1);
+    }
+    return result;
+  }
+  if (typeof obj === 'string') return clampString(obj);
+  return obj;
+}
+
 function stripNoisyFields(obj: unknown, depth = 0): unknown {
   if (depth > 8) return obj;
   if (Array.isArray(obj)) {
@@ -207,13 +270,6 @@ function stripNoisyFields(obj: unknown, depth = 0): unknown {
     }
     return result;
   }
-  // Clean and truncate long string values (e.g. bodies, comments)
-  if (typeof obj === 'string' && obj.length > LONG_STRING_CLEANUP_THRESHOLD) {
-    const s = cleanBody(obj);
-    if (s.length > STRING_VALUE_TRUNCATION_LIMIT) {
-      return s.slice(0, STRING_VALUE_TRUNCATION_LIMIT) + '... (truncated)';
-    }
-    return s;
-  }
+  if (typeof obj === 'string') return clampString(obj);
   return obj;
 }

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -104,6 +104,10 @@ function parseArgs(args: string[]): ParsedApiArgs {
       const key = name === '--jq' ? 'jq' : 'template';
       if (parsed[key] !== undefined)
         throw new AxiError(`${name} may only be given once`, 'VALIDATION_ERROR');
+      // An empty value (an unset shell variable) is a no-op filter for gh that
+      // would still suppress the default field stripping here.
+      if (value.trim() === '')
+        throw new AxiError(`${name} requires a value`, 'VALIDATION_ERROR');
       parsed[key] = value;
     }
   }
@@ -125,18 +129,25 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
 
   const { positionals, fields, headers, jq, template, paginate } = parseArgs(args);
 
-  let method: string;
-  let path: string;
+  const pathRequired = new AxiError(
+    'API path is required: gh-axi api [<method>] <path>',
+    'VALIDATION_ERROR',
+  );
+  if (positionals.length === 0) throw pathRequired;
 
-  if (positionals.length >= 2 && HTTP_METHODS.has(positionals[0].toUpperCase())) {
-    method = positionals[0].toUpperCase();
-    path = positionals[1];
-  } else if (positionals.length >= 1) {
-    method = 'GET';
-    path = positionals[0];
-  } else {
-    throw new AxiError('API path is required: gh-axi api [<method>] <path>', 'VALIDATION_ERROR');
+  // A positional the command cannot place is a caller typo, and dropping it
+  // silently requests a different endpoint than the one that was asked for.
+  const methodGiven = HTTP_METHODS.has(positionals[0].toUpperCase());
+  if (positionals.length > (methodGiven ? 2 : 1)) {
+    throw new AxiError(
+      'too many arguments for gh-axi api: expected [<method>] <path>',
+      'VALIDATION_ERROR',
+    );
   }
+  if (methodGiven && positionals.length < 2) throw pathRequired;
+
+  const method = methodGiven ? positionals[0].toUpperCase() : 'GET';
+  const path = methodGiven ? positionals[1] : positionals[0];
 
   const ghArgs = ['api', path, '--method', method];
 
@@ -164,8 +175,7 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
   const raw = await ghExec(ghArgs, ctx);
   try {
     const data = JSON.parse(raw);
-    const cleaned = callerShapedOutput ? clampStrings(data) : stripNoisyFields(data);
-    return encode(cleaned);
+    return encode(shapeOutput(data, !callerShapedOutput));
   } catch {
     // Not JSON — wrap in TOON envelope with truncation metadata
     const trimmed = raw.trim();
@@ -217,43 +227,39 @@ function collapseRepo(obj: Record<string, unknown>): Record<string, unknown> {
   return obj;
 }
 
+/** Bound a string value's length, leaving its content untouched. */
+function truncateString(value: string): string {
+  if (value.length <= STRING_VALUE_TRUNCATION_LIMIT) return value;
+  return value.slice(0, STRING_VALUE_TRUNCATION_LIMIT) + '... (truncated)';
+}
+
 /** Clean and truncate a long string value (e.g. bodies, comments, blobs). */
 function clampString(value: string): string {
   if (value.length <= LONG_STRING_CLEANUP_THRESHOLD) return value;
-  const cleaned = cleanBody(value);
-  if (cleaned.length > STRING_VALUE_TRUNCATION_LIMIT) {
-    return cleaned.slice(0, STRING_VALUE_TRUNCATION_LIMIT) + '... (truncated)';
-  }
-  return cleaned;
+  return truncateString(cleanBody(value));
 }
 
 /**
- * Bound string values without touching keys, for output the caller shaped with
- * --jq/--template.
+ * Walk a decoded API response, bounding every string value.
+ *
+ * With `stripNoisyKeys` the noisy keys are dropped and long strings are cleaned
+ * as well. Output the caller shaped with --jq/--template keeps both its keys and
+ * its content verbatim and is only length-bounded, since rewriting a field they
+ * selected by name is the same silent mutation as deleting it.
  */
-function clampStrings(obj: unknown, depth = 0): unknown {
-  if (depth > 8) return obj;
-  if (Array.isArray(obj)) return obj.map((item) => clampStrings(item, depth + 1));
-  if (obj !== null && typeof obj === 'object') {
-    const result: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
-      result[key] = clampStrings(value, depth + 1);
-    }
-    return result;
-  }
-  if (typeof obj === 'string') return clampString(obj);
-  return obj;
-}
-
-function stripNoisyFields(obj: unknown, depth = 0): unknown {
+function shapeOutput(obj: unknown, stripNoisyKeys: boolean, depth = 0): unknown {
   if (depth > 8) return obj;
   if (Array.isArray(obj)) {
-    return obj.map((item) => stripNoisyFields(item, depth + 1));
+    return obj.map((item) => shapeOutput(item, stripNoisyKeys, depth + 1));
   }
   if (obj !== null && typeof obj === 'object') {
     const record = obj as Record<string, unknown>;
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(record)) {
+      if (!stripNoisyKeys) {
+        result[key] = shapeOutput(value, stripNoisyKeys, depth + 1);
+        continue;
+      }
       if (NOISY_KEYS.has(key)) continue;
       if (isTemplateUrlKey(key)) continue;
       // Strip nested user objects down to just login
@@ -266,10 +272,10 @@ function stripNoisyFields(obj: unknown, depth = 0): unknown {
         result[key] = collapseRepo(value as Record<string, unknown>);
         continue;
       }
-      result[key] = stripNoisyFields(value, depth + 1);
+      result[key] = shapeOutput(value, stripNoisyKeys, depth + 1);
     }
     return result;
   }
-  if (typeof obj === 'string') return clampString(obj);
+  if (typeof obj === 'string') return stripNoisyKeys ? clampString(obj) : truncateString(obj);
   return obj;
 }

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -2,21 +2,74 @@ import { encode } from '@toon-format/toon';
 import type { RepoContext } from '../context.js';
 import { ghExec } from '../gh.js';
 import { AxiError } from '../errors.js';
-import { hasFlag, getAllFlags } from '../args.js';
+import { hasFlag, getFlag, getAllFlags } from '../args.js';
 import { cleanBody } from '../body.js';
 
 export const API_HELP = `usage: gh-axi api [<method>] <path>
 description: Make an authenticated GitHub API request. Defaults to GET if no method specified.
 methods[6]:
   GET, POST, PUT, PATCH, DELETE, HEAD
-flags[3]:
-  --field <key=value> (repeatable), --header <key:value> (repeatable), --paginate
+flags[5]:
+  --field <key=value> (repeatable), --header <key:value> (repeatable), --paginate, --jq <expression>, --template <format>
 examples:
   gh-axi api /repos/{owner}/{repo}
   gh-axi api POST /repos/{owner}/{repo}/issues --field title="Bug report"
-  gh-axi api /repos/{owner}/{repo}/pulls --paginate`;
+  gh-axi api /repos/{owner}/{repo}/pulls --paginate
+  gh-axi api /repos/{owner}/{repo}/issues/1 --jq '[.labels[].name]'`;
 
 const HTTP_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD']);
+
+/** Flags that consume the following argument as their value. */
+const VALUE_FLAGS = new Set(['--field', '--header', '--jq', '--template']);
+
+/** Flags that stand alone and must not consume the following argument. */
+const BOOL_FLAGS = new Set(['--paginate']);
+
+/** The flag's name without any `=value` suffix, so errors never echo a value. */
+function flagName(arg: string): string {
+  const equals = arg.indexOf('=');
+  return equals === -1 ? arg : arg.slice(0, equals);
+}
+
+/**
+ * Split args into positionals, rejecting anything unrecognised.
+ *
+ * Unknown flags used to be skipped along with the following argument, so a flag
+ * `gh-axi api` did not implement — `--jq` above all — silently vanished together
+ * with its value and the caller got an unfiltered response that looked plausible.
+ * Only flags known to take a value consume the next argument, which also keeps
+ * `--paginate <path>` from swallowing the path.
+ */
+function parsePositionals(args: string[]): string[] {
+  const positionals: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith('-')) {
+      positionals.push(arg);
+      continue;
+    }
+    const name = flagName(arg);
+    if (BOOL_FLAGS.has(name)) {
+      if (name !== arg)
+        throw new AxiError(`${name} does not take a value`, 'VALIDATION_ERROR');
+      continue;
+    }
+    if (VALUE_FLAGS.has(name)) {
+      // `--flag=value` carries its own value; `--flag value` consumes the next arg.
+      if (name === arg) {
+        if (i + 1 >= args.length)
+          throw new AxiError(`${name} requires a value`, 'VALIDATION_ERROR');
+        i++;
+      }
+      continue;
+    }
+    throw new AxiError(
+      `unknown flag ${name} for gh-axi api. Supported flags: ${[...VALUE_FLAGS, ...BOOL_FLAGS].join(', ')}`,
+      'VALIDATION_ERROR',
+    );
+  }
+  return positionals;
+}
 
 /** Maximum length for raw (non-JSON) API output before truncation. */
 const RAW_OUTPUT_TRUNCATION_LIMIT = 4000;
@@ -32,14 +85,7 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
   if (args[0] === '--help' || args.length === 0) return API_HELP;
 
   // Parse method and path from positional args
-  const positionals: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    if (args[i].startsWith('--')) {
-      i++; // skip flag value
-    } else {
-      positionals.push(args[i]);
-    }
-  }
+  const positionals = parsePositionals(args);
 
   let method: string;
   let path: string;
@@ -68,11 +114,22 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
 
   if (hasFlag(args, '--paginate')) ghArgs.push('--paginate');
 
+  const jq = getFlag(args, '--jq');
+  if (jq !== undefined) ghArgs.push('--jq', jq);
+
+  const template = getFlag(args, '--template');
+  if (template !== undefined) ghArgs.push('--template', template);
+
+  // A caller who wrote a jq expression or template already chose the exact shape
+  // they want, so noisy-field stripping would silently delete fields they asked
+  // for by name (`url`, `node_id`, ...).
+  const callerShapedOutput = jq !== undefined || template !== undefined;
+
   // Try to parse as JSON, strip noisy fields, encode to TOON; fall back to raw output
   const raw = await ghExec(ghArgs, ctx);
   try {
     const data = JSON.parse(raw);
-    const cleaned = stripNoisyFields(data);
+    const cleaned = callerShapedOutput ? data : stripNoisyFields(data);
     return encode(cleaned);
   } catch {
     // Not JSON — wrap in TOON envelope with truncation metadata

--- a/test/commands/api.test.ts
+++ b/test/commands/api.test.ts
@@ -100,6 +100,71 @@ describe('apiCommand', () => {
     expect(result).toContain('truncated: false');
   });
 
+  it('forwards --jq to gh api', async () => {
+    mockedGhExec.mockResolvedValue('[]');
+
+    await apiCommand(['/repos/octo/repo/issues/1', '--jq', '[.labels[].name]']);
+
+    expect(mockedGhExec).toHaveBeenCalledWith(
+      expect.arrayContaining(['--jq', '[.labels[].name]']),
+      undefined,
+    );
+  });
+
+  it('forwards --template to gh api', async () => {
+    mockedGhExec.mockResolvedValue('out');
+
+    await apiCommand(['/repos/octo/repo', '--template', '{{.name}}']);
+
+    expect(mockedGhExec).toHaveBeenCalledWith(
+      expect.arrayContaining(['--template', '{{.name}}']),
+      undefined,
+    );
+  });
+
+  it('does not strip fields the caller explicitly selected with --jq', async () => {
+    // `url` is a noisy key by default, but selecting it by hand is deliberate.
+    mockedGhExec.mockResolvedValue(JSON.stringify({ url: 'https://api.github.com/x' }));
+
+    const result = await apiCommand(['/repos/octo/repo', '--jq', '{url: .url}']);
+
+    expect(result).toContain('https://api.github.com/x');
+  });
+
+  it('rejects an unknown flag instead of silently ignoring it', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '--bogus', 'x'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it('names the offending flag without echoing its value', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '--token=hunter2'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('--token'),
+    });
+    await expect(apiCommand(['/repos/octo/repo', '--token=hunter2'])).rejects.not.toMatchObject({
+      message: expect.stringContaining('hunter2'),
+    });
+  });
+
+  it('does not consume the path when --paginate precedes it', async () => {
+    mockedGhExec.mockResolvedValue('{}');
+
+    await apiCommand(['--paginate', '/repos/octo/repo/pulls']);
+
+    expect(mockedGhExec).toHaveBeenCalledWith(
+      expect.arrayContaining(['api', '/repos/octo/repo/pulls', '--paginate']),
+      undefined,
+    );
+  });
+
+  it('rejects a value flag with no value', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '--jq'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    });
+  });
+
   it('wraps truncated non-JSON output in TOON envelope with truncation metadata', async () => {
     const longText = 'x'.repeat(5000);
     mockedGhExec.mockResolvedValue(longText);

--- a/test/commands/api.test.ts
+++ b/test/commands/api.test.ts
@@ -159,6 +159,66 @@ describe('apiCommand', () => {
     );
   });
 
+  it('rejects a repeated --jq instead of silently dropping one expression', async () => {
+    await expect(
+      apiCommand(['/repos/octo/repo', '--jq', '.name', '--jq', '.full_name']),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('--jq'),
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it('rejects a repeated --template without echoing either value', async () => {
+    await expect(
+      apiCommand(['/repos/octo/repo', '--template={{.name}}', '--template={{.id}}']),
+    ).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('--template'),
+    });
+    await expect(
+      apiCommand(['/repos/octo/repo', '--template={{.name}}', '--template={{.id}}']),
+    ).rejects.not.toMatchObject({ message: expect.stringContaining('{{.name}}') });
+  });
+
+  it('does not forward a flag-shaped --header value as its own flag', async () => {
+    mockedGhExec.mockResolvedValue('{}');
+
+    await apiCommand(['/repos/octo/repo', '--header', '--jq=.x']);
+
+    const ghArgs = mockedGhExec.mock.calls[0][0];
+    expect(ghArgs).toEqual(expect.arrayContaining(['--header', '--jq=.x']));
+    expect(ghArgs).not.toContain('--jq');
+  });
+
+  it('truncates long string values in caller-shaped --jq output', async () => {
+    const blob = 'a'.repeat(50_000);
+    mockedGhExec.mockResolvedValue(JSON.stringify({ content: blob }));
+
+    const result = await apiCommand(['/repos/octo/repo/readme', '--jq', '{content: .content}']);
+
+    expect(result).toContain('... (truncated)');
+    expect(result.length).toBeLessThan(3000);
+  });
+
+  it('repeats --field and --header flags in order', async () => {
+    mockedGhExec.mockResolvedValue('{}');
+
+    await apiCommand([
+      'POST', '/repos/octo/repo/issues',
+      '--field', 'title=Bug', '--field=body=Broken',
+      '--header', 'A:1', '--header', 'B:2',
+    ]);
+
+    expect(mockedGhExec).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        '--field', 'title=Bug', '--field', 'body=Broken',
+        '--header', 'A:1', '--header', 'B:2',
+      ]),
+      undefined,
+    );
+  });
+
   it('rejects a value flag with no value', async () => {
     await expect(apiCommand(['/repos/octo/repo', '--jq'])).rejects.toMatchObject({
       code: 'VALIDATION_ERROR',

--- a/test/commands/api.test.ts
+++ b/test/commands/api.test.ts
@@ -219,6 +219,63 @@ describe('apiCommand', () => {
     );
   });
 
+  it('rejects an empty --jq value instead of silently disabling field stripping', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '--jq='])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('--jq'),
+    });
+    await expect(apiCommand(['/repos/octo/repo', '--jq', '   '])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty --template value', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '--template='])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('--template'),
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it('does not rewrite content of a long string on the --jq path', async () => {
+    const body = 'see https://github.com/octo/repo/pull/5 '.repeat(10);
+    mockedGhExec.mockResolvedValue(JSON.stringify({ body }));
+
+    const result = await apiCommand(['/repos/octo/repo/issues/1', '--jq', '{body: .body}']);
+
+    expect(body.length).toBeGreaterThan(200);
+    expect(result).toContain('https://github.com/octo/repo/pull/5');
+    expect(result).not.toContain('PR#5');
+  });
+
+  it('still cleans long strings on the default path', async () => {
+    const body = 'see https://github.com/octo/repo/pull/5 '.repeat(10);
+    mockedGhExec.mockResolvedValue(JSON.stringify({ body }));
+
+    const result = await apiCommand(['/repos/octo/repo/issues/1']);
+
+    expect(result).toContain('PR#5');
+  });
+
+  it('rejects an extra positional instead of silently ignoring it', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '/extra'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    });
+    await expect(apiCommand(['POST', '/repos/octo/repo', '/extra'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it('rejects a lone HTTP method with no path', async () => {
+    await expect(apiCommand(['POST'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('path is required'),
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
   it('rejects a value flag with no value', async () => {
     await expect(apiCommand(['/repos/octo/repo', '--jq'])).rejects.toMatchObject({
       code: 'VALIDATION_ERROR',


### PR DESCRIPTION
## What Changed

- Replaced `api`'s positional scan with a single-pass argument parser (`parseArgs` in `src/commands/api.ts`) that knows which flags take a value: `--jq` and `--template` are now forwarded to `gh` instead of being swallowed with their value, `--paginate` no longer consumes the following argument, and unknown flags, missing/empty flag values, a repeated `--jq`/`--template`, and extra positionals all raise a `VALIDATION_ERROR` (error text echoes the flag name only, never its value).
- Reworked output shaping: `stripNoisyFields` became `shapeOutput(data, stripNoisyKeys)`, so a response the caller shaped with `--jq`/`--template` keeps every key and value verbatim while still being length-clamped at 2000 chars — previously that path had no size cap at all.
- Documented the five supported `api` flags and the strict parsing behavior in the command help text and `README.md`, and added 27 tests in `test/commands/api.test.ts` covering the parser and the two output paths (full suite: 626 tests passing).

## Risk Assessment

✅ Low: All seven findings across the two prior review rounds are now fixed with dedicated unit tests, the walker dedupe is behavior-preserving on the default path line for line, and the change stays confined to one command plus its test file with no stale references, dead exports, or doc drift.

## Testing

Ran the full vitest suite (626 tests, all green) and then produced the real evidence: a live-GitHub-API CLI transcript comparing the published gh-axi 0.1.27 (equal to the base commit) against a build of this branch, covering the exact issue #77 repro plus unknown-flag, duplicate-flag, empty-value, stray-positional, `--paginate`, `--template`, and no-regression cases; the before/after difference shows `--jq` going from silently ignored (full object dump) to correctly filtered output and unknown flags going from silently swallowed to a loud VALIDATION_ERROR with exit 2. This is a CLI-only change with no rendered UI surface, so the transcript file is the reviewer-visible artifact; the build output was removed afterwards and the worktree is clean.

<details>
<summary>Evidence: Before/after CLI transcript against the live GitHub API (issue #77 repro + flag validation)</summary>

<code># BEFORE — gh-axi 0.1.27 (published, == base 291fc1a)&#10;$ gh-axi api repos/kunchenguid/gh-axi/issues/72 --jq &#39;[.labels[].name]&#39;&#10;id: 4879728874&#10;number: 72&#10;title: &#34;chore(main): release gh-axi 0.1.28&#34;&#10;user: &#34;github-actions[bot]&#34;&#10;labels[1]{id,name,color,default,description}:&#10;10524724474,&#34;autorelease: pending&#34;,ededed,false,null&#10;state: open&#10;... (whole object — --jq ignored)&#10;[exit 0]&#10;&#10;$ gh-axi api --totally-bogus somevalue repos/kunchenguid/gh-axi/issues/72&#10;id: 4879728874&#10;... (unknown flag silently swallowed)&#10;[exit 0]&#10;&#10;$ gh-axi api --paginate repos/kunchenguid/gh-axi/issues/72&#10;error: &#34;API path is required: gh-axi api [&lt;method&gt;] &lt;path&gt;&#34; # --paginate ate the path&#10;[exit 2]&#10;&#10;# AFTER — this branch (4ffe6c8)&#10;$ gh-axi api repos/kunchenguid/gh-axi/issues/72 --jq &#39;[.labels[].name]&#39;&#10;[1]: &#34;autorelease: pending&#34;&#10;[exit 0]&#10;&#10;$ gh-axi api repos/kunchenguid/gh-axi/issues/72 --template &#39;{{.number}} {{.state}}&#39;&#10;api_response:&#10;body: 72 open&#10;[exit 0]&#10;&#10;$ gh-axi api --totally-bogus somevalue repos/kunchenguid/gh-axi/issues/72&#10;error: &#34;unknown flag --totally-bogus for gh-axi api. Supported flags: --field, --header, --jq, --template, --paginate&#34;&#10;code: VALIDATION_ERROR&#10;[exit 2]&#10;&#10;$ gh-axi api --paginate repos/kunchenguid/gh-axi/labels&#10;[13]{id,name,color,default,description}:&#10;10524724474,&#34;autorelease: pending&#34;,ededed,false,null&#10;... 12 more labels ...&#10;[exit 0]&#10;&#10;$ gh-axi api &lt;path&gt; --jq .title --jq .state -&gt; &#34;--jq may only be given once&#34; [exit 2]&#10;$ gh-axi api &lt;path&gt; --jq= -&gt; &#34;--jq requires a value&#34; [exit 2]&#10;$ gh-axi api --paginate=true &lt;path&gt; -&gt; &#34;--paginate does not take a value&#34; [exit 2]&#10;$ gh-axi api GET &lt;path&gt; extra-typo -&gt; &#34;too many arguments...&#34; [exit 2]&#10;$ gh-axi api &lt;path&gt; --x-secret=hunter2 -&gt; &#34;unknown flag --x-secret ...&#34; (value never echoed) [exit 2]</code>

```text
############################################################
# BEFORE  — gh-axi 0.1.27 (published, == base 291fc1a)
############################################################

--- issue #77 repro: --jq silently ignored, full body dumped ---

$ /opt/homebrew/bin/gh-axi api repos/kunchenguid/gh-axi/issues/72 --jq [.labels[].name]
id: 4879728874
number: 72
title: "chore(main): release gh-axi 0.1.28"
user: "github-actions[bot]"
labels[1]{id,name,color,default,description}:
  10524724474,"autorelease: pending",ededed,false,null
state: open
locked: false
assignees: []
milestone: null
comments: 0
created_at: "2026-07-14T04:02:30Z"
updated_at: "2026-07-14T04:02:31Z"
closed_at: null
[exit 0]

--- unknown flag swallowed together with its value, no error ---

$ /opt/homebrew/bin/gh-axi api --totally-bogus somevalue repos/kunchenguid/gh-axi/issues/72
id: 4879728874
number: 72
title: "chore(main): release gh-axi 0.1.28"
user: "github-actions[bot]"
labels[1]{id,name,color,default,description}:
  10524724474,"autorelease: pending",ededed,false,null
state: open
locked: false
assignees: []
milestone: null
comments: 0
created_at: "2026-07-14T04:02:30Z"
updated_at: "2026-07-14T04:02:31Z"
closed_at: null
[exit 0]

--- --paginate eats the path that follows it ---

$ /opt/homebrew/bin/gh-axi api --paginate repos/kunchenguid/gh-axi/issues/72
error: "API path is required: gh-axi api [<method>] <path>"
code: VALIDATION_ERROR
[exit 2]

############################################################
# AFTER   — this branch (bauti/fix-api-unknown-flags @ 4ffe6c8)
############################################################

--- issue #77 repro: --jq now applied, only the labels come back ---

$ node dist/bin/gh-axi.js api repos/kunchenguid/gh-axi/issues/72 --jq [.labels[].name]
[1]: "autorelease: pending"
[exit 0]

--- --jq=expr equals form, and a scalar projection ---

$ node dist/bin/gh-axi.js api repos/kunchenguid/gh-axi/issues/72 --jq=.title
api_response:
  body: "chore(main): release gh-axi 0.1.28"
  truncated: false
[exit 0]

--- --template is forwarded too ---

$ node dist/bin/gh-axi.js api repos/kunchenguid/gh-axi/issues/72 --template {{.number}} {{.state}}
api_response:
  body: 72 open
  truncated: false
[exit 0]

--- unknown flag is now a loud validation error ---

$ node dist/bin/gh-axi.js api --totally-bogus somevalue repos/kunchenguid/gh-axi/issues/72
error: "unknown flag --totally-bogus for gh-axi api. Supported flags: --field, --header, --jq, --template, --paginate"
code: VALIDATION_ERROR
[exit 2]

--- --paginate no longer swallows the path ---

$ node dist/bin/gh-axi.js api --paginate repos/kunchenguid/gh-axi/labels
[13]{id,name,color,default,description}:
  10524724474,"autorelease: pending",ededed,false,null
  10524731617,"autorelease: tagged",ededed,false,null
  10524630915,bug,d73a4a,true,Something isn't working
  10524630932,documentation,0075ca,true,Improvements or additions to documentation
  10524630945,duplicate,cfd3d7,true,This issue or pull request already exists
  10524630958,enhancement,a2eeef,true,New feature or request
  10945865255,ezoss/awaiting-contributor,C5DEF5,false,Managed by ezoss
  10854402776,ezoss/triaged,C2E0C6,false,Managed by ezoss
  10524630980,good first issue,7057ff,true,Good for newcomers
  10524630969,help wanted,"008672",true,Extra attention is needed
  10524630991,invalid,e4e669,true,This doesn't seem right
  10524631000,question,d876e3,true,Further information is requested
  10524631011,wontfix,ffffff,true,This will not be worked on
[exit 0]

--- --paginate rejects an attached value ---

$ node dist/bin/gh-axi.js api --paginate=true repos/kunchenguid/gh-axi/issues/72
error: "--paginate does not take a value"
code: VALIDATION_ERROR
[exit 2]

--- repeated --jq rejected instead of silently keeping the last ---

$ node dist/bin/gh-axi.js api repos/kunchenguid/gh-axi/issues/72 --jq .title --jq .state
error: "--jq may only be given once"
code: VALIDATION_ERROR
[exit 2]

--- empty --jq (unset shell var) rejected instead of no-op filtering ---

$ node dist/bin/gh-axi.js api repos/kunchenguid/gh-axi/issues/72 --jq=
error: "--jq requires a value"
code: VALIDATION_ERROR
[exit 2]

--- value flag with no value at all ---

$ node dist/bin/gh-axi.js api repos/kunchenguid/gh-axi/issues/72 --jq
error: "--jq requires a value"
code: VALIDATION_ERROR
[exit 2]

--- stray positional rejected instead of silently dropped ---

$ node dist/bin/gh-axi.js api GET repos/kunchenguid/gh-axi/issues/72 extra-typo
error: "too many arguments for gh-axi api: expected [<method>] <path>"
code: VALIDATION_ERROR
[exit 2]

--- error text never echoes the flag's value (no secret leak) ---

$ node dist/bin/gh-axi.js api repos/kunchenguid/gh-axi/issues/72 --x-secret=hunter2
error: "unknown flag --x-secret for gh-axi api. Supported flags: --field, --header, --jq, --template, --paginate"
code: VALIDATION_ERROR
[exit 2]

--- no --jq: default TOON + noisy-field stripping still applies ---

$ node dist/bin/gh-axi.js api repos/kunchenguid/gh-axi/labels/bug
id: 10524630915
name: bug
color: d73a4a
default: true
description: Something isn't working
[exit 0]

--- repeatable --field / --header still work (POST dry shape via GET+field) ---

$ node dist/bin/gh-axi.js api search/issues --field q=repo:kunchenguid/gh-axi is:pr --header X-Demo: 1 --jq .total_count
66
[exit 0]

--- help now advertises the new flags ---

$ node dist/bin/gh-axi.js api --help
usage: gh-axi api [<method>] <path>
description: Make an authenticated GitHub API request. Defaults to GET if no method specified.
methods[6]:
  GET, POST, PUT, PATCH, DELETE, HEAD
flags[5]:
  --field <key=value> (repeatable), --header <key:value> (repeatable), --paginate, --jq <expression>, --template <format>
examples:
  gh-axi api /repos/{owner}/{repo}
  gh-axi api POST /repos/{owner}/{repo}/issues --field title="Bug report"
  gh-axi api /repos/{owner}/{repo}/pulls --paginate
  gh-axi api /repos/{owner}/{repo}/issues/1 --jq '[.labels[].name]'[exit 0]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `src/commands/api.ts:132` - When --jq or --template is passed, `callerShapedOutput` skips `stripNoisyFields` entirely — and that function is the *only* size cap on the JSON branch (it truncates strings over 2000 chars via STRING_VALUE_TRUNCATION_LIMIT). The non-JSON fallback caps at 4000 chars, but this path has no cap at all. Failure: `gh-axi api /repos/o/r/readme --jq &#39;{c: .content}&#39;` returns valid JSON, skips stripping, and dumps the full base64 blob (hundreds of KB) unbounded, blowing the agent&#39;s context — whereas the same request without --jq is capped at 2000 chars. Consider keeping the length truncation while skipping only the key-stripping (e.g. split stripNoisyFields into a key filter and a string clamp, and always apply the clamp).
- ⚠️ `src/commands/api.ts:117` - `getFlag` returns the *first* match and ignores the rest, and `parsePositionals` accepts duplicates without complaint, so `--jq A --jq B` silently forwards only `A`. This is the same silently-dropped-flag class the commit exists to fix (and matches open issues #75/#78), and it diverges from `gh` itself, where cobra&#39;s repeated string flag takes the *last* value — so the user gets a plausible-looking but wrong-filtered response. Same for `--template`. Either reject a duplicate `--jq`/`--template` in `parsePositionals` or take the last occurrence to match gh.
- ℹ️ `src/commands/api.ts:43` - `args` is now walked five times with two different notions of which flags consume the next argument: `parsePositionals` uses VALUE_FLAGS/BOOL_FLAGS, while the later `getAllFlags`/`getFlag`/`hasFlag` calls each re-scan the whole array with no concept of value positions. That duplication is the root cause of the duplicate-flag bug above, and it means adding a flag requires updating two places that can drift (a value-position arg matching a flag name exactly, e.g. `--header --jq=.x`, is skipped by parsePositionals but still picked up by getFlag and forwarded to gh). A single pass in `parsePositionals` returning `{positionals, fields, headers, jq, template, paginate}` would remove both the drift and the extra scans.

🔧 Fix: bound --jq output and reject duplicate api flags
4 issues (1 warning, 3 infos) still open:
- ⚠️ `src/commands/api.ts:107` - `parseArgs` accepts an empty value for --jq/--template: `--jq=` (or `--jq &#34;&#34;`, which is what an unset shell variable expands to) sets `parsed.jq = &#39;&#39;`, which is `!== undefined`, so line 161 flips `callerShapedOutput` to true and line 153 forwards `--jq &#39;&#39;` to gh. gh&#39;s api command only applies the filter when FilterOutput is non-empty, so the expression does nothing — while gh-axi has already swapped `stripNoisyFields` for the key-preserving `clampStrings`. Failure: `gh-axi api /repos/o/r --jq=&#34;$UNSET_VAR&#34;` silently returns the *full unstripped* response, i.e. an empty flag both no-ops and disables the tool&#39;s default cleanup with no error. This is the same silent-no-op-flag class as open issue #80 (empty `--assignee=`). Reject an empty value for --jq/--template in parseArgs alongside the existing &#39;requires a value&#39; check.
- ℹ️ `src/commands/api.ts:223` - `clampString` runs `cleanBody` on every string over LONG_STRING_CLEANUP_THRESHOLD (200) chars, even when the result stays under the 2000-char limit and no truncation marker is appended. `cleanBody` rewrites GitHub PR/issue URLs to `PR#5`/`Issue#5`, replaces `![alt](url)` with `[image: alt]`, and collapses quoted blocks to `[quoted text removed]`. On the caller-shaped path this silently alters a field the caller selected by name — `--jq &#39;{b: .body}&#39;` on a 300-char body containing a PR link returns `PR#5` with no indication anything changed — which cuts against the rationale in the comment at line 157. This mirrors pre-existing default-path behavior, but --jq newly exposes it. Note `truncateBody` in src/body.ts sets the precedent of signaling this (`(cleaned, N chars original ...)`). Consider only invoking cleanBody when the string actually exceeds STRING_VALUE_TRUNCATION_LIMIT, or signaling when cleanup modified content.
- ℹ️ `src/commands/api.ts:234` - `clampStrings` (234-246) and `stripNoisyFields` (248-275) are the same recursive walk — identical `depth &gt; 8` guard, identical array mapping, identical object rebuild, identical `clampString` leaf handling — differing only in the per-key filtering the object branch applies. That is exactly the duplicate-notion-of-one-thing pattern round 1 removed from the arg parser, reintroduced on the output side: a change to the depth limit, array handling, or leaf clamping now has to be made in two places or the two paths drift. Fold them into one walker that takes the key filter (or a `stripKeys` boolean) as a parameter.
- ℹ️ `src/commands/api.ts:131` - The parser is now loud about every unknown or malformed flag, but positionals are still silently discarded: anything past the first two is dropped, and a lone method-shaped positional is treated as a path. Failure: `gh-axi api /repos/o/r /extra` silently ignores `/extra` and requests `/repos/o/r`; `gh-axi api POST` silently requests `GET /POST` instead of complaining that no path was given. Both are caller typos that now produce a plausible-looking wrong result while a mistyped flag right next to them is rejected. Pre-existing (unchanged from the base commit), but it is the last silent-drop path left in this command — rejecting more than two positionals, and a single positional that is an HTTP method, would close it.

🔧 Fix: reject empty flags and stray positionals in api
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm test` (full vitest suite, 626 tests across 29 files, all passing)</code>
- <code>`pnpm exec vitest run test/commands/api.test.ts` (27 tests covering the new arg parser)</code>
- <code>`pnpm build` then real-API before/after transcript comparing `/opt/homebrew/bin/gh-axi` (published 0.1.27 == base 291fc1a) against `node dist/bin/gh-axi.js` (this branch)</code>
- <code>Issue #77 repro: `gh-axi api repos/kunchenguid/gh-axi/issues/72 --jq &#39;[.labels[].name]&#39;` on both builds</code>
- <code>`gh-axi api repos/kunchenguid/gh-axi/issues/72 --jq=.title` and `--template &#39;{{.number}} {{.state}}&#39;` (value forwarding, equals form)</code>
- <code>`gh-axi api --totally-bogus somevalue &lt;path&gt;` (unknown flag now rejected on both loose and attached-value forms)</code>
- <code>`gh-axi api --paginate repos/kunchenguid/gh-axi/labels` and `--paginate=true &lt;path&gt;` (bool flag no longer consumes the next arg)</code>
- <code>`--jq .title --jq .state`, `--jq=`, bare trailing `--jq`, and `GET &lt;path&gt; extra-typo` (duplicate / empty / missing value / stray positional rejection)</code>
- <code>`gh-axi api &lt;path&gt; --x-secret=hunter2` (error text echoes flag name only, never the value)</code>
- <code>`gh-axi api search/issues --field q=&#39;...&#39; --header &#39;X-Demo: 1&#39; --jq .total_count` and `api repos/kunchenguid/gh-axi/labels/bug` (repeatable flags + default noisy-field stripping unregressed)</code>
- <code>`gh-axi api --help` (help text advertises the 5 supported flags)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `src/commands/api.ts:1` - `pnpm exec prettier --check src/commands/api.ts` fails, but I deliberately did not reformat it. Prettier is a devDependency with no config file, no format script, and no CI step; its defaults would rewrite the file&#39;s single-quoted strings to double quotes, contradicting the codebase convention. Five other pre-existing src files (label.ts, repo.ts, workflow.ts, fields.ts, toon.ts) fail the same check, confirming Prettier is not the repo&#39;s TS formatter (CLAUDE.md only invokes it for pnpm-lock.yaml). Applying it to one changed file would introduce style churn inconsistent with the rest of src/. Follow-up worth a separate change: either add a .prettierrc with `singleQuote: true` plus a `format` script and CI check, or drop Prettier from devDependencies for TS.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
