### PR TITLE
fix: support --body-file - to read body from stdin

### DIFF
--- a/src/body.ts
+++ b/src/body.ts
@@ -2,6 +2,14 @@ import { readFileSync } from "node:fs";
 import { AxiError } from "./errors.js";
 
 /**
+ * Multi-line --body text passed through a Windows npx.cmd/cmd.exe shim (the
+ * default npx on Windows) gets its argv truncated at the first embedded
+ * newline before this process ever sees it. --body-file - matches gh's own
+ * stdin convention and sidesteps argv entirely.
+ */
+const STDIN_SENTINEL = "-";
+
+/**
  * Shared body input, cleaning, and truncation for all entity types.
  *
  * Cleanups are only applied when content needs truncation.
@@ -89,6 +97,9 @@ function readBodyFile(
   path: string,
   suggestions: string[],
 ): string {
+  if (path === STDIN_SENTINEL) {
+    return readFileSync(0, "utf8");
+  }
   try {
     return readFileSync(path, "utf8");
   } catch (error) {

--- a/test/body.test.ts
+++ b/test/body.test.ts
@@ -1,9 +1,20 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { cleanBody, takeBody, truncateBody } from "../src/body.js";
 import { AxiError } from "../src/errors.js";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: (path: Parameters<typeof actual.readFileSync>[0], ...rest: unknown[]) =>
+      path === 0
+        ? "from stdin"
+        : (actual.readFileSync as (...a: unknown[]) => string)(path, ...rest),
+  };
+});
 
 function withTempDir<T>(fn: (dir: string) => T): T {
   const dir = mkdtempSync(join(tmpdir(), "gh-axi-body-"));
@@ -47,6 +58,10 @@ describe("takeBody", () => {
 
       expect(takeBody([`--body-file=${file}`])).toBe("from equals");
     }));
+
+  it("reads body from stdin when --body-file is -", () => {
+    expect(takeBody(["--body-file", "-"])).toBe("from stdin");
+  });
 
   it("returns undefined when the body is optional and omitted", () => {
     expect(takeBody(["--label", "bug"])).toBeUndefined();


### PR DESCRIPTION
## Summary
- On Windows, `npx` resolves to `npx.cmd`. When Git Bash (or similar) invokes it with a multi-line `--body "$(cat <<'EOF' ... EOF)"` argument, cmd.exe's own command-line parsing splits on the embedded newlines before this process ever sees the argument — so `--body` silently receives only the first line. `gh-axi pr create --title X --body "## Summary\n\nfull text..."` ends up creating a PR with a body of just `## Summary`, no error, no warning.
- Confirmed with `gh-axi pr view <n> --json body` showing the truncated value.
- `gh` itself sidesteps this class of problem for `--body-file` by accepting `-` to mean "read from stdin," which never touches argv. This PR adds the same convention to `readBodyFile` in `src/body.ts`, so `--body-file -` (piped content) works as a reliable escape hatch on any platform, not just Windows.

## Changes
- `src/body.ts`: `readBodyFile` returns `readFileSync(0, "utf8")` when the file flag's value is `-`.
- `test/body.test.ts`: added a case for `--body-file -` reading from stdin (mocks `node:fs` readFileSync for fd `0`).

## Test plan
- [x] `tsc --noEmit` clean
- [ ] `pnpm test` (couldn't get the native esbuild binary to install in my sandboxed shell to run vitest locally — should be green in CI; happy to iterate if not)
