### PR TITLE
fix(repo): stop misreading flag values as owner positional in repo list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Requires the `project` (or `read:project`) OAuth scope on the `gh` token; `src/e
 `gh` accepts `--label`, `--assignee`, `--reviewer`, `--project`, and the `--add-*`/`--remove-*` variants once per value, so gh-axi must collect _every_ occurrence.
 Use `getAllFlags`/`takeAllFlags` plus `pushRepeated`; `getFlag`/`takeFlag` keep only the first occurrence and silently discard the rest, which is the bug that recurred as #55, #57, and #75.
 Both collectors reject a dangling (`--label` with nothing after it) or blank (`--label=`) value with a `VALIDATION_ERROR` instead of dropping it.
+`getFlag`/`takeFlag` similarly reject a flag-like value (one starting with `--`) rather than treating it as the value, so a dangling single-value flag can't silently swallow the next flag's token.
 Pick the collector that matches the surrounding file: `issue.ts` reads args non-destructively (`getAllFlags`), `pr.ts` consumes them (`takeAllFlags`).
 When a flag becomes repeatable, mark it `(repeatable)` in that command's `*_HELP` string.
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -4,6 +4,16 @@ function flagEqualsPrefix(flag: string): string {
   return `${flag}=`;
 }
 
+/**
+ * A dangling flag (no value given before the next `--flag` token) must never
+ * silently swallow that next flag as its own value - doing so both loses the
+ * next flag and can leak the wrong token into a positional slot downstream.
+ */
+function rejectFlagLikeValue(value: string, flag: string): void {
+  if (value.startsWith("--"))
+    throw new AxiError(`${flag} requires a value`, "VALIDATION_ERROR");
+}
+
 /** Get a flag's value from --flag value or --flag=value without modifying args. */
 export function getFlag(args: string[], name: string): string | undefined {
   const equalsPrefix = flagEqualsPrefix(name);
@@ -11,7 +21,9 @@ export function getFlag(args: string[], name: string): string | undefined {
     const arg = args[i];
     if (arg === name) {
       if (i + 1 >= args.length) return undefined;
-      return args[i + 1];
+      const val = args[i + 1];
+      rejectFlagLikeValue(val, name);
+      return val;
     }
     if (arg.startsWith(equalsPrefix)) {
       return arg.slice(equalsPrefix.length);
@@ -27,6 +39,7 @@ export function takeFlag(args: string[], flag: string): string | undefined {
     const arg = args[i];
     if (arg === flag) {
       const val = args[i + 1];
+      if (val !== undefined) rejectFlagLikeValue(val, flag);
       args.splice(i, 2);
       return val;
     }
@@ -53,7 +66,7 @@ export function takeBoolFlag(args: string[], flag: string): boolean {
 }
 
 function requireFlagValue(value: string, flag: string): string {
-  if (value.trim() === "")
+  if (value.trim() === "" || value.startsWith("--"))
     throw new AxiError(`${flag} requires a value`, "VALIDATION_ERROR");
   return value;
 }

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -2,7 +2,7 @@ import { encode } from '@toon-format/toon';
 import type { RepoContext } from '../context.js';
 import { ghJson, ghExec } from '../gh.js';
 import { AxiError } from '../errors.js';
-import { getFlag, hasFlag } from '../args.js';
+import { getFlag, hasFlag, takeFlag, takeBoolFlag } from '../args.js';
 import {
   field,
   lower,
@@ -167,21 +167,26 @@ async function forkRepo(args: string[], ctx?: RepoContext): Promise<string> {
 }
 
 async function listRepos(args: string[], ctx?: RepoContext): Promise<string> {
+  // Consume value-taking flags before scanning for positionals, so a bare
+  // flag value (e.g. the "200" in --limit 200) can never be mistaken for
+  // the optional owner positional when no owner is given.
+  const limit = takeFlag(args, '--limit') ?? '30';
+  const visibility = takeFlag(args, '--visibility');
+  const language = takeFlag(args, '--language');
+  const archived = takeBoolFlag(args, '--archived');
+
   const positionals = args.filter((a) => !a.startsWith('--'));
   const owner = positionals[1]; // optional
 
-  const limit = getFlag(args, '--limit') ?? '30';
   const ghArgs = [
     'repo', 'list',
     '--json', 'name,description,visibility,primaryLanguage,stargazerCount,updatedAt',
     '--limit', limit,
   ];
   if (owner) ghArgs.splice(2, 0, owner); // insert owner after 'list'
-  const visibility = getFlag(args, '--visibility');
   if (visibility) ghArgs.push('--visibility', visibility);
-  const language = getFlag(args, '--language');
   if (language) ghArgs.push('--language', language);
-  if (hasFlag(args, '--archived')) ghArgs.push('--archived');
+  if (archived) ghArgs.push('--archived');
 
   const repos = await ghJson<Record<string, unknown>[]>(ghArgs);
   const isEmpty = repos.length === 0;

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -94,7 +94,7 @@ function takeViewFlagValue(args: string[], flag: string): string | undefined {
   const present = args.includes(flag);
   const value = takeFlag(args, flag);
   if (!present) return undefined;
-  if (!value || value.startsWith("--")) {
+  if (!value) {
     throw new AxiError(`Missing value for ${flag}`, "VALIDATION_ERROR");
   }
   return value;

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -33,6 +33,12 @@ describe("getFlag", () => {
     expect(getFlag(["--state", "open", "--repo"], "--repo")).toBeUndefined();
   });
 
+  it("throws instead of swallowing an adjacent flag as the value", () => {
+    expect(() =>
+      getFlag(["--repo", "--state", "open"], "--repo"),
+    ).toThrow("--repo requires a value");
+  });
+
   it("does not modify the args array", () => {
     const args = ["--repo", "cli/cli"];
     getFlag(args, "--repo");
@@ -67,6 +73,14 @@ describe("takeFlag", () => {
     const val = takeFlag(args, "--flag");
     expect(val).toBe("val");
     expect(args).toEqual(["--other"]);
+  });
+
+  it("throws instead of swallowing an adjacent flag as the value", () => {
+    const args = ["--limit", "--visibility", "public"];
+    expect(() => takeFlag(args, "--limit")).toThrow(
+      "--limit requires a value",
+    );
+    expect(args).toEqual(["--limit", "--visibility", "public"]);
   });
 });
 

--- a/test/commands/repo.test.ts
+++ b/test/commands/repo.test.ts
@@ -225,6 +225,13 @@ describe('repoCommand', () => {
       ]);
     });
 
+    it('throws instead of misreading an adjacent flag as the --limit value', async () => {
+      await expect(
+        repoCommand(['list', '--limit', '--visibility', 'public'], ctx),
+      ).rejects.toThrow('--limit requires a value');
+      expect(mockedGhJson).not.toHaveBeenCalled();
+    });
+
     it('does not mistake --visibility or --language values for the owner positional', async () => {
       mockedGhJson.mockResolvedValue([]);
 

--- a/test/commands/repo.test.ts
+++ b/test/commands/repo.test.ts
@@ -200,6 +200,44 @@ describe('repoCommand', () => {
 
       expect(result).toContain('showing first 10');
     });
+
+    it('does not mistake the --limit value for the owner positional when no owner is given', async () => {
+      mockedGhJson.mockResolvedValue([]);
+
+      await repoCommand(['list', '--limit', '10'], ctx);
+
+      expect(mockedGhJson).toHaveBeenCalledWith([
+        'repo', 'list',
+        '--json', 'name,description,visibility,primaryLanguage,stargazerCount,updatedAt',
+        '--limit', '10',
+      ]);
+    });
+
+    it('passes an explicit owner positional through to gh repo list', async () => {
+      mockedGhJson.mockResolvedValue([]);
+
+      await repoCommand(['list', 'octo', '--limit', '10'], ctx);
+
+      expect(mockedGhJson).toHaveBeenCalledWith([
+        'repo', 'list', 'octo',
+        '--json', 'name,description,visibility,primaryLanguage,stargazerCount,updatedAt',
+        '--limit', '10',
+      ]);
+    });
+
+    it('does not mistake --visibility or --language values for the owner positional', async () => {
+      mockedGhJson.mockResolvedValue([]);
+
+      await repoCommand(['list', '--visibility', 'public', '--language', 'TypeScript'], ctx);
+
+      expect(mockedGhJson).toHaveBeenCalledWith([
+        'repo', 'list',
+        '--json', 'name,description,visibility,primaryLanguage,stargazerCount,updatedAt',
+        '--limit', '30',
+        '--visibility', 'public',
+        '--language', 'TypeScript',
+      ]);
+    });
   });
 
   describe('clone', () => {

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -455,7 +455,7 @@ describe("runCommand", () => {
         runCommand(["view", "100", "--job", "--log"], ctx),
       ).rejects.toMatchObject({
         code: "VALIDATION_ERROR",
-        message: "Missing value for --job",
+        message: "--job requires a value",
       });
       expect(mockedGhExec).not.toHaveBeenCalled();
       expect(mockedGhJson).not.toHaveBeenCalled();


### PR DESCRIPTION
## What Changed

- `repo list` no longer misreads a flag's value (e.g. `--limit`'s number, or `--visibility`/`--language` values) as the owner positional argument, so `gh repo list` is invoked with the correct owner instead of a spurious one.
- `getFlag`/`takeFlag` in `src/args.ts` now reject a value that itself looks like another flag (starts with `--`) instead of consuming it, closing a related case where a dangling single-value flag (e.g. `--limit --visibility public`) could swallow the next flag's token; the `--flag=value` form remains unaffected.
- Documented the new dangling-flag rejection behavior for `getFlag`/`takeFlag` in AGENTS.md.

## Risk Assessment

✅ Low: The new commit fixes the round-1 finding at the correct shared boundary (args.ts) rather than a local patch, is covered by targeted tests that reproduce the exact failing sequence, and its only collateral effect (free-text flag values starting with "--" now require the `--flag=value` form) has a working escape hatch and doesn't reintroduce the original bug.

## Testing

Ran the targeted vitest suites for args.ts and the repo/run commands (98 tests, all passing, including new regression tests added in this change), then independently reproduced the original bug end-to-end against a real authenticated gh CLI session by running `gh-axi repo list --limit 3` on the base commit (owner positional wrongly swallowed the limit value, producing the wrong repo list) versus the target commit (correct behavior, lists the authenticated user's own repos). Working tree is clean and the temporary comparison worktree was removed after use.

<details>
<summary>Evidence: Before/after CLI transcript for gh-axi repo list --limit bug</summary>

```text
# `gh-axi repo list --limit N` owner-positional bug: before/after CLI transcript

Command run in both cases: `npx tsx bin/gh-axi.ts repo list --limit 3`
(authenticated `gh` account: ahuang100)

## Base commit fe384b3 (bug present)

`--limit`'s value `3` was mistaken for the owner positional, so the CLI ran
`gh repo list 3 --json ... --limit 3` instead of listing the authenticated
user's own repos. Output was wrong/unexpected repos:

`` `
count: 2
repos[2]{name,description,visibility,language,stars,updated}:
  dotfiles,"",public,Vim Script,0,12y ago
  pair-box,"",public,null,0,12y ago
help[1]:
  Run `gh-axi repo view --repo <owner/name>` to view a repository
`` `

## Target commit 101fa57 (fix applied)

`--limit`'s value is consumed by `takeFlag` before positionals are scanned,
so it can no longer be mistaken for the owner. Output correctly lists the
authenticated user's own repos, limited to 3:

`` `
count: 3 (showing first 3)
repos[3]{name,description,visibility,language,stars,updated}:
  gh-axi,GitHub CLI for agents — designed with AXI (Agent eXperience Interface).,public,TypeScript,0,1h ago
  AGL,"AGL - Adversarial Generative Loop ",private,Python,0,2mo ago
  helical_cot,Results for the helical CoT experiments,private,Jupyter Notebook,0,2mo ago
help[1]:
  Run `gh-axi repo view --repo <owner/name>` to view a repository
`` `
```
</details>
<details>
<summary>Evidence: Targeted vitest run (args.ts, repo.ts, run.ts)</summary>

```text
test/args.test.ts (45 tests) passed
test/commands/repo.test.ts (23 tests) passed
test/commands/run.test.ts (30 tests) passed
All 98 tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `src/commands/repo.ts:173` - The fix correctly stops a flag&#39;s value from being misread as the owner positional in the common case, but the four sequential takeFlag/takeBoolFlag calls share the same mutable args array and are destructive. If a flag is given without its value directly followed by another not-yet-consumed flag (e.g. `gh-axi repo list --limit --visibility public`), takeFlag(&#39;--limit&#39;) swallows the literal token &#39;--visibility&#39; as limit&#39;s value and splices both out, leaving &#39;public&#39; as a stray non-flag token that the owner-positional scan (`positionals[1]`) then picks up and inserts into the gh invocation as the owner (`gh repo list public ...`). In practice this still surfaces as a gh-level parse error (since &#39;--visibility&#39; becomes an invalid --limit value), so it is not a silent wrong-owner success, but it is a narrow reappearance of the same bug class (a non-owner token landing in the owner slot) for malformed input. Consider having takeFlag reject/ignore a &#39;value&#39; that itself starts with &#39;--&#39; so a dangling flag can&#39;t consume an adjacent real flag.

🔧 Fix: args: reject flag-like values so dangling flags can&#39;t swallow the next flag
2 infos still open:
- ℹ️ `src/args.ts:12` - The dangling-flag fix from round 1 was correctly placed at the shared boundary (getFlag/takeFlag/requireFlagValue in args.ts) rather than patched only in repo.ts, so the invariant now holds everywhere args flow through these helpers, and the new tests (args.test.ts, repo.test.ts, run.test.ts) confirm the exact `--limit --visibility public` repro now throws cleanly instead of leaking a token into the owner positional. One foreseeable side effect worth being aware of: this also applies to free-text flags across the codebase (--title, --description, --comment, --subject, --milestone, --query, etc. in pr.ts/issue.ts/project.ts/label.ts), so a legitimate value that itself starts with &#34;--&#34; (e.g. `--title &#34;--wip: fix login&#34;`) is now rejected with a confusing &#34;&lt;flag&gt; requires a value&#34; message even though a value was supplied. The `--flag=value` equals-form still bypasses the check as an escape hatch (both getFlag and takeFlag only reject in the space-separated branch), so nothing is actually unrepresentable, but the escape hatch isn&#39;t documented anywhere.
- ℹ️ `CLAUDE.md` - CLAUDE.md&#39;s &#34;Repeatable flags&#34; section documents that getAllFlags/takeAllFlags reject dangling/blank values, but doesn&#39;t yet mention that getFlag/takeFlag/requireFlagValue also now reject a value that looks like another flag (starts with &#34;--&#34;) as of this change. Since this file&#39;s stated purpose is to capture exactly this kind of durable, cross-cutting sharp edge so it isn&#39;t rediscovered, a short follow-up note here (and that `--flag=value` is the escape hatch for a literal dash-prefixed value) would match the existing documentation bar.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx vitest run test/args.test.ts test/commands/repo.test.ts test/commands/run.test.ts` - 98 tests passed, including the new cases &#39;does not mistake the --limit value for the owner positional when no owner is given&#39;, &#39;passes an explicit owner positional through to gh repo list&#39;, &#39;does not mistake --visibility or --language values for the owner positional&#39;, and dangling/flag-like-value rejection tests in args.test.ts</code>
- <code>Manual E2E: ran `npx tsx bin/gh-axi.ts repo list --limit 3` against the live authenticated gh CLI (account ahuang100) on target commit 101fa57 - correctly listed the authenticated user&#39;s own repos (gh-axi, AGL, helical_cot)</code>
- `Manual E2E regression repro: checked out base commit fe384b3 in a temporary git worktree and ran the identical command - reproduced the bug, where the limit value '3' was misread as the owner positional, producing wrong output (dotfiles, pair-box instead of the user's actual repos); temporary worktree removed afterward`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
