### PR TITLE
feat(gist): add gist command family with list, view, create, edit, rename, delete, clone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ The fix is structural: these command functions omit the `ctx` parameter entirely
 ## GitHub Projects (`gh project`) support (`src/commands/project.ts`)
 
 Unlike every other command family, `gh project` is owner-scoped (`--owner <login>`), not repo-scoped — it has no `--repo` flag at all.
-`project.ts`'s subfunctions therefore never pass `RepoContext` as the second arg to `ghJson` (matching `search.ts`'s existing pattern), since `gh.ts#buildArgs` auto-appends `--repo` for flag/env-sourced contexts and `gh project` would reject that flag.
+`project.ts`'s subfunctions therefore never pass `RepoContext` as the second arg to `ghJson` (matching `search.ts`'s existing pattern) — see "User-scoped commands" above for why.
 Instead, `resolveOwner()` defaults `--owner` to the current repo's owner (`ctx?.owner`) when the flag is omitted and a repo context is available, falling back to explicit `@me` otherwise because `gh project` requires an owner in non-interactive shells.
 `gh project` subcommands use `--format json` (whole-object dump), not the `--json field,field` selection style used by `issue`/`pr`/`release`; list-shaped responses come back wrapped (e.g. `{ projects: [...], totalCount }`), not as a bare array.
 Since Projects v2 items carry per-project custom fields (Status, Priority, ...) with no fixed schema, `item-list`/`field-list` render through bespoke functions (`renderProjectItems`/`renderProjectFields`) that flatten any unknown scalar top-level key into its own column, rather than a fixed `FieldDef` schema.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,14 @@ Variable values are not treated as secrets: `variableCommand`'s `set` subcommand
 
 `secretCommand`'s `list`/`set`/`delete` forward `--env`/`-e <environment>` to `gh secret ... --env` via `resolveScope` in `src/commands/secret.ts`; the repo/host context flags are already stripped in `cli.ts` before the command sees its args, so `-R`/`--hostname` compose with `--env` for free. `resolveScope` is deliberately strict: a malformed `--env` (missing/empty value), conflicting `--env` flags, gh's other scopes (`--org`/`--user`/`--app`, plus the value-channel `--env-file`), and any unknown flag all throw loudly rather than silently falling back to repo scope. Unknown flags are echoed by name only (the `=value` is stripped) so a secret value can never leak into an error message.
 
+## User-scoped commands (`src/commands/gist.ts`, `src/commands/project.ts`)
+
+Some GitHub API endpoints are user-scoped rather than repo-scoped: `gh api /gists` and `gh project` have no `--repo` flag and reject it if supplied.
+`gh.ts#buildArgs` auto-appends `--repo <nwo>` for any `RepoContext` whose `source !== "git"`, so passing ctx to `ghJson` from these handlers would inject a flag the CLI rejects.
+The fix is structural: these command functions omit the `ctx` parameter entirely (TypeScript accepts `(args: string[])` as `CommandFn` because fewer params are always assignable).
+`cli.ts`'s `withRepoContext` wrapper still resolves a context for other commands — it just never reaches `ghJson` in the user-scoped handlers.
+`gist.ts` follows this pattern; `project.ts` does too (though it additionally uses ctx?.owner for owner defaulting, it never forwards ctx to `ghJson`).
+
 ## GitHub Projects (`gh project`) support (`src/commands/project.ts`)
 
 Unlike every other command family, `gh project` is owner-scoped (`--owner <login>`), not repo-scoped — it has no `--repo` flag at all.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ gh-axi variable set NODE_ENV --body production        # set a variable from a fl
 gh-axi gist list                # list your gists
 gh-axi gist list --public       # list only public gists
 gh-axi gist view <id>           # view a gist's files and content
+echo 'new content' | gh-axi gist edit <id> --filename notes.md  # replace a file from stdin
+gh-axi gist edit <id> --remove old.txt  # remove a file
+gh-axi gist rename <id> old.txt new.txt  # rename a file
 gh-axi gist create notes.md --public --desc "My notes"  # create a public gist
 gh-axi gist create --file a.py --file b.py --secret    # create a secret multi-file gist
 echo "content" | gh-axi gist create --filename hello.txt --public  # create from piped content
@@ -154,7 +157,7 @@ JSON responses are normally stripped of noisy fields before TOON encoding, but a
 | `release`  | Releases — list, view, create, edit, delete                                 |
 | `repo`     | Repositories — list, view, create, edit, clone, fork                        |
 | `label`    | Labels — list, create, edit, delete                                         |
-| `gist`     | Gists — list, view, create, delete, clone                                   |
+| `gist`     | Gists — list, view, edit, rename, create, delete, clone                     |
 | `project`  | Projects (v2) - list, view, create, edit, close, copy, items, fields        |
 | `secret`   | Actions secrets — list, set, delete                                         |
 | `variable` | Actions variables — list, set, delete                                       |

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ echo -n "sk-..." | gh-axi secret set CSC_LINK --env production  # scope a secret
 gh-axi variable set NODE_ENV --body production        # set a variable from a flag
 gh-axi gist list                # list your gists
 gh-axi gist list --public       # list only public gists
+gh-axi gist create notes.md --public --desc "My notes"  # create a public gist
+gh-axi gist create --file a.py --file b.py --secret    # create a secret multi-file gist
+echo "content" | gh-axi gist create --filename hello.txt --public  # create from piped content
 gh-axi gist delete <id|url>     # delete a gist (always confirmed non-interactively)
 gh-axi gist clone <id|url>      # clone a gist locally
 gh-axi setup hooks              # install optional agent session hooks
@@ -131,6 +134,11 @@ Other `gh secret` scopes (`--org`, `--user`, `--app`) are rejected with a clear 
 `gh-axi project` wraps GitHub Projects (v2) and requires the `project` (or `read:project`) OAuth scope; if a call fails on a missing scope, gh-axi tells you the `gh auth refresh -s <scope>` command to run.
 `--owner` defaults to the current repo's owner, falling back to explicit `@me` for the authenticated user.
 
+`gh-axi gist create` requires `--public` or `--secret` explicitly — passing neither (or both) is an error.
+Gist visibility is fixed at creation; a secret gist is unlisted (anyone with the URL can read it), not private.
+Two file-on-disk input forms are available: positional paths (`gist create a.py b.py`) or repeatable `--file` flags (`gist create --file a.py --file b.py`); mixing the two is an error.
+To create a gist from piped content, use `--filename <name>` together with a pipe (`echo "..." | gh-axi gist create --filename foo.txt --public`).
+
 `gh-axi api` accepts `--field`, `--header`, `--paginate`, `--jq <expression>`, and `--template <format>`; any other flag, an extra positional argument, or a repeated `--jq`/`--template` is rejected with a clear error instead of being silently dropped.
 JSON responses are normally stripped of noisy fields before TOON encoding, but a response you shaped yourself with `--jq` or `--template` keeps every key and value verbatim — only over-long strings are still truncated so one field cannot flood an agent's context.
 
@@ -145,7 +153,7 @@ JSON responses are normally stripped of noisy fields before TOON encoding, but a
 | `release`  | Releases — list, view, create, edit, delete                                 |
 | `repo`     | Repositories — list, view, create, edit, clone, fork                        |
 | `label`    | Labels — list, create, edit, delete                                         |
-| `gist`     | Gists — list, delete, clone                                                 |
+| `gist`     | Gists — list, create, delete, clone                                         |
 | `project`  | Projects (v2) - list, view, create, edit, close, copy, items, fields        |
 | `secret`   | Actions secrets — list, set, delete                                         |
 | `variable` | Actions variables — list, set, delete                                       |

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ echo -n "sk-..." | gh-axi secret set CSC_LINK --env production  # scope a secret
 gh-axi variable set NODE_ENV --body production        # set a variable from a flag
 gh-axi gist list                # list your gists
 gh-axi gist list --public       # list only public gists
+gh-axi gist view <id>           # view a gist's files and content
 gh-axi gist create notes.md --public --desc "My notes"  # create a public gist
 gh-axi gist create --file a.py --file b.py --secret    # create a secret multi-file gist
 echo "content" | gh-axi gist create --filename hello.txt --public  # create from piped content
@@ -153,7 +154,7 @@ JSON responses are normally stripped of noisy fields before TOON encoding, but a
 | `release`  | Releases — list, view, create, edit, delete                                 |
 | `repo`     | Repositories — list, view, create, edit, clone, fork                        |
 | `label`    | Labels — list, create, edit, delete                                         |
-| `gist`     | Gists — list, create, delete, clone                                         |
+| `gist`     | Gists — list, view, create, delete, clone                                   |
 | `project`  | Projects (v2) - list, view, create, edit, close, copy, items, fields        |
 | `secret`   | Actions secrets — list, set, delete                                         |
 | `variable` | Actions variables — list, set, delete                                       |

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ echo -n "sk-..." | gh-axi secret set CSC_LINK --env production  # scope a secret
 gh-axi variable set NODE_ENV --body production        # set a variable from a flag
 gh-axi gist list                # list your gists
 gh-axi gist list --public       # list only public gists
+gh-axi gist delete <id|url>     # delete a gist (always confirmed non-interactively)
+gh-axi gist clone <id|url>      # clone a gist locally
 gh-axi setup hooks              # install optional agent session hooks
 gh-axi update --check           # check whether a newer release exists
 gh-axi update                   # upgrade a global install
@@ -143,7 +145,7 @@ JSON responses are normally stripped of noisy fields before TOON encoding, but a
 | `release`  | Releases — list, view, create, edit, delete                                 |
 | `repo`     | Repositories — list, view, create, edit, clone, fork                        |
 | `label`    | Labels — list, create, edit, delete                                         |
-| `gist`     | Gists — list                                                                |
+| `gist`     | Gists — list, delete, clone                                                 |
 | `project`  | Projects (v2) - list, view, create, edit, close, copy, items, fields        |
 | `secret`   | Actions secrets — list, set, delete                                         |
 | `variable` | Actions variables — list, set, delete                                       |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ gh-axi project list --owner my-org        # list Projects (v2) for an owner
 echo -n "sk-..." | gh-axi secret set OPENAI_API_KEY  # set a secret from stdin
 echo -n "sk-..." | gh-axi secret set CSC_LINK --env production  # scope a secret to an environment
 gh-axi variable set NODE_ENV --body production        # set a variable from a flag
+gh-axi gist list                # list your gists
+gh-axi gist list --public       # list only public gists
 gh-axi setup hooks              # install optional agent session hooks
 gh-axi update --check           # check whether a newer release exists
 gh-axi update                   # upgrade a global install
@@ -141,6 +143,7 @@ JSON responses are normally stripped of noisy fields before TOON encoding, but a
 | `release`  | Releases — list, view, create, edit, delete                                 |
 | `repo`     | Repositories — list, view, create, edit, clone, fork                        |
 | `label`    | Labels — list, create, edit, delete                                         |
+| `gist`     | Gists — list                                                                |
 | `project`  | Projects (v2) - list, view, create, edit, close, copy, items, fields        |
 | `secret`   | Actions secrets — list, set, delete                                         |
 | `variable` | Actions variables — list, set, delete                                       |

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-axi
-description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or listing gists via `gist list`."
+description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist delete`, or `gist clone`."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -21,7 +21,7 @@ For GitHub Enterprise or another custom host, the underlying `gh` CLI must be au
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing gists; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, deleting, or cloning gists; or calling the GitHub API directly.
 
 ## Workflow
 
@@ -61,5 +61,5 @@ Run `npx -y gh-axi --help` for global flags, or `npx -y gh-axi <command> --help`
 - For multi-line variable values, pipe stdin to `npx -y gh-axi variable set <name>`; `--body`/`-b` is for inline values only.
 - Projects (v2) are owner-scoped: pass `--owner <login>`, or omit it to use the current repo owner and then `@me`.
 - Projects calls need the `project` or `read:project` OAuth scope; if scope errors occur, ask the user to run the `gh auth refresh -s ...` command shown by gh-axi.
-- Use `gist list` to list your GitHub Gists; filter by visibility with `--public` or `--secret`, and add extra fields with `--fields url,owner,created`.
+- Use `gist list` to list your GitHub Gists; filter by visibility with `--public` or `--secret`, and add extra fields with `--fields url,owner,created`. Use `gist delete <id|url>` to delete a gist (always confirmed non-interactively). Use `gist clone <id|url>` to clone a gist locally.
 - Use `api` for anything the dedicated commands do not cover, e.g. `npx -y gh-axi api repos/{owner}/{repo}/topics`.

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-axi
-description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, or managing Actions secrets/variables."
+description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or listing gists via `gist list`."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -21,7 +21,7 @@ For GitHub Enterprise or another custom host, the underlying `gh` CLI must be au
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing gists; or calling the GitHub API directly.
 
 ## Workflow
 
@@ -37,8 +37,8 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 ## Commands
 
 ```
-commands[14]:
-  (none)=dashboard, issue, pr, run, workflow, release, repo, label, project, secret, variable, search, api, setup
+commands[15]:
+  (none)=dashboard, issue, pr, run, workflow, release, repo, label, gist, project, secret, variable, search, api, setup
 ```
 
 Installed copies also inherit the SDK built-in `update` command.
@@ -61,4 +61,5 @@ Run `npx -y gh-axi --help` for global flags, or `npx -y gh-axi <command> --help`
 - For multi-line variable values, pipe stdin to `npx -y gh-axi variable set <name>`; `--body`/`-b` is for inline values only.
 - Projects (v2) are owner-scoped: pass `--owner <login>`, or omit it to use the current repo owner and then `@me`.
 - Projects calls need the `project` or `read:project` OAuth scope; if scope errors occur, ask the user to run the `gh auth refresh -s ...` command shown by gh-axi.
+- Use `gist list` to list your GitHub Gists; filter by visibility with `--public` or `--secret`, and add extra fields with `--fields url,owner,created`.
 - Use `api` for anything the dedicated commands do not cover, e.g. `npx -y gh-axi api repos/{owner}/{repo}/topics`.

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-axi
-description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist create`, `gist delete`, or `gist clone`."
+description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist view`, `gist create`, `gist delete`, or `gist clone`."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -21,7 +21,7 @@ For GitHub Enterprise or another custom host, the underlying `gh` CLI must be au
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, deleting, or cloning gists; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, creating, deleting, or cloning gists; or calling the GitHub API directly.
 
 ## Workflow
 
@@ -61,7 +61,7 @@ Run `npx -y gh-axi --help` for global flags, or `npx -y gh-axi <command> --help`
 - For multi-line variable values, pipe stdin to `npx -y gh-axi variable set <name>`; `--body`/`-b` is for inline values only.
 - Projects (v2) are owner-scoped: pass `--owner <login>`, or omit it to use the current repo owner and then `@me`.
 - Projects calls need the `project` or `read:project` OAuth scope; if scope errors occur, ask the user to run the `gh auth refresh -s ...` command shown by gh-axi.
-- Use `gist list` to list your GitHub Gists; filter by visibility with `--public` or `--secret`, and add extra fields with `--fields url,owner,created`.
+- Use `gist list` to list your GitHub Gists; filter by visibility with `--public` or `--secret`, and add extra fields with `--fields url,owner,created`. Use `gist view <id|url>` to fetch a gist's metadata and file content; pass `--files` for names only, `-f/--filename <name>` for a single file, or `--full` to disable truncation.
 - Use `gist create` to create a gist. Visibility is required: pass `--public` or `--secret` (omitting either, or passing both, is an error). Use positional paths (`gist create a.py b.py`) or repeatable `--file` flags; do not mix the two. Pipe content with `--filename <name>` for stdin input. A secret gist is unlisted — anyone with the URL can read it.
 - Use `gist delete <id|url>` to delete a gist (always confirmed non-interactively). Use `gist clone <id|url>` to clone a gist locally.
 - Use `api` for anything the dedicated commands do not cover, e.g. `npx -y gh-axi api repos/{owner}/{repo}/topics`.

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-axi
-description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist view`, `gist create`, `gist delete`, or `gist clone`."
+description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist view`, `gist edit`, `gist rename`, `gist create`, `gist delete`, or `gist clone`."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -21,7 +21,7 @@ For GitHub Enterprise or another custom host, the underlying `gh` CLI must be au
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, creating, deleting, or cloning gists; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, editing, renaming, creating, deleting, or cloning gists; or calling the GitHub API directly.
 
 ## Workflow
 
@@ -62,6 +62,8 @@ Run `npx -y gh-axi --help` for global flags, or `npx -y gh-axi <command> --help`
 - Projects (v2) are owner-scoped: pass `--owner <login>`, or omit it to use the current repo owner and then `@me`.
 - Projects calls need the `project` or `read:project` OAuth scope; if scope errors occur, ask the user to run the `gh auth refresh -s ...` command shown by gh-axi.
 - Use `gist list` to list your GitHub Gists; filter by visibility with `--public` or `--secret`, and add extra fields with `--fields url,owner,created`. Use `gist view <id|url>` to fetch a gist's metadata and file content; pass `--files` for names only, `-f/--filename <name>` for a single file, or `--full` to disable truncation.
+- Use `gist edit <id|url>` to update a gist's files or description: pipe content via stdin with `--filename <name>` to replace or add a file, `--add <path>` to add from disk, `--remove <name>` to remove, and `--desc <text>` to update the description. `gist edit` never opens $EDITOR.
+- Use `gist rename <id|url> <old> <new>` to rename a file within a gist.
 - Use `gist create` to create a gist. Visibility is required: pass `--public` or `--secret` (omitting either, or passing both, is an error). Use positional paths (`gist create a.py b.py`) or repeatable `--file` flags; do not mix the two. Pipe content with `--filename <name>` for stdin input. A secret gist is unlisted — anyone with the URL can read it.
 - Use `gist delete <id|url>` to delete a gist (always confirmed non-interactively). Use `gist clone <id|url>` to clone a gist locally.
 - Use `api` for anything the dedicated commands do not cover, e.g. `npx -y gh-axi api repos/{owner}/{repo}/topics`.

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-axi
-description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist delete`, or `gist clone`."
+description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist create`, `gist delete`, or `gist clone`."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -61,5 +61,7 @@ Run `npx -y gh-axi --help` for global flags, or `npx -y gh-axi <command> --help`
 - For multi-line variable values, pipe stdin to `npx -y gh-axi variable set <name>`; `--body`/`-b` is for inline values only.
 - Projects (v2) are owner-scoped: pass `--owner <login>`, or omit it to use the current repo owner and then `@me`.
 - Projects calls need the `project` or `read:project` OAuth scope; if scope errors occur, ask the user to run the `gh auth refresh -s ...` command shown by gh-axi.
-- Use `gist list` to list your GitHub Gists; filter by visibility with `--public` or `--secret`, and add extra fields with `--fields url,owner,created`. Use `gist delete <id|url>` to delete a gist (always confirmed non-interactively). Use `gist clone <id|url>` to clone a gist locally.
+- Use `gist list` to list your GitHub Gists; filter by visibility with `--public` or `--secret`, and add extra fields with `--fields url,owner,created`.
+- Use `gist create` to create a gist. Visibility is required: pass `--public` or `--secret` (omitting either, or passing both, is an error). Use positional paths (`gist create a.py b.py`) or repeatable `--file` flags; do not mix the two. Pipe content with `--filename <name>` for stdin input. A secret gist is unlisted — anyone with the URL can read it.
+- Use `gist delete <id|url>` to delete a gist (always confirmed non-interactively). Use `gist clone <id|url>` to clone a gist locally.
 - Use `api` for anything the dedicated commands do not cover, e.g. `npx -y gh-axi api repos/{owner}/{repo}/topics`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import { secretCommand, SECRET_HELP } from "./commands/secret.js";
 import { variableCommand, VARIABLE_HELP } from "./commands/variable.js";
 import { searchCommand, SEARCH_HELP } from "./commands/search.js";
 import { apiCommand, API_HELP } from "./commands/api.js";
+import { gistCommand, GIST_HELP } from "./commands/gist.js";
 import { setupCommand, SETUP_HELP } from "./commands/setup.js";
 import { resolveHost, type HostContext } from "./host.js";
 import { withSuggestionHost } from "./suggestions.js";
@@ -32,8 +33,8 @@ type MainOptions = {
 };
 
 export const TOP_HELP = `usage: gh-axi [command] [args] [flags]
-commands[14]:
-  (none)=dashboard, issue, pr, run, workflow, release, repo, label, project, secret, variable, search, api, setup
+commands[15]:
+  (none)=dashboard, issue, pr, run, workflow, release, repo, label, gist, project, secret, variable, search, api, setup
 flags[4]:
   -R/--repo <OWNER/NAME> (after command), --hostname <host> (after command) or GH_HOST env, both flags accept space or equals form, --help, -v/-V/--version
 examples:
@@ -55,6 +56,7 @@ const COMMAND_HELP: Record<string, string> = {
   release: RELEASE_HELP,
   repo: REPO_HELP,
   label: LABEL_HELP,
+  gist: GIST_HELP,
   project: PROJECT_HELP,
   secret: SECRET_HELP,
   variable: VARIABLE_HELP,
@@ -76,6 +78,10 @@ const COMMANDS: Record<string, WrappedCommandFn> = {
   release: withRepoContext("release", releaseCommand),
   repo: withRepoContext("repo", repoCommand),
   label: withRepoContext("label", labelCommand),
+  // gist is user-scoped; withRepoContext still handles hostname context but
+  // gistCommand itself never forwards ctx to ghJson — see AGENTS.md
+  // "User-scoped commands" section for the owner-scoped pattern.
+  gist: withRepoContext("gist", gistCommand),
   project: withRepoContext("project", projectCommand),
   secret: withRepoContext("secret", secretCommand),
   variable: withRepoContext("variable", variableCommand),

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -59,16 +59,26 @@ const PAGE_SIZE = 100;
 const defaultSchema: FieldDef[] = [
   field("id"),
   field("description"),
-  custom("files", (item) =>
-    Object.keys((item["files"] as Record<string, unknown>) ?? {}).length,
+  custom(
+    "files",
+    (item) =>
+      Object.keys((item["files"] as Record<string, unknown>) ?? {}).length,
   ),
-  custom("visibility", (item) => (item["public"] === true ? "public" : "secret")),
+  custom("visibility", (item) =>
+    item["public"] === true ? "public" : "secret",
+  ),
 ];
 
 /** Extra fields unlocked via --fields. */
 const EXTRA_FIELDS: Record<string, ExtraFieldSpec> = {
-  created: { jsonKey: "created_at", def: relativeTime("created_at", "created") },
-  updated: { jsonKey: "updated_at", def: relativeTime("updated_at", "updated") },
+  created: {
+    jsonKey: "created_at",
+    def: relativeTime("created_at", "created"),
+  },
+  updated: {
+    jsonKey: "updated_at",
+    def: relativeTime("updated_at", "updated"),
+  },
   url: { jsonKey: "html_url", def: field("html_url", "url") },
   comments: { jsonKey: "comments", def: field("comments") },
   owner: { jsonKey: "owner", def: pluck("owner", "login", "owner") },
@@ -120,7 +130,10 @@ function flagName(token: string): string {
  * with hasFlag/includes, which only see the bare form — so `--full=true` must
  * be rejected here rather than accepted and then silently ignored.
  */
-function rejectUnknownFlags(tokens: string[], allowed: readonly string[]): void {
+function rejectUnknownFlags(
+  tokens: string[],
+  allowed: readonly string[],
+): void {
   const unknown = tokens.filter(
     (a) => a.startsWith("-") && !allowed.includes(a),
   );
@@ -187,9 +200,7 @@ const gistMetaSchema: FieldDef[] = [
   custom("visibility", (item: GistDetail) =>
     item.public === true ? "public" : "secret",
   ),
-  custom("files", (item: GistDetail) =>
-    Object.keys(item.files ?? {}).length,
-  ),
+  custom("files", (item: GistDetail) => Object.keys(item.files ?? {}).length),
   relativeTime("created_at", "created"),
   relativeTime("updated_at", "updated"),
   field("comments"),
@@ -300,7 +311,11 @@ async function viewGist(args: string[]): Promise<string> {
 
   // Default: metadata block + all files with (possibly truncated) content.
   return renderOutput([
-    renderDetail("gist", data as unknown as Record<string, unknown>, gistMetaSchema),
+    renderDetail(
+      "gist",
+      data as unknown as Record<string, unknown>,
+      gistMetaSchema,
+    ),
     renderList("files", fileList, makeFileSchema(full)),
     renderHelp(suggestions),
   ]);
@@ -308,7 +323,7 @@ async function viewGist(args: string[]): Promise<string> {
 
 // listGists deliberately has no ctx parameter. gist is user-scoped and
 // gh api /gists has no --repo flag; the guard is enforced structurally.
-// See AGENTS.md "GitHub Projects" section for the owner-scoped pattern.
+// See AGENTS.md "User-scoped commands" section.
 async function listGists(args: string[]): Promise<string> {
   const wantPublic = takeBoolFlag(args, "--public");
   const wantSecret = takeBoolFlag(args, "--secret");
@@ -383,7 +398,11 @@ async function listGists(args: string[]): Promise<string> {
   const schema = [...defaultSchema, ...extraDefs];
   const countLine = formatCountLine({ count: displayed.length, limit });
 
-  const suggestions = getSuggestions({ domain: "gist", action: "list", isEmpty });
+  const suggestions = getSuggestions({
+    domain: "gist",
+    action: "list",
+    isEmpty,
+  });
   return renderOutput([
     countLine,
     renderList("gists", displayed, schema),
@@ -409,17 +428,11 @@ async function deleteGist(args: string[]): Promise<string> {
       "VALIDATION_ERROR",
     );
   if (extra)
-    throw new AxiError(
-      `Unexpected argument: ${extra}`,
-      "VALIDATION_ERROR",
-    );
+    throw new AxiError(`Unexpected argument: ${extra}`, "VALIDATION_ERROR");
 
   await ghExec(["gist", "delete", selector, "--yes"]);
   const suggestions = getSuggestions({ domain: "gist", action: "delete" });
-  return renderOutput([
-    encode({ deleted: selector }),
-    renderHelp(suggestions),
-  ]);
+  return renderOutput([encode({ deleted: selector }), renderHelp(suggestions)]);
 }
 
 // cloneGist has no ctx parameter — gist is user-scoped.
@@ -440,10 +453,7 @@ async function cloneGist(args: string[]): Promise<string> {
       "VALIDATION_ERROR",
     );
   if (extra)
-    throw new AxiError(
-      `Unexpected argument: ${extra}`,
-      "VALIDATION_ERROR",
-    );
+    throw new AxiError(`Unexpected argument: ${extra}`, "VALIDATION_ERROR");
 
   await ghExec(["gist", "clone", selector]);
   const suggestions = getSuggestions({ domain: "gist", action: "clone" });
@@ -539,9 +549,7 @@ async function createGist(args: string[]): Promise<string> {
       throw new AxiError(
         "--filename requires piped content on stdin; no pipe was detected",
         "VALIDATION_ERROR",
-        [
-          `echo 'content' | gh-axi gist create --filename <name> --public`,
-        ],
+        [`echo 'content' | gh-axi gist create --filename <name> --public`],
       );
     }
     const content = await readRequiredStdin(
@@ -564,7 +572,11 @@ async function createGist(args: string[]): Promise<string> {
   const url = stdout.trim().split("\n").pop()?.trim() ?? "";
   const id = url.split("/").pop() ?? "";
 
-  const navSuggestions = getSuggestions({ domain: "gist", action: "create", id });
+  const navSuggestions = getSuggestions({
+    domain: "gist",
+    action: "create",
+    id,
+  });
   const helpLines: string[] = [];
   // Secret gists are unlisted, not private. Surface this before navigation hints
   // so the agent sees the warning even if it stops reading after the first line.
@@ -680,7 +692,9 @@ async function editGist(args: string[]): Promise<string> {
       throw new AxiError(
         "--filename requires content piped via stdin",
         "VALIDATION_ERROR",
-        ["Example: echo 'content' | gh-axi gist edit <id|url> --filename <name>"],
+        [
+          "Example: echo 'content' | gh-axi gist edit <id|url> --filename <name>",
+        ],
       );
     }
     // The `-` positional tells gh to read content from stdin; `--filename`
@@ -791,7 +805,7 @@ async function renameGist(args: string[]): Promise<string> {
 // gistCommand has no ctx parameter — gist is user-scoped and ctx must never
 // reach ghJson. TypeScript accepts (args: string[]) as CommandFn because
 // fewer parameters are always assignable to a type with more optional params.
-// See AGENTS.md "GitHub Projects" section for the owner-scoped pattern.
+// See AGENTS.md "User-scoped commands" section.
 export async function gistCommand(args: string[]): Promise<string> {
   const sub = args[0];
   if (sub === "--help" || sub === undefined) return GIST_HELP;

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -1,7 +1,7 @@
 import { encode } from "@toon-format/toon";
 import { ghJson, ghExec, ghExecWithStdin } from "../gh.js";
 import { AxiError } from "../errors.js";
-import { getFlag, hasFlag, takeFlag, takeBoolFlag, takeAllFlags } from "../args.js";
+import { hasFlag, takeFlag, takeBoolFlag, takeAllFlags } from "../args.js";
 import {
   field,
   custom,
@@ -85,6 +85,7 @@ interface GistFile {
   size: number;
   content?: string;
   truncated?: boolean;
+  raw_url?: string;
 }
 
 interface GistDetail {
@@ -97,6 +98,47 @@ interface GistDetail {
   created_at: string;
   updated_at: string;
   html_url: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared guards
+// ---------------------------------------------------------------------------
+
+/**
+ * Reject every leftover token that looks like a flag but is not on the known
+ * list. Callers must consume their value flags first, so anything remaining is
+ * either a known boolean flag or a typo that would otherwise silently degrade
+ * the result at exit 0 (`--ful` ignored, `--dry-run` ignored before a delete).
+ * Single-dash tokens count too: gh shorthands must never reach a positional slot.
+ */
+function rejectUnknownFlags(tokens: string[], known: readonly string[]): void {
+  const unknown = tokens.filter(
+    (a) => a.startsWith("-") && !known.includes(a.split("=")[0]),
+  );
+  if (unknown.length > 0) {
+    throw new AxiError(
+      `Unknown flag(s): ${unknown.join(", ")}`,
+      "VALIDATION_ERROR",
+    );
+  }
+}
+
+/**
+ * Read piped stdin, rejecting a zero-length read the way resolveValue does.
+ * isStdinTTY() never fires in agent contexts, so an empty read is the only
+ * signal that nothing was actually piped — issuing the gh write anyway would
+ * replace the target file's content with nothing.
+ */
+async function readRequiredStdin(example: string): Promise<string> {
+  const content = await readStdin();
+  if (content.length === 0) {
+    throw new AxiError(
+      "no content received on stdin; nothing was piped",
+      "VALIDATION_ERROR",
+      [example],
+    );
+  }
+  return content;
 }
 
 // ---------------------------------------------------------------------------
@@ -146,13 +188,26 @@ const gistMetaSchema: FieldDef[] = [
   pluck("owner", "login", "owner"),
 ];
 
+/**
+ * GET /gists/<id> caps each file's `content` at 1 MB and sets `truncated: true`
+ * (files over 10 MB carry no content at all). --full cannot undo that server-side
+ * cap, so the note is appended regardless of --full and points at raw_url.
+ */
+function apiTruncationNote(file: GistFile): string {
+  const source = file.raw_url
+    ? ` - fetch the full file from ${file.raw_url}`
+    : "";
+  return `\n... (truncated by the GitHub API at 1MB${source})`;
+}
+
 function makeFileSchema(full: boolean): FieldDef[] {
   return [
     field("filename"),
     custom("size", (item: GistFile) => `${item.size} bytes`),
     custom("content", (item: GistFile) => {
       const raw = typeof item.content === "string" ? item.content : "";
-      return truncateGistContent(raw, CONTENT_MAX_LEN, full);
+      const shown = truncateGistContent(raw, CONTENT_MAX_LEN, full);
+      return item.truncated === true ? shown + apiTruncationNote(item) : shown;
     }),
   ];
 }
@@ -177,9 +232,11 @@ async function viewGist(args: string[]): Promise<string> {
   const filenameShort = takeFlag(args, "-f");
   const filenameLong = takeFlag(args, "--filename");
   const filenameArg = filenameShort ?? filenameLong;
-  // -r/--raw is documented as a no-op: output is always raw text.
-  takeBoolFlag(args, "-r");
-  takeBoolFlag(args, "--raw");
+
+  // Every value flag is consumed above, so any remaining flag-shaped token must
+  // be a boolean view flag. -r/--raw is documented as a no-op (output is always
+  // raw text) and is whitelisted purely to keep that contract.
+  rejectUnknownFlags(args.slice(1), ["--files", "--full", "-r", "--raw"]);
 
   // The selector is the sole remaining positional (args[0] is "view"; all
   // value flags were consumed above). Order-insensitive: `gist view --full <id>`
@@ -244,8 +301,8 @@ async function viewGist(args: string[]): Promise<string> {
 // gh api /gists has no --repo flag; the guard is enforced structurally.
 // See AGENTS.md "GitHub Projects" section for the owner-scoped pattern.
 async function listGists(args: string[]): Promise<string> {
-  const wantPublic = hasFlag(args, "--public");
-  const wantSecret = hasFlag(args, "--secret");
+  const wantPublic = takeBoolFlag(args, "--public");
+  const wantSecret = takeBoolFlag(args, "--secret");
 
   // Fail loudly — passing both is undefined behaviour, not a degraded result.
   if (wantPublic && wantSecret) {
@@ -257,12 +314,17 @@ async function listGists(args: string[]): Promise<string> {
 
   // Let parseFields throw AxiError on unknown fields so the process exits
   // non-zero — matching every sibling command family (issue.ts:226, run.ts:207).
-  const fieldsArg = getFlag(args, "--fields");
+  const fieldsArg = takeFlag(args, "--fields");
   const { extraDefs } = parseFields(fieldsArg, EXTRA_FIELDS);
 
   // Validate --limit before use; parseInt("abc") = NaN and slice(0, NaN) = []
   // giving a silent empty result at exit 0, which is actively wrong.
-  const limitArg = getFlag(args, "--limit");
+  const limitArg = takeFlag(args, "--limit");
+
+  // Both value flags are consumed above, so nothing flag-shaped may remain:
+  // `--limitt 5` must fail loudly instead of silently returning 100 rows.
+  rejectUnknownFlags(args.slice(1), []);
+
   let limit: number;
   if (limitArg !== undefined) {
     const n = parseInt(limitArg, 10);
@@ -324,7 +386,11 @@ async function listGists(args: string[]): Promise<string> {
 // gh gist delete refuses to run non-interactively without --yes;
 // always pass it so this command never prompts.
 async function deleteGist(args: string[]): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith("--"));
+  // delete takes no flags. Reject them before resolving the selector so a
+  // misspelled guard flag (`--dry-run`) can never be silently dropped.
+  rejectUnknownFlags(args.slice(1), []);
+
+  const positionals = args.filter((a) => !a.startsWith("-"));
   const selector = positionals[1]; // positionals[0] == "delete"
   const extra = positionals[2];
 
@@ -351,7 +417,11 @@ async function deleteGist(args: string[]): Promise<string> {
 // Mirrors cloneRepo exactly: take the selector, shell out, report ok.
 // No target-directory or git-flags passthrough — matches repo clone restraint.
 async function cloneGist(args: string[]): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith("--"));
+  // clone takes no flags — same rejection as delete, so no git/gh shorthand
+  // slips through as the selector.
+  rejectUnknownFlags(args.slice(1), []);
+
+  const positionals = args.filter((a) => !a.startsWith("-"));
   const selector = positionals[1]; // positionals[0] == "clone"
   const extra = positionals[2];
 
@@ -412,13 +482,7 @@ async function createGist(args: string[]): Promise<string> {
   // forwarded as file paths. -p is especially dangerous: it reaches gh as the
   // --public flag, creating a public gist while the wrapper reports secret.
   const remaining = args.slice(1);
-  const unknownFlags = remaining.filter((a) => a.startsWith("-"));
-  if (unknownFlags.length > 0) {
-    throw new AxiError(
-      `Unknown flag(s): ${unknownFlags.join(", ")}`,
-      "VALIDATION_ERROR",
-    );
-  }
+  rejectUnknownFlags(remaining, []);
   const positionals = remaining.filter((a) => !a.startsWith("-"));
 
   // Mixing the two file-on-disk input forms is a hard error.
@@ -471,7 +535,9 @@ async function createGist(args: string[]): Promise<string> {
         ],
       );
     }
-    const content = await readStdin();
+    const content = await readRequiredStdin(
+      `echo 'content' | gh-axi gist create --filename <name> --public`,
+    );
     ghArgs.push("--filename", filename);
     // No ctx — gist is user-scoped; buildArgs must not append --repo.
     stdout = await ghExecWithStdin(ghArgs, content);
@@ -596,7 +662,9 @@ async function editGist(args: string[]): Promise<string> {
     // and opens $EDITOR instead — verified against a live gist.
     const ghArgs = ["gist", "edit", id, "-", "--filename", filenameFlag];
     if (descFlag !== undefined) ghArgs.push("--desc", descFlag);
-    const content = await readStdin();
+    const content = await readRequiredStdin(
+      "Example: echo 'content' | gh-axi gist edit <id|url> --filename <name>",
+    );
     await ghExecWithStdin(ghArgs, content);
   } else if (addFlag !== undefined && wantsStdin) {
     // Add a brand-new file from piped stdin, signalled by the explicit `-`.
@@ -611,7 +679,9 @@ async function editGist(args: string[]): Promise<string> {
     }
     const ghArgs = ["gist", "edit", id, "--add", addFlag, "-"];
     if (descFlag !== undefined) ghArgs.push("--desc", descFlag);
-    const content = await readStdin();
+    const content = await readRequiredStdin(
+      "Example: echo 'content' | gh-axi gist edit <id|url> --add <name> -",
+    );
     await ghExecWithStdin(ghArgs, content);
   } else if (
     descFlag !== undefined &&

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -21,12 +21,14 @@ import { isStdinTTY, readStdin } from "../stdin.js";
 import { gistIdFromSelector } from "../gistSelector.js";
 
 export const GIST_HELP = `usage: gh-axi gist <subcommand> [flags]
-subcommands[5]:
-  list, view <id|url>, create, delete <id|url>, clone <id|url>
+subcommands[7]:
+  list, view <id|url>, edit <id|url>, rename <id|url> <old> <new>, create, delete <id|url>, clone <id|url>
 flags{list}:
   --limit <n> (default 100), --public, --secret, --fields <field,...>
 flags{view}:
   --files (file names only), -f/--filename <name> (single file), --full (no truncation), -r/--raw (no-op), -w/--web (rejected)
+flags{edit}:
+  --filename/-f <name> (required with piped content), --add/-a <path>, --remove/-r <name>, --desc/-d <text>
 flags{create}:
   --public (required, mutually exclusive with --secret)
   --secret (required, mutually exclusive with --public)
@@ -39,6 +41,9 @@ examples:
   gh-axi gist view 5b0e0062eb8e9654adad7bb1d81cc75f
   gh-axi gist view https://gist.github.com/octocat/5b0e0062eb8e9654adad7bb1d81cc75f
   gh-axi gist view 5b0e0062eb8e9654adad7bb1d81cc75f --files
+  echo 'new content' | gh-axi gist edit <id|url> --filename notes.md
+  gh-axi gist edit <id|url> --remove old-file.txt --desc "updated description"
+  gh-axi gist rename <id|url> old.txt new.txt
   gh-axi gist create notes.md --public --desc "My notes"
   gh-axi gist create --file a.py --file b.py --secret
   echo "content" | gh-axi gist create --filename hello.txt --public
@@ -494,6 +499,200 @@ async function createGist(args: string[]): Promise<string> {
   ]);
 }
 
+// extractGistId reduces a bare id or a gist URL to the id. Takes the last
+// non-empty path segment — gh's own GistIDFromURL uses split[2], which returns
+// the OWNER for GHE URLs (https://ghe.host/gist/OWNER/ID); this is correct for
+// all three URL shapes.
+function extractGistId(selector: string): string {
+  if (selector.startsWith("http://") || selector.startsWith("https://")) {
+    const segments = selector.split("/").filter((s) => s.length > 0);
+    return segments[segments.length - 1] ?? selector;
+  }
+  return selector;
+}
+
+// editGist has no ctx parameter — see gistCommand note below.
+async function editGist(args: string[]): Promise<string> {
+  // args[0] = "edit", args[1] = id/url
+  const id = args[1];
+  if (!id) {
+    throw new AxiError(
+      "Gist ID or URL is required: gh-axi gist edit <id|url> [flags]",
+      "VALIDATION_ERROR",
+    );
+  }
+
+  const remaining = args.slice(2);
+
+  const filenameFlag =
+    getFlag(remaining, "--filename") ?? getFlag(remaining, "-f");
+  const addFlag = getFlag(remaining, "--add") ?? getFlag(remaining, "-a");
+  const removeFlag = getFlag(remaining, "--remove") ?? getFlag(remaining, "-r");
+  const descFlag = getFlag(remaining, "--desc") ?? getFlag(remaining, "-d");
+
+  // Reject mutually exclusive file operations in a single call.
+  const fileOpCount = [filenameFlag, addFlag, removeFlag].filter(
+    (v): v is string => v !== undefined,
+  ).length;
+  if (fileOpCount > 1) {
+    throw new AxiError(
+      "--filename, --add, and --remove are mutually exclusive; pass only one per invocation",
+      "VALIDATION_ERROR",
+    );
+  }
+
+  const hasPipedStdin = !isStdinTTY();
+
+  // Guard 2: piped content with no file selector → gh would prompt which file
+  // to edit ("unsure what file to edit; either specify --filename or run
+  // interactively"). Two exemptions:
+  //   • --filename present: the `-` + --filename path consumes stdin ✓
+  //   • --add present: the --add + `-` path consumes stdin ✓
+  //   • desc-only (no file op at all): routes via API and never reads stdin ✓
+  const isDescOnly =
+    descFlag !== undefined &&
+    filenameFlag === undefined &&
+    addFlag === undefined &&
+    removeFlag === undefined;
+  if (
+    hasPipedStdin &&
+    filenameFlag === undefined &&
+    addFlag === undefined &&
+    !isDescOnly
+  ) {
+    throw new AxiError(
+      "piped content requires --filename <name> or --add <name> to identify the target file",
+      "VALIDATION_ERROR",
+      [
+        "Replace a file: echo 'content' | gh-axi gist edit <id|url> --filename <name>",
+        "Add a new file: echo 'content' | gh-axi gist edit <id|url> --add <name>",
+      ],
+    );
+  }
+
+  // Guard 1: --filename given but no piped content → gh would open $EDITOR.
+  // Pre-empt before invoking gh.
+  if (filenameFlag !== undefined && !hasPipedStdin) {
+    throw new AxiError(
+      "--filename requires content to be piped via stdin",
+      "VALIDATION_ERROR",
+      [
+        "Example: echo 'content' | gh-axi gist edit <id|url> --filename <name>",
+      ],
+    );
+  }
+
+  // Guard: nothing to edit — gh with no flags would open $EDITOR.
+  if (
+    filenameFlag === undefined &&
+    addFlag === undefined &&
+    removeFlag === undefined &&
+    descFlag === undefined
+  ) {
+    throw new AxiError(
+      "nothing to edit; pass --filename <name> with piped content, --add <path>, --remove <name>, or --desc <text>",
+      "VALIDATION_ERROR",
+    );
+  }
+
+  // Guard 3 (What-next? prompt) is pre-empted structurally: we always run gh
+  // as a child process with stdin not connected to a TTY.
+
+  if (filenameFlag !== undefined) {
+    // Replace (or create) a file from piped stdin.
+    // The `-` positional tells gh to read content from stdin; `--filename`
+    // names the target file in the gist. Without `-`, gh ignores piped bytes
+    // and opens $EDITOR instead — verified against a live gist.
+    const ghArgs = ["gist", "edit", id, "-", "--filename", filenameFlag];
+    if (descFlag !== undefined) ghArgs.push("--desc", descFlag);
+    const content = await readStdin();
+    await ghExecWithStdin(ghArgs, content);
+  } else if (addFlag !== undefined && hasPipedStdin) {
+    // Add a brand-new file from piped stdin.
+    // `--add <name>` names the new file; the trailing `-` is the content
+    // source (stdin), matching `gh gist edit <id> --add <name> -`.
+    const ghArgs = ["gist", "edit", id, "--add", addFlag, "-"];
+    if (descFlag !== undefined) ghArgs.push("--desc", descFlag);
+    const content = await readStdin();
+    await ghExecWithStdin(ghArgs, content);
+  } else if (
+    descFlag !== undefined &&
+    addFlag === undefined &&
+    removeFlag === undefined
+  ) {
+    // Description-only update.
+    // `gh gist edit <id> --desc <text>` with no file selector still enters
+    // the content-edit loop: on a multi-file gist it errors "unsure what file
+    // to edit"; on a single-file gist it relies on $EDITOR being a no-op
+    // (fragile in CI). Route through the REST API instead — metadata writes
+    // have no binary-content concern so the API path is safe here.
+    const gistId = extractGistId(id);
+    await ghExec([
+      "api",
+      "-X",
+      "PATCH",
+      `/gists/${gistId}`,
+      "-f",
+      `description=${descFlag}`,
+    ]);
+  } else {
+    // Add from disk, remove (with or without --desc), or add/remove + desc.
+    // These paths provide an explicit file selector so gh never prompts.
+    const ghArgs = ["gist", "edit", id];
+    if (addFlag !== undefined) ghArgs.push("--add", addFlag);
+    if (removeFlag !== undefined) ghArgs.push("--remove", removeFlag);
+    if (descFlag !== undefined) ghArgs.push("--desc", descFlag);
+    await ghExec(ghArgs);
+  }
+
+  const suggestions = getSuggestions({ domain: "gist", action: "edit", id });
+  return renderOutput([
+    encode({ edited: "ok", gist: id }),
+    renderHelp(suggestions),
+  ]);
+}
+
+// renameGist has no ctx parameter — see gistCommand note below.
+async function renameGist(args: string[]): Promise<string> {
+  // args[0] = "rename", args[1..] = positionals and (no) flags
+  const allAfterSub = args.slice(1);
+
+  // Reject any flags — rename has none.
+  const unknownFlags = allAfterSub.filter((a) => a.startsWith("-"));
+  if (unknownFlags.length > 0) {
+    throw new AxiError(
+      `gist rename takes no flags; unexpected: ${unknownFlags.join(", ")}`,
+      "VALIDATION_ERROR",
+    );
+  }
+
+  const positionals = allAfterSub;
+
+  if (positionals.length < 3) {
+    throw new AxiError(
+      "usage: gh-axi gist rename <id|url> <old> <new>",
+      "VALIDATION_ERROR",
+    );
+  }
+
+  if (positionals.length > 3) {
+    throw new AxiError(
+      `too many arguments; expected: gh-axi gist rename <id|url> <old> <new>`,
+      "VALIDATION_ERROR",
+    );
+  }
+
+  const [id, oldName, newName] = positionals as [string, string, string];
+
+  await ghExec(["gist", "rename", id, oldName, newName]);
+
+  const suggestions = getSuggestions({ domain: "gist", action: "rename", id });
+  return renderOutput([
+    encode({ renamed: "ok", gist: id, from: oldName, to: newName }),
+    renderHelp(suggestions),
+  ]);
+}
+
 // gistCommand has no ctx parameter — gist is user-scoped and ctx must never
 // reach ghJson. TypeScript accepts (args: string[]) as CommandFn because
 // fewer parameters are always assignable to a type with more optional params.
@@ -507,6 +706,10 @@ export async function gistCommand(args: string[]): Promise<string> {
       return listGists(args);
     case "view":
       return viewGist(args);
+    case "edit":
+      return editGist(args);
+    case "rename":
+      return renameGist(args);
     case "create":
       return createGist(args);
     case "delete":
@@ -515,7 +718,7 @@ export async function gistCommand(args: string[]): Promise<string> {
       return cloneGist(args);
     default:
       return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [
-        "Available subcommands: list, view, create, delete, clone",
+        "Available subcommands: list, view, edit, rename, create, delete, clone",
       ]);
   }
 }

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -1,0 +1,147 @@
+import { ghJson } from "../gh.js";
+import { AxiError } from "../errors.js";
+import { getFlag, hasFlag } from "../args.js";
+import {
+  field,
+  custom,
+  relativeTime,
+  pluck,
+  renderList,
+  renderHelp,
+  renderOutput,
+  renderError,
+  type FieldDef,
+} from "../toon.js";
+import { formatCountLine } from "../format.js";
+import { getSuggestions } from "../suggestions.js";
+import { parseFields, type ExtraFieldSpec } from "../fields.js";
+
+export const GIST_HELP = `usage: gh-axi gist <subcommand> [flags]
+subcommands[1]:
+  list
+flags{list}:
+  --limit <n> (default 100), --public, --secret, --fields <field,...>
+examples:
+  gh-axi gist list
+  gh-axi gist list --public --limit 20
+  gh-axi gist list --fields url,owner,created`;
+
+/** Maximum items per /gists page. Also the per_page ceiling for this endpoint. */
+const PAGE_SIZE = 100;
+
+/** Always-present fields in list output (AXI P2: 3–4 fields). */
+const defaultSchema: FieldDef[] = [
+  field("id"),
+  field("description"),
+  custom("files", (item) =>
+    Object.keys((item["files"] as Record<string, unknown>) ?? {}).length,
+  ),
+  custom("visibility", (item) => (item["public"] === true ? "public" : "secret")),
+];
+
+/** Extra fields unlocked via --fields. */
+const EXTRA_FIELDS: Record<string, ExtraFieldSpec> = {
+  created: { jsonKey: "created_at", def: relativeTime("created_at", "created") },
+  updated: { jsonKey: "updated_at", def: relativeTime("updated_at", "updated") },
+  url: { jsonKey: "html_url", def: field("html_url", "url") },
+  comments: { jsonKey: "comments", def: field("comments") },
+  owner: { jsonKey: "owner", def: pluck("owner", "login", "owner") },
+};
+
+// listGists deliberately has no ctx parameter. gist is user-scoped and
+// gh api /gists has no --repo flag; the guard is enforced structurally.
+// See AGENTS.md "GitHub Projects" section for the owner-scoped pattern.
+async function listGists(args: string[]): Promise<string> {
+  const wantPublic = hasFlag(args, "--public");
+  const wantSecret = hasFlag(args, "--secret");
+
+  // Fail loudly — passing both is undefined behaviour, not a degraded result.
+  if (wantPublic && wantSecret) {
+    throw new AxiError(
+      "--public and --secret are mutually exclusive",
+      "VALIDATION_ERROR",
+    );
+  }
+
+  // Let parseFields throw AxiError on unknown fields so the process exits
+  // non-zero — matching every sibling command family (issue.ts:226, run.ts:207).
+  const fieldsArg = getFlag(args, "--fields");
+  const { extraDefs } = parseFields(fieldsArg, EXTRA_FIELDS);
+
+  // Validate --limit before use; parseInt("abc") = NaN and slice(0, NaN) = []
+  // giving a silent empty result at exit 0, which is actively wrong.
+  const limitArg = getFlag(args, "--limit");
+  let limit: number;
+  if (limitArg !== undefined) {
+    const n = parseInt(limitArg, 10);
+    if (isNaN(n) || n < 1) {
+      throw new AxiError(
+        `--limit must be a positive integer, got: ${limitArg}`,
+        "VALIDATION_ERROR",
+      );
+    }
+    limit = n;
+  } else {
+    limit = PAGE_SIZE;
+  }
+
+  // --limit caps the *displayed* rows after filtering, not the fetch size.
+  // When a visibility filter is active we must fetch ALL pages regardless of
+  // limit — the API has no visibility filter, so we can only count matching
+  // gists after receiving them. Without pagination, a --secret --limit 50 on
+  // an account with 94 secret gists (and some public ones interspersed) would
+  // silently stop at the first 100 API results and under-report.
+  const filtering = wantPublic || wantSecret;
+  const paginate = limit > PAGE_SIZE || filtering;
+  const perPage = filtering ? PAGE_SIZE : Math.min(limit, PAGE_SIZE);
+
+  const apiArgs: string[] = ["api", `/gists?per_page=${perPage}`];
+  if (paginate) {
+    // gh merges paginated array responses into a single valid JSON array
+    // (verified on gh 2.86.0 — no concatenation issue for array endpoints).
+    apiArgs.push("--paginate");
+  }
+
+  // No ctx forwarded — gist is user-scoped; gh.ts#buildArgs would append
+  // --repo <nwo> for flag/env-sourced contexts and gh api has no --repo.
+  const gists = await ghJson<Record<string, unknown>[]>(apiArgs);
+
+  // Client-side visibility filter (the /gists endpoint has no visibility param).
+  const filtered = wantPublic
+    ? gists.filter((g) => g["public"] === true)
+    : wantSecret
+      ? gists.filter((g) => g["public"] !== true)
+      : gists;
+
+  // Client-side display cap applied after filtering.
+  const displayed = filtered.slice(0, limit);
+
+  const isEmpty = displayed.length === 0;
+  const schema = [...defaultSchema, ...extraDefs];
+  const countLine = formatCountLine({ count: displayed.length, limit });
+
+  const suggestions = getSuggestions({ domain: "gist", action: "list", isEmpty });
+  return renderOutput([
+    countLine,
+    renderList("gists", displayed, schema),
+    renderHelp(suggestions),
+  ]);
+}
+
+// gistCommand has no ctx parameter — gist is user-scoped and ctx must never
+// reach ghJson. TypeScript accepts (args: string[]) as CommandFn because
+// fewer parameters are always assignable to a type with more optional params.
+// See AGENTS.md "GitHub Projects" section for the owner-scoped pattern.
+export async function gistCommand(args: string[]): Promise<string> {
+  const sub = args[0];
+  if (sub === "--help" || sub === undefined) return GIST_HELP;
+
+  switch (sub) {
+    case "list":
+      return listGists(args);
+    default:
+      return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [
+        "Available subcommands: list",
+      ]);
+  }
+}

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -8,8 +8,8 @@ import {
   relativeTime,
   pluck,
   renderList,
-  renderHelp,
   renderDetail,
+  renderHelp,
   renderOutput,
   renderError,
   type FieldDef,
@@ -18,12 +18,15 @@ import { formatCountLine } from "../format.js";
 import { getSuggestions } from "../suggestions.js";
 import { parseFields, type ExtraFieldSpec } from "../fields.js";
 import { isStdinTTY, readStdin } from "../stdin.js";
+import { gistIdFromSelector } from "../gistSelector.js";
 
 export const GIST_HELP = `usage: gh-axi gist <subcommand> [flags]
-subcommands[4]:
-  list, create, delete <id|url>, clone <id|url>
+subcommands[5]:
+  list, view <id|url>, create, delete <id|url>, clone <id|url>
 flags{list}:
   --limit <n> (default 100), --public, --secret, --fields <field,...>
+flags{view}:
+  --files (file names only), -f/--filename <name> (single file), --full (no truncation), -r/--raw (no-op), -w/--web (rejected)
 flags{create}:
   --public (required, mutually exclusive with --secret)
   --secret (required, mutually exclusive with --public)
@@ -33,6 +36,9 @@ examples:
   gh-axi gist list
   gh-axi gist list --public --limit 20
   gh-axi gist list --fields url,owner,created
+  gh-axi gist view 5b0e0062eb8e9654adad7bb1d81cc75f
+  gh-axi gist view https://gist.github.com/octocat/5b0e0062eb8e9654adad7bb1d81cc75f
+  gh-axi gist view 5b0e0062eb8e9654adad7bb1d81cc75f --files
   gh-axi gist create notes.md --public --desc "My notes"
   gh-axi gist create --file a.py --file b.py --secret
   echo "content" | gh-axi gist create --filename hello.txt --public
@@ -60,6 +66,163 @@ const EXTRA_FIELDS: Record<string, ExtraFieldSpec> = {
   comments: { jsonKey: "comments", def: field("comments") },
   owner: { jsonKey: "owner", def: pluck("owner", "login", "owner") },
 };
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface GistFile {
+  filename: string;
+  type?: string;
+  language?: string;
+  size: number;
+  content?: string;
+  truncated?: boolean;
+}
+
+interface GistDetail {
+  id: string;
+  description: string | null;
+  public: boolean;
+  owner: { login: string } | null;
+  files: Record<string, GistFile>;
+  comments: number;
+  created_at: string;
+  updated_at: string;
+  html_url: string;
+}
+
+// ---------------------------------------------------------------------------
+// Content truncation (gist-specific: no prose cleanups)
+// ---------------------------------------------------------------------------
+
+/** Maximum characters shown per file in the default (non-full) view. */
+const CONTENT_MAX_LEN = 1500;
+
+/**
+ * Raw head-slice truncation for gist file content.
+ *
+ * Unlike truncateBody, this helper applies NO prose cleanups. Gist content
+ * is often source code or diffs where cleanup transforms (collapsing lines
+ * starting with `>`, stripping URLs) would corrupt the content.
+ * Footer is appended only when content is actually truncated (AXI P3).
+ */
+function truncateGistContent(
+  content: string,
+  maxLen: number,
+  full: boolean,
+): string {
+  if (full || content.length <= maxLen) return content;
+  return (
+    content.slice(0, maxLen) +
+    `\n... (truncated, ${content.length} chars total - use --full)`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// View schemas
+// ---------------------------------------------------------------------------
+
+const gistMetaSchema: FieldDef[] = [
+  field("id"),
+  field("description"),
+  custom("visibility", (item: GistDetail) =>
+    item.public === true ? "public" : "secret",
+  ),
+  custom("files", (item: GistDetail) =>
+    Object.keys(item.files ?? {}).length,
+  ),
+  relativeTime("created_at", "created"),
+  relativeTime("updated_at", "updated"),
+  field("comments"),
+  field("html_url", "url"),
+  pluck("owner", "login", "owner"),
+];
+
+function makeFileSchema(full: boolean): FieldDef[] {
+  return [
+    field("filename"),
+    custom("size", (item: GistFile) => `${item.size} bytes`),
+    custom("content", (item: GistFile) => {
+      const raw = typeof item.content === "string" ? item.content : "";
+      return truncateGistContent(raw, CONTENT_MAX_LEN, full);
+    }),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// View handler
+// ---------------------------------------------------------------------------
+
+// viewGist deliberately has no ctx parameter — gist is user-scoped.
+async function viewGist(args: string[]): Promise<string> {
+  // Reject -w/--web up-front before consuming any other args (AXI P6).
+  if (hasFlag(args, "-w") || hasFlag(args, "--web")) {
+    throw new AxiError(
+      "-w/--web is not supported: opening a browser is a no-op in agent contexts",
+      "VALIDATION_ERROR",
+    );
+  }
+
+  const full = hasFlag(args, "--full");
+  const filesOnly = hasFlag(args, "--files");
+  // takeFlag mutates args; consume -f before --filename to avoid double-take.
+  const filenameShort = takeFlag(args, "-f");
+  const filenameLong = takeFlag(args, "--filename");
+  const filenameArg = filenameShort ?? filenameLong;
+  // -r/--raw is documented as a no-op: output is always raw text.
+  takeBoolFlag(args, "-r");
+  takeBoolFlag(args, "--raw");
+
+  // args[0] is "view"; args[1] is the selector.
+  const selector = args[1];
+  if (!selector || selector.startsWith("-")) {
+    throw new AxiError(
+      "gist view requires a gist id or URL",
+      "VALIDATION_ERROR",
+      ["Usage: gh-axi gist view <id|url>"],
+    );
+  }
+
+  // Validate + extract bare id (throws VALIDATION_ERROR on bad input/host).
+  const id = gistIdFromSelector(selector);
+
+  // No ctx forwarded — gist is user-scoped; gh.ts#buildArgs would append
+  // --repo for flag/env-sourced contexts and gh api has no --repo flag.
+  const data = await ghJson<GistDetail>(["api", `/gists/${id}`]);
+  const fileList = Object.values(data.files ?? {});
+
+  const suggestions = getSuggestions({ domain: "gist", action: "view", id });
+
+  if (filesOnly) {
+    return renderOutput([
+      renderList("files", fileList, [field("filename")]),
+      renderHelp(suggestions),
+    ]);
+  }
+
+  if (filenameArg !== undefined) {
+    const file = (data.files ?? {})[filenameArg];
+    if (!file) {
+      const available = Object.keys(data.files ?? {}).join(", ");
+      throw new AxiError(
+        `File "${filenameArg}" not found in gist ${id}. Available: ${available || "(none)"}`,
+        "VALIDATION_ERROR",
+      );
+    }
+    return renderOutput([
+      renderList("files", [file], makeFileSchema(full)),
+      renderHelp(suggestions),
+    ]);
+  }
+
+  // Default: metadata block + all files with (possibly truncated) content.
+  return renderOutput([
+    renderDetail("gist", data as unknown as Record<string, unknown>, gistMetaSchema),
+    renderList("files", fileList, makeFileSchema(full)),
+    renderHelp(suggestions),
+  ]);
+}
 
 // listGists deliberately has no ctx parameter. gist is user-scoped and
 // gh api /gists has no --repo flag; the guard is enforced structurally.
@@ -342,6 +505,8 @@ export async function gistCommand(args: string[]): Promise<string> {
   switch (sub) {
     case "list":
       return listGists(args);
+    case "view":
+      return viewGist(args);
     case "create":
       return createGist(args);
     case "delete":
@@ -350,7 +515,7 @@ export async function gistCommand(args: string[]): Promise<string> {
       return cloneGist(args);
     default:
       return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [
-        "Available subcommands: list, create, delete, clone",
+        "Available subcommands: list, view, create, delete, clone",
       ]);
   }
 }

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -1,7 +1,7 @@
 import { encode } from "@toon-format/toon";
-import { ghJson, ghExec } from "../gh.js";
+import { ghJson, ghExec, ghExecWithStdin } from "../gh.js";
 import { AxiError } from "../errors.js";
-import { getFlag, hasFlag } from "../args.js";
+import { getFlag, hasFlag, takeFlag, takeBoolFlag, takeAllFlags } from "../args.js";
 import {
   field,
   custom,
@@ -9,6 +9,7 @@ import {
   pluck,
   renderList,
   renderHelp,
+  renderDetail,
   renderOutput,
   renderError,
   type FieldDef,
@@ -16,16 +17,25 @@ import {
 import { formatCountLine } from "../format.js";
 import { getSuggestions } from "../suggestions.js";
 import { parseFields, type ExtraFieldSpec } from "../fields.js";
+import { isStdinTTY, readStdin } from "../stdin.js";
 
 export const GIST_HELP = `usage: gh-axi gist <subcommand> [flags]
-subcommands[3]:
-  list, delete <id|url>, clone <id|url>
+subcommands[4]:
+  list, create, delete <id|url>, clone <id|url>
 flags{list}:
   --limit <n> (default 100), --public, --secret, --fields <field,...>
+flags{create}:
+  --public (required, mutually exclusive with --secret)
+  --secret (required, mutually exclusive with --public)
+  --file <path> (repeatable), --filename <name> (for piped content)
+  -d/--desc <text>
 examples:
   gh-axi gist list
   gh-axi gist list --public --limit 20
   gh-axi gist list --fields url,owner,created
+  gh-axi gist create notes.md --public --desc "My notes"
+  gh-axi gist create --file a.py --file b.py --secret
+  echo "content" | gh-axi gist create --filename hello.txt --public
   gh-axi gist delete <id|url>
   gh-axi gist clone <id|url>`;
 
@@ -185,6 +195,142 @@ async function cloneGist(args: string[]): Promise<string> {
   ]);
 }
 
+// createGist deliberately has no ctx parameter. gist is user-scoped and
+// gh gist create has no --repo flag; the guard is enforced structurally.
+// See AGENTS.md "User-scoped commands" section.
+async function createGist(args: string[]): Promise<string> {
+  // Visibility: required and mutually exclusive — check before any other work.
+  const wantPublic = takeBoolFlag(args, "--public");
+  const wantSecret = takeBoolFlag(args, "--secret");
+
+  if (wantPublic && wantSecret) {
+    throw new AxiError(
+      "--public and --secret are mutually exclusive",
+      "VALIDATION_ERROR",
+    );
+  }
+  if (!wantPublic && !wantSecret) {
+    throw new AxiError(
+      "gist create requires --public or --secret; neither was given\n" +
+        "A secret gist is unlisted (anyone with the URL can read it), not private.",
+      "VALIDATION_ERROR",
+    );
+  }
+
+  // Description: -d and --desc are aliases; take both.
+  const descShort = takeFlag(args, "-d");
+  const descLong = takeFlag(args, "--desc");
+  const desc = descShort ?? descLong;
+
+  // Input form flags. takeAllFlags throws VALIDATION_ERROR on dangling / blank.
+  const filename = takeFlag(args, "--filename");
+  const fileFlags = takeAllFlags(args, "--file");
+
+  // After consuming all known flags, args[0] === "create" (subcommand name).
+  // Anything at index 1+ is either a positional file path or an unknown flag.
+  // Use startsWith("-") — not "--" — so single-dash gh shorthands (e.g. -p for
+  // --public, -w for --web, -f for --filename) are rejected rather than
+  // forwarded as file paths. -p is especially dangerous: it reaches gh as the
+  // --public flag, creating a public gist while the wrapper reports secret.
+  const remaining = args.slice(1);
+  const unknownFlags = remaining.filter((a) => a.startsWith("-"));
+  if (unknownFlags.length > 0) {
+    throw new AxiError(
+      `Unknown flag(s): ${unknownFlags.join(", ")}`,
+      "VALIDATION_ERROR",
+    );
+  }
+  const positionals = remaining.filter((a) => !a.startsWith("-"));
+
+  // Mixing the two file-on-disk input forms is a hard error.
+  if (positionals.length > 0 && fileFlags.length > 0) {
+    throw new AxiError(
+      "Cannot mix positional paths with --file; use one form: " +
+        "either `gist create a.py b.py` or `gist create --file a.py --file b.py`",
+      "VALIDATION_ERROR",
+    );
+  }
+
+  // Mixing file-on-disk with stdin/--filename is also a hard error.
+  const hasFileArgs = positionals.length > 0 || fileFlags.length > 0;
+  if (hasFileArgs && filename !== undefined) {
+    throw new AxiError(
+      "Cannot mix file paths with --filename; use one input form",
+      "VALIDATION_ERROR",
+    );
+  }
+
+  // At least one input source must be provided.
+  if (!hasFileArgs && filename === undefined) {
+    throw new AxiError(
+      "gist create requires at least one file: pass positional path(s), " +
+        "--file <path>, or pipe content with --filename <name>",
+      "VALIDATION_ERROR",
+    );
+  }
+
+  const visibility = wantPublic ? "public" : "secret";
+
+  // Build the base gh argv. Only --public changes default visibility (gh
+  // defaults to secret, so we never pass --secret to gh).
+  const ghArgs = ["gist", "create"];
+  if (wantPublic) ghArgs.push("--public");
+  if (desc) ghArgs.push("-d", desc);
+
+  let stdout: string;
+
+  if (filename !== undefined) {
+    // Stdin form: pipe content to gh with --filename.
+    // Any condition that would make gh prompt or open $EDITOR must be caught
+    // before invoking gh — an agent cannot answer a prompt.
+    if (isStdinTTY()) {
+      throw new AxiError(
+        "--filename requires piped content on stdin; no pipe was detected",
+        "VALIDATION_ERROR",
+        [
+          `echo 'content' | gh-axi gist create --filename <name> --public`,
+        ],
+      );
+    }
+    const content = await readStdin();
+    ghArgs.push("--filename", filename);
+    // No ctx — gist is user-scoped; buildArgs must not append --repo.
+    stdout = await ghExecWithStdin(ghArgs, content);
+  } else {
+    // File form: positionals take precedence; fileFlags are translated to positionals.
+    const paths = positionals.length > 0 ? positionals : fileFlags;
+    ghArgs.push(...paths);
+    // No ctx — gist is user-scoped; buildArgs must not append --repo.
+    stdout = await ghExec(ghArgs);
+  }
+
+  // gh gist create prints only the HTML URL to stdout (status messages go to
+  // stderr). Parse the id from the URL's last path segment, matching the
+  // pattern used by pr create's URL → number extraction.
+  const url = stdout.trim().split("\n").pop()?.trim() ?? "";
+  const id = url.split("/").pop() ?? "";
+
+  const navSuggestions = getSuggestions({ domain: "gist", action: "create", id });
+  const helpLines: string[] = [];
+  // Secret gists are unlisted, not private. Surface this before navigation hints
+  // so the agent sees the warning even if it stops reading after the first line.
+  if (visibility === "secret") {
+    helpLines.push(
+      "a secret gist is unlisted, not private — anyone with the URL can read it",
+    );
+  }
+  helpLines.push(...navSuggestions);
+
+  return renderOutput([
+    renderDetail("created", { id, url, visibility }, [
+      field("id"),
+      field("url"),
+      field("visibility"),
+    ]),
+    renderHelp(helpLines),
+  ]);
+}
+
 // gistCommand has no ctx parameter — gist is user-scoped and ctx must never
 // reach ghJson. TypeScript accepts (args: string[]) as CommandFn because
 // fewer parameters are always assignable to a type with more optional params.
@@ -196,13 +342,15 @@ export async function gistCommand(args: string[]): Promise<string> {
   switch (sub) {
     case "list":
       return listGists(args);
+    case "create":
+      return createGist(args);
     case "delete":
       return deleteGist(args);
     case "clone":
       return cloneGist(args);
     default:
       return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [
-        "Available subcommands: list, delete, clone",
+        "Available subcommands: list, create, delete, clone",
       ]);
   }
 }

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -28,7 +28,7 @@ flags{list}:
 flags{view}:
   --files (file names only), -f/--filename <name> (single file), --full (no truncation), -r/--raw (no-op), -w/--web (rejected)
 flags{edit}:
-  --filename/-f <name> (required with piped content), --add/-a <path>, --remove/-r <name>, --desc/-d <text>
+  --filename/-f <name> (replace from piped stdin), --add/-a <path> (from disk) or --add/-a <name> - (from piped stdin), --remove/-r <name>, --desc/-d <text>
 flags{create}:
   --public (required, mutually exclusive with --secret)
   --secret (required, mutually exclusive with --public)
@@ -42,6 +42,8 @@ examples:
   gh-axi gist view https://gist.github.com/octocat/5b0e0062eb8e9654adad7bb1d81cc75f
   gh-axi gist view 5b0e0062eb8e9654adad7bb1d81cc75f --files
   echo 'new content' | gh-axi gist edit <id|url> --filename notes.md
+  echo 'new file' | gh-axi gist edit <id|url> --add new.txt -
+  gh-axi gist edit <id|url> --add ./local.txt
   gh-axi gist edit <id|url> --remove old-file.txt --desc "updated description"
   gh-axi gist rename <id|url> old.txt new.txt
   gh-axi gist create notes.md --public --desc "My notes"
@@ -179,13 +181,22 @@ async function viewGist(args: string[]): Promise<string> {
   takeBoolFlag(args, "-r");
   takeBoolFlag(args, "--raw");
 
-  // args[0] is "view"; args[1] is the selector.
-  const selector = args[1];
-  if (!selector || selector.startsWith("-")) {
+  // The selector is the sole remaining positional (args[0] is "view"; all
+  // value flags were consumed above). Order-insensitive: `gist view --full <id>`
+  // must work as well as `gist view <id> --full`.
+  const positionals = args.slice(1).filter((a) => !a.startsWith("-"));
+  const selector = positionals[0];
+  if (!selector) {
     throw new AxiError(
       "gist view requires a gist id or URL",
       "VALIDATION_ERROR",
       ["Usage: gh-axi gist view <id|url>"],
+    );
+  }
+  if (positionals.length > 1) {
+    throw new AxiError(
+      `Unexpected argument: ${positionals[1]}`,
+      "VALIDATION_ERROR",
     );
   }
 
@@ -499,36 +510,39 @@ async function createGist(args: string[]): Promise<string> {
   ]);
 }
 
-// extractGistId reduces a bare id or a gist URL to the id. Takes the last
-// non-empty path segment — gh's own GistIDFromURL uses split[2], which returns
-// the OWNER for GHE URLs (https://ghe.host/gist/OWNER/ID); this is correct for
-// all three URL shapes.
-function extractGistId(selector: string): string {
-  if (selector.startsWith("http://") || selector.startsWith("https://")) {
-    const segments = selector.split("/").filter((s) => s.length > 0);
-    return segments[segments.length - 1] ?? selector;
-  }
-  return selector;
-}
-
 // editGist has no ctx parameter — see gistCommand note below.
 async function editGist(args: string[]): Promise<string> {
-  // args[0] = "edit", args[1] = id/url
-  const id = args[1];
+  // Consume every value flag first (takeFlag mutates), so the selector can be
+  // located order-insensitively among whatever positionals remain. args[0] is
+  // "edit". `??` short-circuits: a present long flag skips the short alias.
+  const rest = args.slice(1);
+  const filenameFlag = takeFlag(rest, "--filename") ?? takeFlag(rest, "-f");
+  const addFlag = takeFlag(rest, "--add") ?? takeFlag(rest, "-a");
+  const removeFlag = takeFlag(rest, "--remove") ?? takeFlag(rest, "-r");
+  const descFlag = takeFlag(rest, "--desc") ?? takeFlag(rest, "-d");
+
+  // A lone "-" is the explicit "read content from stdin" sentinel (gh's own
+  // convention). It is the ONLY stdin signal — never inferred from TTY-ness,
+  // because this tool always runs with a non-TTY stdin in agent contexts, so
+  // `!isStdinTTY()` would misclassify every invocation as "content piped".
+  const wantsStdin = rest.includes("-");
+
+  // The selector is the sole remaining positional (anything that is neither a
+  // flag nor the "-" sentinel). Order-insensitive, unlike the old args[1].
+  const positionals = rest.filter((a) => !a.startsWith("-"));
+  const id = positionals[0];
   if (!id) {
     throw new AxiError(
       "Gist ID or URL is required: gh-axi gist edit <id|url> [flags]",
       "VALIDATION_ERROR",
     );
   }
-
-  const remaining = args.slice(2);
-
-  const filenameFlag =
-    getFlag(remaining, "--filename") ?? getFlag(remaining, "-f");
-  const addFlag = getFlag(remaining, "--add") ?? getFlag(remaining, "-a");
-  const removeFlag = getFlag(remaining, "--remove") ?? getFlag(remaining, "-r");
-  const descFlag = getFlag(remaining, "--desc") ?? getFlag(remaining, "-d");
+  if (positionals.length > 1) {
+    throw new AxiError(
+      `Unexpected argument: ${positionals[1]}`,
+      "VALIDATION_ERROR",
+    );
+  }
 
   // Reject mutually exclusive file operations in a single call.
   const fileOpCount = [filenameFlag, addFlag, removeFlag].filter(
@@ -541,47 +555,6 @@ async function editGist(args: string[]): Promise<string> {
     );
   }
 
-  const hasPipedStdin = !isStdinTTY();
-
-  // Guard 2: piped content with no file selector → gh would prompt which file
-  // to edit ("unsure what file to edit; either specify --filename or run
-  // interactively"). Two exemptions:
-  //   • --filename present: the `-` + --filename path consumes stdin ✓
-  //   • --add present: the --add + `-` path consumes stdin ✓
-  //   • desc-only (no file op at all): routes via API and never reads stdin ✓
-  const isDescOnly =
-    descFlag !== undefined &&
-    filenameFlag === undefined &&
-    addFlag === undefined &&
-    removeFlag === undefined;
-  if (
-    hasPipedStdin &&
-    filenameFlag === undefined &&
-    addFlag === undefined &&
-    !isDescOnly
-  ) {
-    throw new AxiError(
-      "piped content requires --filename <name> or --add <name> to identify the target file",
-      "VALIDATION_ERROR",
-      [
-        "Replace a file: echo 'content' | gh-axi gist edit <id|url> --filename <name>",
-        "Add a new file: echo 'content' | gh-axi gist edit <id|url> --add <name>",
-      ],
-    );
-  }
-
-  // Guard 1: --filename given but no piped content → gh would open $EDITOR.
-  // Pre-empt before invoking gh.
-  if (filenameFlag !== undefined && !hasPipedStdin) {
-    throw new AxiError(
-      "--filename requires content to be piped via stdin",
-      "VALIDATION_ERROR",
-      [
-        "Example: echo 'content' | gh-axi gist edit <id|url> --filename <name>",
-      ],
-    );
-  }
-
   // Guard: nothing to edit — gh with no flags would open $EDITOR.
   if (
     filenameFlag === undefined &&
@@ -590,16 +563,34 @@ async function editGist(args: string[]): Promise<string> {
     descFlag === undefined
   ) {
     throw new AxiError(
-      "nothing to edit; pass --filename <name> with piped content, --add <path>, --remove <name>, or --desc <text>",
+      "nothing to edit; pass --filename <name> with piped content, --add <path|name>, --remove <name>, or --desc <text>",
       "VALIDATION_ERROR",
     );
   }
 
-  // Guard 3 (What-next? prompt) is pre-empted structurally: we always run gh
-  // as a child process with stdin not connected to a TTY.
+  // Guard: the stdin sentinel needs a file selector, else gh prompts which
+  // file to write ("unsure what file to edit").
+  if (wantsStdin && filenameFlag === undefined && addFlag === undefined) {
+    throw new AxiError(
+      "stdin content (-) requires --filename <name> or --add <name> to identify the target file",
+      "VALIDATION_ERROR",
+      [
+        "Replace a file: echo 'content' | gh-axi gist edit <id|url> --filename <name>",
+        "Add a new file: echo 'content' | gh-axi gist edit <id|url> --add <name> -",
+      ],
+    );
+  }
 
   if (filenameFlag !== undefined) {
-    // Replace (or create) a file from piped stdin.
+    // Replace (or create) a file from piped stdin. --filename's content always
+    // comes from stdin, so fail fast on a TTY (we must never block reading it).
+    if (isStdinTTY()) {
+      throw new AxiError(
+        "--filename requires content piped via stdin",
+        "VALIDATION_ERROR",
+        ["Example: echo 'content' | gh-axi gist edit <id|url> --filename <name>"],
+      );
+    }
     // The `-` positional tells gh to read content from stdin; `--filename`
     // names the target file in the gist. Without `-`, gh ignores piped bytes
     // and opens $EDITOR instead — verified against a live gist.
@@ -607,10 +598,17 @@ async function editGist(args: string[]): Promise<string> {
     if (descFlag !== undefined) ghArgs.push("--desc", descFlag);
     const content = await readStdin();
     await ghExecWithStdin(ghArgs, content);
-  } else if (addFlag !== undefined && hasPipedStdin) {
-    // Add a brand-new file from piped stdin.
+  } else if (addFlag !== undefined && wantsStdin) {
+    // Add a brand-new file from piped stdin, signalled by the explicit `-`.
     // `--add <name>` names the new file; the trailing `-` is the content
     // source (stdin), matching `gh gist edit <id> --add <name> -`.
+    if (isStdinTTY()) {
+      throw new AxiError(
+        "--add with the stdin sentinel (-) requires content piped via stdin",
+        "VALIDATION_ERROR",
+        ["Example: echo 'content' | gh-axi gist edit <id|url> --add <name> -"],
+      );
+    }
     const ghArgs = ["gist", "edit", id, "--add", addFlag, "-"];
     if (descFlag !== undefined) ghArgs.push("--desc", descFlag);
     const content = await readStdin();
@@ -626,7 +624,7 @@ async function editGist(args: string[]): Promise<string> {
     // to edit"; on a single-file gist it relies on $EDITOR being a no-op
     // (fragile in CI). Route through the REST API instead — metadata writes
     // have no binary-content concern so the API path is safe here.
-    const gistId = extractGistId(id);
+    const gistId = gistIdFromSelector(id);
     await ghExec([
       "api",
       "-X",
@@ -636,8 +634,9 @@ async function editGist(args: string[]): Promise<string> {
       `description=${descFlag}`,
     ]);
   } else {
-    // Add from disk, remove (with or without --desc), or add/remove + desc.
-    // These paths provide an explicit file selector so gh never prompts.
+    // Add from disk (`--add <path>`, no `-`), remove, or those combined with
+    // --desc. Each provides an explicit file selector so gh never prompts, and
+    // none reads stdin.
     const ghArgs = ["gist", "edit", id];
     if (addFlag !== undefined) ghArgs.push("--add", addFlag);
     if (removeFlag !== undefined) ghArgs.push("--remove", removeFlag);

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -1,4 +1,5 @@
-import { ghJson } from "../gh.js";
+import { encode } from "@toon-format/toon";
+import { ghJson, ghExec } from "../gh.js";
 import { AxiError } from "../errors.js";
 import { getFlag, hasFlag } from "../args.js";
 import {
@@ -17,14 +18,16 @@ import { getSuggestions } from "../suggestions.js";
 import { parseFields, type ExtraFieldSpec } from "../fields.js";
 
 export const GIST_HELP = `usage: gh-axi gist <subcommand> [flags]
-subcommands[1]:
-  list
+subcommands[3]:
+  list, delete <id|url>, clone <id|url>
 flags{list}:
   --limit <n> (default 100), --public, --secret, --fields <field,...>
 examples:
   gh-axi gist list
   gh-axi gist list --public --limit 20
-  gh-axi gist list --fields url,owner,created`;
+  gh-axi gist list --fields url,owner,created
+  gh-axi gist delete <id|url>
+  gh-axi gist clone <id|url>`;
 
 /** Maximum items per /gists page. Also the per_page ceiling for this endpoint. */
 const PAGE_SIZE = 100;
@@ -128,6 +131,60 @@ async function listGists(args: string[]): Promise<string> {
   ]);
 }
 
+// deleteGist has no ctx parameter — gist is user-scoped.
+// gh gist delete refuses to run non-interactively without --yes;
+// always pass it so this command never prompts.
+async function deleteGist(args: string[]): Promise<string> {
+  const positionals = args.filter((a) => !a.startsWith("--"));
+  const selector = positionals[1]; // positionals[0] == "delete"
+  const extra = positionals[2];
+
+  if (!selector)
+    throw new AxiError(
+      "Gist is required: gh-axi gist delete <id|url>",
+      "VALIDATION_ERROR",
+    );
+  if (extra)
+    throw new AxiError(
+      `Unexpected argument: ${extra}`,
+      "VALIDATION_ERROR",
+    );
+
+  await ghExec(["gist", "delete", selector, "--yes"]);
+  const suggestions = getSuggestions({ domain: "gist", action: "delete" });
+  return renderOutput([
+    encode({ deleted: selector }),
+    renderHelp(suggestions),
+  ]);
+}
+
+// cloneGist has no ctx parameter — gist is user-scoped.
+// Mirrors cloneRepo exactly: take the selector, shell out, report ok.
+// No target-directory or git-flags passthrough — matches repo clone restraint.
+async function cloneGist(args: string[]): Promise<string> {
+  const positionals = args.filter((a) => !a.startsWith("--"));
+  const selector = positionals[1]; // positionals[0] == "clone"
+  const extra = positionals[2];
+
+  if (!selector)
+    throw new AxiError(
+      "Gist is required: gh-axi gist clone <id|url>",
+      "VALIDATION_ERROR",
+    );
+  if (extra)
+    throw new AxiError(
+      `Unexpected argument: ${extra}`,
+      "VALIDATION_ERROR",
+    );
+
+  await ghExec(["gist", "clone", selector]);
+  const suggestions = getSuggestions({ domain: "gist", action: "clone" });
+  return renderOutput([
+    encode({ clone: "ok", gist: selector }),
+    renderHelp(suggestions),
+  ]);
+}
+
 // gistCommand has no ctx parameter — gist is user-scoped and ctx must never
 // reach ghJson. TypeScript accepts (args: string[]) as CommandFn because
 // fewer parameters are always assignable to a type with more optional params.
@@ -139,9 +196,13 @@ export async function gistCommand(args: string[]): Promise<string> {
   switch (sub) {
     case "list":
       return listGists(args);
+    case "delete":
+      return deleteGist(args);
+    case "clone":
+      return cloneGist(args);
     default:
       return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [
-        "Available subcommands: list",
+        "Available subcommands: list, delete, clone",
       ]);
   }
 }

--- a/src/commands/gist.ts
+++ b/src/commands/gist.ts
@@ -104,16 +104,25 @@ interface GistDetail {
 // Shared guards
 // ---------------------------------------------------------------------------
 
+/** A token's flag name, ignoring any `=value` suffix. */
+function flagName(token: string): string {
+  return token.split("=")[0];
+}
+
 /**
- * Reject every leftover token that looks like a flag but is not on the known
+ * Reject every leftover token that looks like a flag but is not on the allowed
  * list. Callers must consume their value flags first, so anything remaining is
- * either a known boolean flag or a typo that would otherwise silently degrade
+ * either an allowed bare token or a typo that would otherwise silently degrade
  * the result at exit 0 (`--ful` ignored, `--dry-run` ignored before a delete).
  * Single-dash tokens count too: gh shorthands must never reach a positional slot.
+ *
+ * Matching is exact, never normalized across `=`. Allowed tokens are read back
+ * with hasFlag/includes, which only see the bare form — so `--full=true` must
+ * be rejected here rather than accepted and then silently ignored.
  */
-function rejectUnknownFlags(tokens: string[], known: readonly string[]): void {
+function rejectUnknownFlags(tokens: string[], allowed: readonly string[]): void {
   const unknown = tokens.filter(
-    (a) => a.startsWith("-") && !known.includes(a.split("=")[0]),
+    (a) => a.startsWith("-") && !allowed.includes(a),
   );
   if (unknown.length > 0) {
     throw new AxiError(
@@ -219,7 +228,7 @@ function makeFileSchema(full: boolean): FieldDef[] {
 // viewGist deliberately has no ctx parameter — gist is user-scoped.
 async function viewGist(args: string[]): Promise<string> {
   // Reject -w/--web up-front before consuming any other args (AXI P6).
-  if (hasFlag(args, "-w") || hasFlag(args, "--web")) {
+  if (args.some((a) => flagName(a) === "-w" || flagName(a) === "--web")) {
     throw new AxiError(
       "-w/--web is not supported: opening a browser is a no-op in agent contexts",
       "VALIDATION_ERROR",
@@ -586,6 +595,23 @@ async function editGist(args: string[]): Promise<string> {
   const addFlag = takeFlag(rest, "--add") ?? takeFlag(rest, "-a");
   const removeFlag = takeFlag(rest, "--remove") ?? takeFlag(rest, "-r");
   const descFlag = takeFlag(rest, "--desc") ?? takeFlag(rest, "-d");
+
+  // Every value flag is consumed above. Anything flag-shaped that survives is a
+  // typo which the positional filter below would otherwise drop silently —
+  // `--remove old.txt --dry-run` must not quietly remove the file. The lone "-"
+  // stdin sentinel is a positional, and each alias stays allowed so a duplicate
+  // pair (`--remove x -r y`) still falls through to the surplus-positional error.
+  rejectUnknownFlags(rest, [
+    "-",
+    "--filename",
+    "-f",
+    "--add",
+    "-a",
+    "--remove",
+    "-r",
+    "--desc",
+    "-d",
+  ]);
 
   // A lone "-" is the explicit "read content from stdin" sentinel (gh's own
   // convention). It is the ONLY stdin signal — never inferred from TTY-ness,

--- a/src/gistSelector.ts
+++ b/src/gistSelector.ts
@@ -1,0 +1,69 @@
+import { AxiError } from "./errors.js";
+import { resolveHost } from "./host.js";
+
+/**
+ * Convert a bare gist id or a gist URL to a bare id.
+ *
+ * Accepts three URL shapes:
+ *   gist.github.com/OWNER/ID       (owner-scoped)
+ *   gist.github.com/ID             (ownerless)
+ *   ghe.example.com/gist/OWNER/ID  (GHE — last segment is always the id)
+ *
+ * Takes the **last non-empty path segment** across all shapes. gh's own
+ * GistIDFromURL takes path segment index 2, which returns OWNER for the GHE
+ * shape — that is wrong. Last-segment handles all three correctly.
+ *
+ * The URL's host is validated against the configured host (GH_HOST > github.com).
+ * Both `<host>` and `gist.<host>` are accepted as valid origins.
+ */
+export function gistIdFromSelector(selector: string): string {
+  const trimmed = selector.trim();
+
+  if (!trimmed) {
+    throw new AxiError(
+      "Gist selector must not be empty",
+      "VALIDATION_ERROR",
+    );
+  }
+
+  if (/\s/.test(trimmed)) {
+    throw new AxiError(
+      `Gist selector must not contain whitespace: "${selector.trim()}"`,
+      "VALIDATION_ERROR",
+    );
+  }
+
+  if (trimmed.startsWith("https://") || trimmed.startsWith("http://")) {
+    return extractIdFromUrl(trimmed);
+  }
+
+  // Bare id — return as-is.
+  return trimmed;
+}
+
+function extractIdFromUrl(rawUrl: string): string {
+  const url = new URL(rawUrl);
+  const hostname = url.hostname;
+
+  // Accept <configured> or gist.<configured>.
+  const configured = resolveHost();
+  const validHosts = new Set([configured, `gist.${configured}`]);
+  if (!validHosts.has(hostname)) {
+    throw new AxiError(
+      `Gist URL host "${hostname}" does not match the configured host "${configured}"`,
+      "VALIDATION_ERROR",
+    );
+  }
+
+  // Take the last non-empty path segment — correct for all URL shapes.
+  const segments = url.pathname.split("/").filter(Boolean);
+  const id = segments[segments.length - 1];
+  if (!id) {
+    throw new AxiError(
+      `Could not extract a gist id from URL: ${rawUrl}`,
+      "VALIDATION_ERROR",
+    );
+  }
+
+  return id;
+}

--- a/src/gistSelector.ts
+++ b/src/gistSelector.ts
@@ -20,10 +20,7 @@ export function gistIdFromSelector(selector: string): string {
   const trimmed = selector.trim();
 
   if (!trimmed) {
-    throw new AxiError(
-      "Gist selector must not be empty",
-      "VALIDATION_ERROR",
-    );
+    throw new AxiError("Gist selector must not be empty", "VALIDATION_ERROR");
   }
 
   if (/\s/.test(trimmed)) {
@@ -46,11 +43,9 @@ export function gistIdFromSelector(selector: string): string {
 // that could alter the API path it gets interpolated into.
 function validateBareId(id: string): string {
   if (!/^[A-Za-z0-9]+$/.test(id)) {
-    throw new AxiError(
-      `Invalid gist id: "${id}"`,
-      "VALIDATION_ERROR",
-      ["A gist id is alphanumeric; pass a bare id or a full gist URL"],
-    );
+    throw new AxiError(`Invalid gist id: "${id}"`, "VALIDATION_ERROR", [
+      "A gist id is alphanumeric; pass a bare id or a full gist URL",
+    ]);
   }
   return id;
 }
@@ -60,10 +55,7 @@ function extractIdFromUrl(rawUrl: string): string {
   try {
     url = new URL(rawUrl);
   } catch {
-    throw new AxiError(
-      `Malformed gist URL: ${rawUrl}`,
-      "VALIDATION_ERROR",
-    );
+    throw new AxiError(`Malformed gist URL: ${rawUrl}`, "VALIDATION_ERROR");
   }
   const hostname = url.hostname;
 

--- a/src/gistSelector.ts
+++ b/src/gistSelector.ts
@@ -37,12 +37,34 @@ export function gistIdFromSelector(selector: string): string {
     return extractIdFromUrl(trimmed);
   }
 
-  // Bare id — return as-is.
-  return trimmed;
+  // Bare id — validate its charset before it is interpolated into the
+  // `/gists/<id>` API path, so a malformed selector can never traverse the path.
+  return validateBareId(trimmed);
+}
+
+// A gist id is alphanumeric. Reject anything else (slashes, dot-segments, etc.)
+// that could alter the API path it gets interpolated into.
+function validateBareId(id: string): string {
+  if (!/^[A-Za-z0-9]+$/.test(id)) {
+    throw new AxiError(
+      `Invalid gist id: "${id}"`,
+      "VALIDATION_ERROR",
+      ["A gist id is alphanumeric; pass a bare id or a full gist URL"],
+    );
+  }
+  return id;
 }
 
 function extractIdFromUrl(rawUrl: string): string {
-  const url = new URL(rawUrl);
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new AxiError(
+      `Malformed gist URL: ${rawUrl}`,
+      "VALIDATION_ERROR",
+    );
+  }
   const hostname = url.hostname;
 
   // Accept <configured> or gist.<configured>.
@@ -65,5 +87,7 @@ function extractIdFromUrl(rawUrl: string): string {
     );
   }
 
-  return id;
+  // The extracted segment also lands in the `/gists/<id>` API path, so hold it
+  // to the same charset as a bare id (blocks `..`, encoded slashes, etc.).
+  return validateBareId(id);
 }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -6,7 +6,7 @@ export const SKILL_DESCRIPTION =
   "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, " +
   "releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. " +
   "Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, " +
-  "checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or listing gists via `gist list`.";
+  "checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist delete`, or `gist clone`.";
 
 export const SKILL_AUTHOR = "Kun Chen (kunchenguid)";
 
@@ -71,7 +71,7 @@ For GitHub Enterprise or another custom host, the underlying \`gh\` CLI must be 
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing gists; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, deleting, or cloning gists; or calling the GitHub API directly.
 
 ## Workflow
 
@@ -110,7 +110,7 @@ Run \`npx -y gh-axi --help\` for global flags, or \`npx -y gh-axi <command> --he
 - For multi-line variable values, pipe stdin to \`npx -y gh-axi variable set <name>\`; \`--body\`/\`-b\` is for inline values only.
 - Projects (v2) are owner-scoped: pass \`--owner <login>\`, or omit it to use the current repo owner and then \`@me\`.
 - Projects calls need the \`project\` or \`read:project\` OAuth scope; if scope errors occur, ask the user to run the \`gh auth refresh -s ...\` command shown by gh-axi.
-- Use \`gist list\` to list your GitHub Gists; filter by visibility with \`--public\` or \`--secret\`, and add extra fields with \`--fields url,owner,created\`.
+- Use \`gist list\` to list your GitHub Gists; filter by visibility with \`--public\` or \`--secret\`, and add extra fields with \`--fields url,owner,created\`. Use \`gist delete <id|url>\` to delete a gist (always confirmed non-interactively). Use \`gist clone <id|url>\` to clone a gist locally.
 - Use \`api\` for anything the dedicated commands do not cover, e.g. \`npx -y gh-axi api repos/{owner}/{repo}/topics\`.
 `;
 }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -6,7 +6,7 @@ export const SKILL_DESCRIPTION =
   "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, " +
   "releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. " +
   "Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, " +
-  "checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist view`, `gist create`, `gist delete`, or `gist clone`.";
+  "checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist view`, `gist edit`, `gist rename`, `gist create`, `gist delete`, or `gist clone`.";
 
 export const SKILL_AUTHOR = "Kun Chen (kunchenguid)";
 
@@ -71,7 +71,7 @@ For GitHub Enterprise or another custom host, the underlying \`gh\` CLI must be 
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, creating, deleting, or cloning gists; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, editing, renaming, creating, deleting, or cloning gists; or calling the GitHub API directly.
 
 ## Workflow
 
@@ -111,6 +111,8 @@ Run \`npx -y gh-axi --help\` for global flags, or \`npx -y gh-axi <command> --he
 - Projects (v2) are owner-scoped: pass \`--owner <login>\`, or omit it to use the current repo owner and then \`@me\`.
 - Projects calls need the \`project\` or \`read:project\` OAuth scope; if scope errors occur, ask the user to run the \`gh auth refresh -s ...\` command shown by gh-axi.
 - Use \`gist list\` to list your GitHub Gists; filter by visibility with \`--public\` or \`--secret\`, and add extra fields with \`--fields url,owner,created\`. Use \`gist view <id|url>\` to fetch a gist's metadata and file content; pass \`--files\` for names only, \`-f/--filename <name>\` for a single file, or \`--full\` to disable truncation.
+- Use \`gist edit <id|url>\` to update a gist's files or description: pipe content via stdin with \`--filename <name>\` to replace or add a file, \`--add <path>\` to add from disk, \`--remove <name>\` to remove, and \`--desc <text>\` to update the description. \`gist edit\` never opens $EDITOR.
+- Use \`gist rename <id|url> <old> <new>\` to rename a file within a gist.
 - Use \`gist create\` to create a gist. Visibility is required: pass \`--public\` or \`--secret\` (omitting either, or passing both, is an error). Use positional paths (\`gist create a.py b.py\`) or repeatable \`--file\` flags; do not mix the two. Pipe content with \`--filename <name>\` for stdin input. A secret gist is unlisted — anyone with the URL can read it.
 - Use \`gist delete <id|url>\` to delete a gist (always confirmed non-interactively). Use \`gist clone <id|url>\` to clone a gist locally.
 - Use \`api\` for anything the dedicated commands do not cover, e.g. \`npx -y gh-axi api repos/{owner}/{repo}/topics\`.

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -4,9 +4,9 @@ import { DESCRIPTION, TOP_HELP } from "./cli.js";
 // Kept terse and outcome-focused so it fires on "needs GitHub" intents.
 export const SKILL_DESCRIPTION =
   "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, " +
-  "releases, repositories, labels, Projects (v2), Actions secrets and variables, search, and raw API access. " +
+  "releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. " +
   "Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, " +
-  "checking CI runs, triggering workflows, cutting releases, managing Projects boards, or managing Actions secrets/variables.";
+  "checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or listing gists via `gist list`.";
 
 export const SKILL_AUTHOR = "Kun Chen (kunchenguid)";
 
@@ -71,7 +71,7 @@ For GitHub Enterprise or another custom host, the underlying \`gh\` CLI must be 
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing gists; or calling the GitHub API directly.
 
 ## Workflow
 
@@ -110,6 +110,7 @@ Run \`npx -y gh-axi --help\` for global flags, or \`npx -y gh-axi <command> --he
 - For multi-line variable values, pipe stdin to \`npx -y gh-axi variable set <name>\`; \`--body\`/\`-b\` is for inline values only.
 - Projects (v2) are owner-scoped: pass \`--owner <login>\`, or omit it to use the current repo owner and then \`@me\`.
 - Projects calls need the \`project\` or \`read:project\` OAuth scope; if scope errors occur, ask the user to run the \`gh auth refresh -s ...\` command shown by gh-axi.
+- Use \`gist list\` to list your GitHub Gists; filter by visibility with \`--public\` or \`--secret\`, and add extra fields with \`--fields url,owner,created\`.
 - Use \`api\` for anything the dedicated commands do not cover, e.g. \`npx -y gh-axi api repos/{owner}/{repo}/topics\`.
 `;
 }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -6,7 +6,7 @@ export const SKILL_DESCRIPTION =
   "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, " +
   "releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. " +
   "Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, " +
-  "checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist delete`, or `gist clone`.";
+  "checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist create`, `gist delete`, or `gist clone`.";
 
 export const SKILL_AUTHOR = "Kun Chen (kunchenguid)";
 
@@ -110,7 +110,9 @@ Run \`npx -y gh-axi --help\` for global flags, or \`npx -y gh-axi <command> --he
 - For multi-line variable values, pipe stdin to \`npx -y gh-axi variable set <name>\`; \`--body\`/\`-b\` is for inline values only.
 - Projects (v2) are owner-scoped: pass \`--owner <login>\`, or omit it to use the current repo owner and then \`@me\`.
 - Projects calls need the \`project\` or \`read:project\` OAuth scope; if scope errors occur, ask the user to run the \`gh auth refresh -s ...\` command shown by gh-axi.
-- Use \`gist list\` to list your GitHub Gists; filter by visibility with \`--public\` or \`--secret\`, and add extra fields with \`--fields url,owner,created\`. Use \`gist delete <id|url>\` to delete a gist (always confirmed non-interactively). Use \`gist clone <id|url>\` to clone a gist locally.
+- Use \`gist list\` to list your GitHub Gists; filter by visibility with \`--public\` or \`--secret\`, and add extra fields with \`--fields url,owner,created\`.
+- Use \`gist create\` to create a gist. Visibility is required: pass \`--public\` or \`--secret\` (omitting either, or passing both, is an error). Use positional paths (\`gist create a.py b.py\`) or repeatable \`--file\` flags; do not mix the two. Pipe content with \`--filename <name>\` for stdin input. A secret gist is unlisted — anyone with the URL can read it.
+- Use \`gist delete <id|url>\` to delete a gist (always confirmed non-interactively). Use \`gist clone <id|url>\` to clone a gist locally.
 - Use \`api\` for anything the dedicated commands do not cover, e.g. \`npx -y gh-axi api repos/{owner}/{repo}/topics\`.
 `;
 }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -6,7 +6,7 @@ export const SKILL_DESCRIPTION =
   "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, " +
   "releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. " +
   "Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, " +
-  "checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist create`, `gist delete`, or `gist clone`.";
+  "checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist view`, `gist create`, `gist delete`, or `gist clone`.";
 
 export const SKILL_AUTHOR = "Kun Chen (kunchenguid)";
 
@@ -71,7 +71,7 @@ For GitHub Enterprise or another custom host, the underlying \`gh\` CLI must be 
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, deleting, or cloning gists; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, creating, deleting, or cloning gists; or calling the GitHub API directly.
 
 ## Workflow
 
@@ -110,7 +110,7 @@ Run \`npx -y gh-axi --help\` for global flags, or \`npx -y gh-axi <command> --he
 - For multi-line variable values, pipe stdin to \`npx -y gh-axi variable set <name>\`; \`--body\`/\`-b\` is for inline values only.
 - Projects (v2) are owner-scoped: pass \`--owner <login>\`, or omit it to use the current repo owner and then \`@me\`.
 - Projects calls need the \`project\` or \`read:project\` OAuth scope; if scope errors occur, ask the user to run the \`gh auth refresh -s ...\` command shown by gh-axi.
-- Use \`gist list\` to list your GitHub Gists; filter by visibility with \`--public\` or \`--secret\`, and add extra fields with \`--fields url,owner,created\`.
+- Use \`gist list\` to list your GitHub Gists; filter by visibility with \`--public\` or \`--secret\`, and add extra fields with \`--fields url,owner,created\`. Use \`gist view <id|url>\` to fetch a gist's metadata and file content; pass \`--files\` for names only, \`-f/--filename <name>\` for a single file, or \`--full\` to disable truncation.
 - Use \`gist create\` to create a gist. Visibility is required: pass \`--public\` or \`--secret\` (omitting either, or passing both, is an error). Use positional paths (\`gist create a.py b.py\`) or repeatable \`--file\` flags; do not mix the two. Pipe content with \`--filename <name>\` for stdin input. A secret gist is unlisted — anyone with the URL can read it.
 - Use \`gist delete <id|url>\` to delete a gist (always confirmed non-interactively). Use \`gist clone <id|url>\` to clone a gist locally.
 - Use \`api\` for anything the dedicated commands do not cover, e.g. \`npx -y gh-axi api repos/{owner}/{repo}/topics\`.

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -680,6 +680,24 @@ const table: SuggestionEntry[] = [
     ],
   },
 
+  // Gist edit
+  {
+    match: (c) => c.domain === "gist" && c.action === "edit",
+    lines: (c) => [
+      `Run \`gh-axi gist list\` to see all gists`,
+      `Run \`gh-axi gist rename ${c.id} <old> <new>\` to rename a file`,
+    ],
+  },
+
+  // Gist rename
+  {
+    match: (c) => c.domain === "gist" && c.action === "rename",
+    lines: (c) => [
+      `Run \`gh-axi gist list\` to see all gists`,
+      `Run \`gh-axi gist edit ${c.id} --filename <name>\` to edit file content`,
+    ],
+  },
+
   // Gist create
   {
     match: (c) => c.domain === "gist" && c.action === "create",

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -666,9 +666,7 @@ const table: SuggestionEntry[] = [
   {
     match: (c) =>
       c.domain === "gist" && c.action === "list" && c.isEmpty === true,
-    lines: () => [
-      "Run `gh-axi api /gists` to see gist data via the raw API",
-    ],
+    lines: () => ["Run `gh-axi api /gists` to see gist data via the raw API"],
   },
 
   // Gist view
@@ -701,9 +699,7 @@ const table: SuggestionEntry[] = [
   // Gist create
   {
     match: (c) => c.domain === "gist" && c.action === "create",
-    lines: () => [
-      "Run `gh-axi gist list` to see all your gists",
-    ],
+    lines: () => ["Run `gh-axi gist list` to see all your gists"],
   },
 
   // Gist delete
@@ -717,7 +713,6 @@ const table: SuggestionEntry[] = [
     match: (c) => c.domain === "gist" && c.action === "clone",
     lines: () => ["Run `gh-axi gist list` to see your gists"],
   },
-
 
   // Search
   {

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -671,6 +671,18 @@ const table: SuggestionEntry[] = [
     ],
   },
 
+  // Gist delete
+  {
+    match: (c) => c.domain === "gist" && c.action === "delete",
+    lines: () => ["Run `gh-axi gist list` to see remaining gists"],
+  },
+
+  // Gist clone
+  {
+    match: (c) => c.domain === "gist" && c.action === "clone",
+    lines: () => ["Run `gh-axi gist list` to see your gists"],
+  },
+
   // Search
   {
     match: (c) => c.domain === "search",

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -655,6 +655,22 @@ const table: SuggestionEntry[] = [
     ],
   },
 
+  // Gist list
+  {
+    match: (c) => c.domain === "gist" && c.action === "list" && !c.isEmpty,
+    lines: () => [
+      "Run `gh-axi api /gists/<id>` to view a gist's files and metadata",
+      "Run `gh-axi gist list --fields url,owner,created` to add extra fields",
+    ],
+  },
+  {
+    match: (c) =>
+      c.domain === "gist" && c.action === "list" && c.isEmpty === true,
+    lines: () => [
+      "Run `gh-axi api /gists` to see gist data via the raw API",
+    ],
+  },
+
   // Search
   {
     match: (c) => c.domain === "search",

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -659,7 +659,7 @@ const table: SuggestionEntry[] = [
   {
     match: (c) => c.domain === "gist" && c.action === "list" && !c.isEmpty,
     lines: () => [
-      "Run `gh-axi api /gists/<id>` to view a gist's files and metadata",
+      "Run `gh-axi gist view <id>` to view a gist's files and metadata",
       "Run `gh-axi gist list --fields url,owner,created` to add extra fields",
     ],
   },
@@ -668,6 +668,15 @@ const table: SuggestionEntry[] = [
       c.domain === "gist" && c.action === "list" && c.isEmpty === true,
     lines: () => [
       "Run `gh-axi api /gists` to see gist data via the raw API",
+    ],
+  },
+
+  // Gist view
+  {
+    match: (c) => c.domain === "gist" && c.action === "view",
+    lines: (c) => [
+      `Run \`gh-axi gist view ${String(c.id)} --files\` to list file names only`,
+      `Run \`gh-axi gist list\` to see all your gists`,
     ],
   },
 
@@ -690,6 +699,7 @@ const table: SuggestionEntry[] = [
     match: (c) => c.domain === "gist" && c.action === "clone",
     lines: () => ["Run `gh-axi gist list` to see your gists"],
   },
+
 
   // Search
   {

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -671,6 +671,14 @@ const table: SuggestionEntry[] = [
     ],
   },
 
+  // Gist create
+  {
+    match: (c) => c.domain === "gist" && c.action === "create",
+    lines: () => [
+      "Run `gh-axi gist list` to see all your gists",
+    ],
+  },
+
   // Gist delete
   {
     match: (c) => c.domain === "gist" && c.action === "delete",

--- a/test/commands/gist.test.ts
+++ b/test/commands/gist.test.ts
@@ -25,7 +25,9 @@ const mockedReadStdin = vi.mocked(readStdin);
 
 const GIST_ID = "5b0e0062eb8e9654adad7bb1d81cc75f";
 
-function gist(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+function gist(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     id: GIST_ID,
     description: "a gist",
@@ -41,7 +43,9 @@ function gist(overrides: Record<string, unknown> = {}): Record<string, unknown> 
 }
 
 /** A gist detail fixture for view tests (includes file content). */
-function gistDetail(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+function gistDetail(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     id: GIST_ID,
     description: "a detail gist",
@@ -137,7 +141,7 @@ describe("gistCommand", () => {
         "gist",
         "edit",
         "abc123",
-        "-",           // source positional — must be present and before --filename
+        "-", // source positional — must be present and before --filename
         "--filename",
         "notes.md",
       ]);
@@ -175,7 +179,7 @@ describe("gistCommand", () => {
         "abc123",
         "--add",
         "brand-new.txt",
-        "-",           // content source: stdin
+        "-", // content source: stdin
       ]);
       expect(capturedContent).toBe("brand new content");
     });
@@ -311,7 +315,14 @@ describe("gistCommand", () => {
     });
 
     it("add-from-disk+desc: includes both flags in argv to ghExec", async () => {
-      await gistCommand(["edit", "abc123", "--add", "/tmp/f.txt", "--desc", "d"]);
+      await gistCommand([
+        "edit",
+        "abc123",
+        "--add",
+        "/tmp/f.txt",
+        "--desc",
+        "d",
+      ]);
 
       const [capturedArgs] = mockedGhExec.mock.calls[0];
       expect(capturedArgs).toContain("--add");
@@ -354,9 +365,9 @@ describe("gistCommand", () => {
       mockedIsStdinTTY.mockReturnValue(false);
       // A bare stdin sentinel with no file selector: gh would prompt which file
       // to write, so we reject up-front.
-      await expect(
-        gistCommand(["edit", "abc123", "-"]),
-      ).rejects.toThrow(/--filename|--add/);
+      await expect(gistCommand(["edit", "abc123", "-"])).rejects.toThrow(
+        /--filename|--add/,
+      );
       expect(mockedGhExec).not.toHaveBeenCalled();
       expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
     });
@@ -524,12 +535,22 @@ describe("gistCommand", () => {
     });
 
     it("ends with contextual help suggestions", async () => {
-      const result = await gistCommand(["edit", "abc123", "--remove", "old.txt"]);
+      const result = await gistCommand([
+        "edit",
+        "abc123",
+        "--remove",
+        "old.txt",
+      ]);
       expect(result).toContain("help[");
     });
 
     it("suggestions reference gist list and gist rename", async () => {
-      const result = await gistCommand(["edit", "abc123", "--remove", "old.txt"]);
+      const result = await gistCommand([
+        "edit",
+        "abc123",
+        "--remove",
+        "old.txt",
+      ]);
       expect(result).toContain("gist list");
       expect(result).toContain("gist rename");
     });
@@ -764,9 +785,9 @@ describe("gistCommand", () => {
 
     it("rejects unknown --fields values", async () => {
       mockedGhJson.mockResolvedValue([gist()]);
-      await expect(
-        gistCommand(["list", "--fields", "nope"]),
-      ).rejects.toThrow(AxiError);
+      await expect(gistCommand(["list", "--fields", "nope"])).rejects.toThrow(
+        AxiError,
+      );
     });
 
     it("ends with contextual help suggestions", async () => {
@@ -817,46 +838,46 @@ describe("gistCommand", () => {
 
     it("rejects a non-numeric --limit", async () => {
       mockedGhJson.mockResolvedValue([]);
-      await expect(
-        gistCommand(["list", "--limit", "abc"]),
-      ).rejects.toThrow(AxiError);
+      await expect(gistCommand(["list", "--limit", "abc"])).rejects.toThrow(
+        AxiError,
+      );
     });
 
     it("rejects --limit 0", async () => {
       mockedGhJson.mockResolvedValue([]);
-      await expect(
-        gistCommand(["list", "--limit", "0"]),
-      ).rejects.toThrow(AxiError);
+      await expect(gistCommand(["list", "--limit", "0"])).rejects.toThrow(
+        AxiError,
+      );
     });
 
     it("rejects a negative --limit", async () => {
       mockedGhJson.mockResolvedValue([]);
-      await expect(
-        gistCommand(["list", "--limit", "-5"]),
-      ).rejects.toThrow(AxiError);
+      await expect(gistCommand(["list", "--limit", "-5"])).rejects.toThrow(
+        AxiError,
+      );
     });
 
     // A typo must fail loudly, not silently return the default 100 rows.
     it("rejects an unknown flag instead of silently ignoring it", async () => {
       mockedGhJson.mockResolvedValue([]);
-      await expect(
-        gistCommand(["list", "--limitt", "5"]),
-      ).rejects.toThrow(AxiError);
+      await expect(gistCommand(["list", "--limitt", "5"])).rejects.toThrow(
+        AxiError,
+      );
       expect(mockedGhJson).not.toHaveBeenCalled();
     });
 
     it("names the unknown flag in the error", async () => {
       mockedGhJson.mockResolvedValue([]);
-      await expect(
-        gistCommand(["list", "--limitt", "5"]),
-      ).rejects.toThrow(/--limitt/);
+      await expect(gistCommand(["list", "--limitt", "5"])).rejects.toThrow(
+        /--limitt/,
+      );
     });
 
     it("rejects an unknown flag in --flag=value form", async () => {
       mockedGhJson.mockResolvedValue([]);
-      await expect(
-        gistCommand(["list", "--fieldz=url"]),
-      ).rejects.toThrow(AxiError);
+      await expect(gistCommand(["list", "--fieldz=url"])).rejects.toThrow(
+        AxiError,
+      );
     });
 
     it("still accepts --fields in --flag=value form", async () => {
@@ -869,7 +890,10 @@ describe("gistCommand", () => {
   describe("delete", () => {
     it("deletes the gist and reports what was deleted", async () => {
       mockedGhExec.mockResolvedValue("");
-      const result = await gistCommand(["delete", "abc1230000000000000000000000000a"]);
+      const result = await gistCommand([
+        "delete",
+        "abc1230000000000000000000000000a",
+      ]);
       expect(result).toContain("abc1230000000000000000000000000a");
     });
 
@@ -905,7 +929,8 @@ describe("gistCommand", () => {
 
     it("accepts a gist URL as the selector", async () => {
       mockedGhExec.mockResolvedValue("");
-      const url = "https://gist.github.com/octocat/abc1230000000000000000000000000a";
+      const url =
+        "https://gist.github.com/octocat/abc1230000000000000000000000000a";
       const result = await gistCommand(["delete", url]);
       expect(result).toContain(url);
       const capturedArgs = mockedGhExec.mock.calls[0]![0] as string[];
@@ -915,7 +940,10 @@ describe("gistCommand", () => {
 
     it("emits contextual help suggestions", async () => {
       mockedGhExec.mockResolvedValue("");
-      const result = await gistCommand(["delete", "abc1230000000000000000000000000a"]);
+      const result = await gistCommand([
+        "delete",
+        "abc1230000000000000000000000000a",
+      ]);
       expect(result).toContain("help[");
       expect(result).toContain("gist list");
     });
@@ -931,7 +959,11 @@ describe("gistCommand", () => {
     it("rejects an unknown flag and never reaches gh", async () => {
       mockedGhExec.mockResolvedValue("");
       await expect(
-        gistCommand(["delete", "--dry-run", "abc1230000000000000000000000000a"]),
+        gistCommand([
+          "delete",
+          "--dry-run",
+          "abc1230000000000000000000000000a",
+        ]),
       ).rejects.toThrow(AxiError);
       expect(mockedGhExec).not.toHaveBeenCalled();
     });
@@ -939,7 +971,11 @@ describe("gistCommand", () => {
     it("names the unknown flag in the error", async () => {
       mockedGhExec.mockResolvedValue("");
       await expect(
-        gistCommand(["delete", "--dry-run", "abc1230000000000000000000000000a"]),
+        gistCommand([
+          "delete",
+          "--dry-run",
+          "abc1230000000000000000000000000a",
+        ]),
       ).rejects.toThrow(/--dry-run/);
     });
 
@@ -955,7 +991,10 @@ describe("gistCommand", () => {
   describe("clone", () => {
     it("clones the gist and reports ok", async () => {
       mockedGhExec.mockResolvedValue("");
-      const result = await gistCommand(["clone", "abc1230000000000000000000000000a"]);
+      const result = await gistCommand([
+        "clone",
+        "abc1230000000000000000000000000a",
+      ]);
       expect(result).toContain("ok");
     });
 
@@ -981,7 +1020,8 @@ describe("gistCommand", () => {
 
     it("accepts a gist URL as the selector", async () => {
       mockedGhExec.mockResolvedValue("");
-      const url = "https://gist.github.com/octocat/abc1230000000000000000000000000a";
+      const url =
+        "https://gist.github.com/octocat/abc1230000000000000000000000000a";
       const result = await gistCommand(["clone", url]);
       expect(result).toContain("ok");
       const capturedArgs = mockedGhExec.mock.calls[0]![0] as string[];
@@ -990,7 +1030,10 @@ describe("gistCommand", () => {
 
     it("emits contextual help suggestions", async () => {
       mockedGhExec.mockResolvedValue("");
-      const result = await gistCommand(["clone", "abc1230000000000000000000000000a"]);
+      const result = await gistCommand([
+        "clone",
+        "abc1230000000000000000000000000a",
+      ]);
       expect(result).toContain("help[");
       expect(result).toContain("gist list");
     });
@@ -1030,9 +1073,7 @@ describe("gistCommand", () => {
     // ── Visibility validation ───────────────────────────────────────────────
 
     it("rejects when neither --public nor --secret is given", async () => {
-      await expect(
-        gistCommand(["create", "a.py"]),
-      ).rejects.toThrow(AxiError);
+      await expect(gistCommand(["create", "a.py"])).rejects.toThrow(AxiError);
     });
 
     it("rejects when both --public and --secret are given", async () => {
@@ -1337,10 +1378,7 @@ describe("gistCommand", () => {
 
     it("accepts a gist.github.com URL as selector", async () => {
       mockedGhJson.mockResolvedValue(gistDetail());
-      await gistCommand([
-        "view",
-        `https://gist.github.com/octocat/${GIST_ID}`,
-      ]);
+      await gistCommand(["view", `https://gist.github.com/octocat/${GIST_ID}`]);
       const captured = mockedGhJson.mock.calls[0][0] as string[];
       expect(captured[1]).toBe(`/gists/${GIST_ID}`);
     });
@@ -1426,7 +1464,11 @@ describe("gistCommand", () => {
       mockedGhJson.mockResolvedValue(
         gistDetail({
           files: {
-            "big.txt": { filename: "big.txt", size: 2000, content: longContent },
+            "big.txt": {
+              filename: "big.txt",
+              size: 2000,
+              content: longContent,
+            },
           },
         }),
       );
@@ -1440,8 +1482,16 @@ describe("gistCommand", () => {
       mockedGhJson.mockResolvedValue(
         gistDetail({
           files: {
-            "ring.erl": { filename: "ring.erl", size: 42, content: "module code" },
-            "readme.md": { filename: "readme.md", size: 10, content: "# Readme" },
+            "ring.erl": {
+              filename: "ring.erl",
+              size: 42,
+              content: "module code",
+            },
+            "readme.md": {
+              filename: "readme.md",
+              size: 10,
+              content: "# Readme",
+            },
           },
         }),
       );
@@ -1456,12 +1506,25 @@ describe("gistCommand", () => {
       mockedGhJson.mockResolvedValue(
         gistDetail({
           files: {
-            "ring.erl": { filename: "ring.erl", size: 42, content: "module code" },
-            "readme.md": { filename: "readme.md", size: 10, content: "# Readme" },
+            "ring.erl": {
+              filename: "ring.erl",
+              size: 42,
+              content: "module code",
+            },
+            "readme.md": {
+              filename: "readme.md",
+              size: 10,
+              content: "# Readme",
+            },
           },
         }),
       );
-      const result = await gistCommand(["view", GIST_ID, "--filename", "ring.erl"]);
+      const result = await gistCommand([
+        "view",
+        GIST_ID,
+        "--filename",
+        "ring.erl",
+      ]);
       expect(result).toContain("ring.erl");
       expect(result).toContain("module code");
       expect(result).not.toContain("readme.md");
@@ -1492,15 +1555,15 @@ describe("gistCommand", () => {
     });
 
     it("-w/--web is rejected with VALIDATION_ERROR", async () => {
-      await expect(
-        gistCommand(["view", GIST_ID, "--web"]),
-      ).rejects.toThrow(AxiError);
+      await expect(gistCommand(["view", GIST_ID, "--web"])).rejects.toThrow(
+        AxiError,
+      );
     });
 
     it("-w short form is also rejected", async () => {
-      await expect(
-        gistCommand(["view", GIST_ID, "-w"]),
-      ).rejects.toThrow(AxiError);
+      await expect(gistCommand(["view", GIST_ID, "-w"])).rejects.toThrow(
+        AxiError,
+      );
     });
 
     it("emits contextual help suggestions", async () => {
@@ -1513,9 +1576,9 @@ describe("gistCommand", () => {
 
     it("rejects an unknown flag instead of silently degrading the result", async () => {
       mockedGhJson.mockResolvedValue(gistDetail());
-      await expect(
-        gistCommand(["view", GIST_ID, "--ful"]),
-      ).rejects.toThrow(/--ful/);
+      await expect(gistCommand(["view", GIST_ID, "--ful"])).rejects.toThrow(
+        /--ful/,
+      );
       expect(mockedGhJson).not.toHaveBeenCalled();
     });
 
@@ -1547,17 +1610,17 @@ describe("gistCommand", () => {
 
     it("rejects --files=1 rather than accepting and ignoring it", async () => {
       mockedGhJson.mockResolvedValue(gistDetail());
-      await expect(
-        gistCommand(["view", GIST_ID, "--files=1"]),
-      ).rejects.toThrow(/--files=1/);
+      await expect(gistCommand(["view", GIST_ID, "--files=1"])).rejects.toThrow(
+        /--files=1/,
+      );
       expect(mockedGhJson).not.toHaveBeenCalled();
     });
 
     it("rejects -r=x rather than accepting and ignoring it", async () => {
       mockedGhJson.mockResolvedValue(gistDetail());
-      await expect(
-        gistCommand(["view", GIST_ID, "-r=x"]),
-      ).rejects.toThrow(AxiError);
+      await expect(gistCommand(["view", GIST_ID, "-r=x"])).rejects.toThrow(
+        AxiError,
+      );
       expect(mockedGhJson).not.toHaveBeenCalled();
     });
 
@@ -1569,7 +1632,11 @@ describe("gistCommand", () => {
 
     it("still accepts -f/--filename in =value form", async () => {
       mockedGhJson.mockResolvedValue(gistDetail());
-      const result = await gistCommand(["view", GIST_ID, "--filename=ring.erl"]);
+      const result = await gistCommand([
+        "view",
+        GIST_ID,
+        "--filename=ring.erl",
+      ]);
       expect(result).toContain("ring.erl");
       expect(result).toContain("-module(ring)");
     });
@@ -1585,7 +1652,8 @@ describe("gistCommand", () => {
               size: 5_000_000,
               content: "partial bytes",
               truncated: true,
-              raw_url: "https://gist.githubusercontent.com/octocat/raw/huge.txt",
+              raw_url:
+                "https://gist.githubusercontent.com/octocat/raw/huge.txt",
             },
           },
         }),
@@ -1608,7 +1676,8 @@ describe("gistCommand", () => {
               size: 5_000_000,
               content: "partial bytes",
               truncated: true,
-              raw_url: "https://gist.githubusercontent.com/octocat/raw/huge.txt",
+              raw_url:
+                "https://gist.githubusercontent.com/octocat/raw/huge.txt",
             },
           },
         }),
@@ -1649,7 +1718,8 @@ describe("gistCommand", () => {
               size: 5_000_000,
               content: "partial bytes",
               truncated: true,
-              raw_url: "https://gist.githubusercontent.com/octocat/raw/huge.txt",
+              raw_url:
+                "https://gist.githubusercontent.com/octocat/raw/huge.txt",
             },
           },
         }),

--- a/test/commands/gist.test.ts
+++ b/test/commands/gist.test.ts
@@ -1,0 +1,231 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("../../src/gh.js", () => ({
+  ghJson: vi.fn(),
+  ghExec: vi.fn(),
+  ghRaw: vi.fn(),
+}));
+
+import { ghJson } from "../../src/gh.js";
+import { AxiError } from "../../src/errors.js";
+import { gistCommand, GIST_HELP } from "../../src/commands/gist.js";
+
+const mockedGhJson = vi.mocked(ghJson);
+
+function gist(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "5b0e0062eb8e9654adad7bb1d81cc75f",
+    description: "a gist",
+    public: false,
+    html_url:
+      "https://gist.github.com/octocat/5b0e0062eb8e9654adad7bb1d81cc75f",
+    comments: 0,
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-02T00:00:00Z",
+    owner: { login: "octocat" },
+    files: { "a.txt": { filename: "a.txt", size: 10 } },
+    ...overrides,
+  };
+}
+
+// Use hex-style IDs with no English-word substrings so toContain(id) cannot
+// collide with toContain("public") / toContain("secret") or similar text.
+const ID_ALPHA = "aaaa0000000000000000000000000000"; // used as the public gist
+const ID_BRAVO = "bbbb1111111111111111111111111111"; // used as the secret gist
+
+describe("gistCommand", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("router", () => {
+    it("returns help when --help is passed", async () => {
+      expect(await gistCommand(["--help"])).toBe(GIST_HELP);
+    });
+
+    it("returns help when no subcommand is given", async () => {
+      expect(await gistCommand([])).toBe(GIST_HELP);
+    });
+
+    it("returns a structured error for an unknown subcommand", async () => {
+      const result = await gistCommand(["frobnicate"]);
+      expect(result).toContain("Unknown subcommand: frobnicate");
+      expect(result).toContain("list");
+    });
+  });
+
+  describe("list", () => {
+    it("renders gists with a count line", async () => {
+      mockedGhJson.mockResolvedValue([gist(), gist({ id: "abc" })]);
+      const result = await gistCommand(["list"]);
+      expect(result).toContain("count:");
+      expect(result).toContain("5b0e0062eb8e9654adad7bb1d81cc75f");
+    });
+
+    it("uses exactly the four default fields", async () => {
+      mockedGhJson.mockResolvedValue([gist()]);
+      const result = await gistCommand(["list"]);
+      const header = result
+        .split("\n")
+        .find((l) => l.includes("gists[") && l.includes("{"));
+      expect(header).toBeDefined();
+      expect(header).toContain("{id,description,files,visibility}");
+    });
+
+    it("reports secret gists as secret and public as public", async () => {
+      mockedGhJson.mockResolvedValue([
+        gist({ public: false }),
+        gist({ id: "cc0000000000000000000000000000cc", public: true }),
+      ]);
+      const result = await gistCommand(["list"]);
+      expect(result).toContain("secret");
+      expect(result).toContain("public");
+    });
+
+    it("counts files per gist", async () => {
+      mockedGhJson.mockResolvedValue([
+        gist({ files: { "a.txt": {}, "b.txt": {}, "c.txt": {} } }),
+      ]);
+      const result = await gistCommand(["list"]);
+      expect(result).toMatch(/,3,/);
+    });
+
+    it("requests per_page=100 by default", async () => {
+      mockedGhJson.mockResolvedValue([]);
+      await gistCommand(["list"]);
+      const args = mockedGhJson.mock.calls[0][0] as string[];
+      expect(args[0]).toBe("api");
+      expect(args.join(" ")).toContain("per_page=100");
+    });
+
+    it("never passes repo context to gh — gist is user-scoped", async () => {
+      // gistCommand has no ctx parameter; the guard is structural (TypeScript
+      // accepts (args: string[]) as CommandFn). We verify the contract by
+      // confirming ghJson is called without a second argument regardless of
+      // whatever the withRepoContext wrapper in cli.ts might supply.
+      mockedGhJson.mockResolvedValue([]);
+      await gistCommand(["list"]);
+      expect(mockedGhJson.mock.calls[0][1]).toBeUndefined();
+    });
+
+    it("honours --limit below the page size", async () => {
+      mockedGhJson.mockResolvedValue([gist(), gist({ id: "b" })]);
+      const result = await gistCommand(["list", "--limit", "1"]);
+      expect(result).toContain("count: 1");
+    });
+
+    it("paginates when the limit exceeds one page", async () => {
+      mockedGhJson.mockResolvedValue([]);
+      await gistCommand(["list", "--limit", "250"]);
+      const args = mockedGhJson.mock.calls[0][0] as string[];
+      expect(args).toContain("--paginate");
+    });
+
+    it("filters to public gists with --public", async () => {
+      mockedGhJson.mockResolvedValue([
+        gist({ id: ID_BRAVO, public: false }),
+        gist({ id: ID_ALPHA, public: true }),
+      ]);
+      const result = await gistCommand(["list", "--public"]);
+      expect(result).toContain(ID_ALPHA);
+      expect(result).not.toContain(ID_BRAVO);
+    });
+
+    it("filters to secret gists with --secret", async () => {
+      mockedGhJson.mockResolvedValue([
+        gist({ id: ID_BRAVO, public: false }),
+        gist({ id: ID_ALPHA, public: true }),
+      ]);
+      const result = await gistCommand(["list", "--secret"]);
+      expect(result).toContain(ID_BRAVO);
+      expect(result).not.toContain(ID_ALPHA);
+    });
+
+    it("rejects --public and --secret together", async () => {
+      await expect(
+        gistCommand(["list", "--public", "--secret"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("gives a definitive empty state", async () => {
+      mockedGhJson.mockResolvedValue([]);
+      const result = await gistCommand(["list"]);
+      expect(result).toContain("count: 0");
+    });
+
+    it("adds requested extra fields with --fields", async () => {
+      mockedGhJson.mockResolvedValue([gist()]);
+      const result = await gistCommand(["list", "--fields", "url,owner"]);
+      const header = result
+        .split("\n")
+        .find((l) => l.includes("gists[") && l.includes("{"));
+      expect(header).toBeDefined();
+      expect(header).toContain("url");
+      expect(header).toContain("owner");
+    });
+
+    it("rejects unknown --fields values", async () => {
+      mockedGhJson.mockResolvedValue([gist()]);
+      await expect(
+        gistCommand(["list", "--fields", "nope"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("ends with contextual help suggestions", async () => {
+      mockedGhJson.mockResolvedValue([gist()]);
+      const result = await gistCommand(["list"]);
+      expect(result).toContain("help[");
+      expect(result).toContain("gh-axi api /gists/");
+    });
+
+    it("shows help suggestions when no gists exist", async () => {
+      mockedGhJson.mockResolvedValue([]);
+      const result = await gistCommand(["list"]);
+      expect(result).toContain("help[");
+    });
+
+    // Regression: --limit must cap *displayed rows after filtering*, not the
+    // fetch size. With 3 secret + 1 public gist and --public --limit 2:
+    //   - count must be 1 (the one public gist), not 0 (limit before filter)
+    //   - per_page must be 100 (full page), not 2 (limit used as fetch size)
+    //   - --paginate must be present (filtering always paginates)
+    // The per_page and --paginate assertions ensure the test bites when either
+    // the old perPage=Math.min(limit,PAGE_SIZE) or paginate=limit>PAGE_SIZE
+    // bug is reintroduced — the count assertion alone passes even with the bug
+    // if the mock returns fewer items than the buggy perPage.
+    it("applies --limit after the visibility filter and fetches a full page", async () => {
+      mockedGhJson.mockResolvedValue([
+        gist({ id: ID_BRAVO + "0", public: false }),
+        gist({ id: ID_BRAVO + "1", public: false }),
+        gist({ id: ID_BRAVO + "2", public: false }),
+        gist({ id: ID_ALPHA, public: true }),
+      ]);
+      const result = await gistCommand(["list", "--public", "--limit", "2"]);
+      expect(result).toContain("count: 1");
+      const capturedArgs = mockedGhJson.mock.calls[0][0] as string[];
+      expect(capturedArgs.join(" ")).toContain("per_page=100");
+      expect(capturedArgs).toContain("--paginate");
+    });
+
+    it("rejects a non-numeric --limit", async () => {
+      mockedGhJson.mockResolvedValue([]);
+      await expect(
+        gistCommand(["list", "--limit", "abc"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("rejects --limit 0", async () => {
+      mockedGhJson.mockResolvedValue([]);
+      await expect(
+        gistCommand(["list", "--limit", "0"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("rejects a negative --limit", async () => {
+      mockedGhJson.mockResolvedValue([]);
+      await expect(
+        gistCommand(["list", "--limit", "-5"]),
+      ).rejects.toThrow(AxiError);
+    });
+  });
+});

--- a/test/commands/gist.test.ts
+++ b/test/commands/gist.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
 vi.mock("../../src/gh.js", () => ({
   ghJson: vi.fn(),
@@ -23,18 +23,44 @@ const mockedGhExecWithStdin = vi.mocked(ghExecWithStdin);
 const mockedIsStdinTTY = vi.mocked(isStdinTTY);
 const mockedReadStdin = vi.mocked(readStdin);
 
+const GIST_ID = "5b0e0062eb8e9654adad7bb1d81cc75f";
+
 function gist(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
-    id: "5b0e0062eb8e9654adad7bb1d81cc75f",
+    id: GIST_ID,
     description: "a gist",
     public: false,
-    html_url:
-      "https://gist.github.com/octocat/5b0e0062eb8e9654adad7bb1d81cc75f",
+    html_url: `https://gist.github.com/octocat/${GIST_ID}`,
     comments: 0,
     created_at: "2026-07-01T00:00:00Z",
     updated_at: "2026-07-02T00:00:00Z",
     owner: { login: "octocat" },
     files: { "a.txt": { filename: "a.txt", size: 10 } },
+    ...overrides,
+  };
+}
+
+/** A gist detail fixture for view tests (includes file content). */
+function gistDetail(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: GIST_ID,
+    description: "a detail gist",
+    public: true,
+    html_url: `https://gist.github.com/octocat/${GIST_ID}`,
+    comments: 3,
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-02T00:00:00Z",
+    owner: { login: "octocat" },
+    files: {
+      "ring.erl": {
+        filename: "ring.erl",
+        type: "text/plain",
+        language: "Erlang",
+        size: 42,
+        content: "-module(ring).\n-export([start/2]).",
+        truncated: false,
+      },
+    },
     ...overrides,
   };
 }
@@ -60,6 +86,10 @@ describe("gistCommand", () => {
     mockedReadStdin.mockResolvedValue("file content");
   });
 
+  afterEach(() => {
+    delete process.env["GH_HOST"];
+  });
+
   describe("router", () => {
     it("returns help when --help is passed", async () => {
       expect(await gistCommand(["--help"])).toBe(GIST_HELP);
@@ -75,6 +105,11 @@ describe("gistCommand", () => {
       expect(result).toContain("list");
       expect(result).toContain("create");
     });
+
+    it("unknown subcommand error mentions view", async () => {
+      const result = await gistCommand(["frobnicate"]);
+      expect(result).toContain("view");
+    });
   });
 
   describe("list", () => {
@@ -82,7 +117,7 @@ describe("gistCommand", () => {
       mockedGhJson.mockResolvedValue([gist(), gist({ id: "abc" })]);
       const result = await gistCommand(["list"]);
       expect(result).toContain("count:");
-      expect(result).toContain("5b0e0062eb8e9654adad7bb1d81cc75f");
+      expect(result).toContain(GIST_ID);
     });
 
     it("uses exactly the four default fields", async () => {
@@ -103,6 +138,16 @@ describe("gistCommand", () => {
       const result = await gistCommand(["list"]);
       expect(result).toContain("secret");
       expect(result).toContain("public");
+    });
+
+    // Mutation closer #1: swapping visibility labels is not caught by the test
+    // above (it sees both strings regardless of which is which). This assertion
+    // pins the label for a single-public gist to "public", catching the swap.
+    it("labels a public-only gist as public, never secret", async () => {
+      mockedGhJson.mockResolvedValue([gist({ public: true })]);
+      const result = await gistCommand(["list"]);
+      expect(result).toContain("public");
+      expect(result).not.toContain("secret");
     });
 
     it("counts files per gist", async () => {
@@ -134,7 +179,8 @@ describe("gistCommand", () => {
     it("honours --limit below the page size", async () => {
       mockedGhJson.mockResolvedValue([gist(), gist({ id: "b" })]);
       const result = await gistCommand(["list", "--limit", "1"]);
-      expect(result).toContain("count: 1");
+      // Mutation closer #3: the truncation marker must appear when limit caps results.
+      expect(result).toContain("count: 1 (showing first 1)");
     });
 
     it("paginates when the limit exceeds one page", async () => {
@@ -198,13 +244,23 @@ describe("gistCommand", () => {
       mockedGhJson.mockResolvedValue([gist()]);
       const result = await gistCommand(["list"]);
       expect(result).toContain("help[");
-      expect(result).toContain("gh-axi api /gists/");
+      expect(result).toContain("gh-axi gist view");
     });
 
     it("shows help suggestions when no gists exist", async () => {
       mockedGhJson.mockResolvedValue([]);
       const result = await gistCommand(["list"]);
       expect(result).toContain("help[");
+    });
+
+    // Mutation closer #2: hardcoding isEmpty=false sends the non-empty suggestion
+    // (which mentions gist view) even when the list is empty; the empty-state
+    // suggestion mentions "gh-axi api /gists`" which is different. Pin it.
+    it("shows the empty-state suggestion text when no gists exist", async () => {
+      mockedGhJson.mockResolvedValue([]);
+      const result = await gistCommand(["list"]);
+      // The empty-state suggestion points at the raw /gists endpoint, not a specific id.
+      expect(result).toContain("gh-axi api /gists`");
     });
 
     // Regression: --limit must cap *displayed rows after filtering*, not the
@@ -625,6 +681,223 @@ describe("gistCommand", () => {
 
     it("ends with a help block", async () => {
       const result = await gistCommand(["create", "a.py", "--public"]);
+      expect(result).toContain("help[");
+    });
+  });
+
+  describe("view", () => {
+    it("requires a selector argument", async () => {
+      await expect(gistCommand(["view"])).rejects.toThrow(AxiError);
+    });
+
+    it("calls gh api /gists/<id> — pins the API endpoint construction", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      await gistCommand(["view", GIST_ID]);
+      const captured = mockedGhJson.mock.calls[0][0] as string[];
+      // Assert on captured argv so the test bites if the endpoint expression changes.
+      expect(captured[0]).toBe("api");
+      expect(captured[1]).toBe(`/gists/${GIST_ID}`);
+    });
+
+    it("never passes repo context to gh — gist view is user-scoped", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      await gistCommand(["view", GIST_ID]);
+      expect(mockedGhJson.mock.calls[0][1]).toBeUndefined();
+    });
+
+    it("returns gist metadata (id, description, visibility, owner)", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      const result = await gistCommand(["view", GIST_ID]);
+      expect(result).toContain(GIST_ID);
+      expect(result).toContain("a detail gist");
+      expect(result).toContain("public");
+      expect(result).toContain("octocat");
+    });
+
+    it("includes file content in the output", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      const result = await gistCommand(["view", GIST_ID]);
+      expect(result).toContain("ring.erl");
+      expect(result).toContain("-module(ring)");
+    });
+
+    it("includes the file size", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      const result = await gistCommand(["view", GIST_ID]);
+      expect(result).toContain("42");
+    });
+
+    it("accepts a gist.github.com URL as selector", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      await gistCommand([
+        "view",
+        `https://gist.github.com/octocat/${GIST_ID}`,
+      ]);
+      const captured = mockedGhJson.mock.calls[0][0] as string[];
+      expect(captured[1]).toBe(`/gists/${GIST_ID}`);
+    });
+
+    it("accepts an ownerless gist.github.com URL", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      await gistCommand(["view", `https://gist.github.com/${GIST_ID}`]);
+      const captured = mockedGhJson.mock.calls[0][0] as string[];
+      expect(captured[1]).toBe(`/gists/${GIST_ID}`);
+    });
+
+    it("accepts a GHE-shaped URL when GH_HOST is set", async () => {
+      process.env["GH_HOST"] = "ghe.example.com";
+      mockedGhJson.mockResolvedValue(gistDetail());
+      await gistCommand([
+        "view",
+        `https://ghe.example.com/gist/OWNER/${GIST_ID}`,
+      ]);
+      const captured = mockedGhJson.mock.calls[0][0] as string[];
+      expect(captured[1]).toBe(`/gists/${GIST_ID}`);
+    });
+
+    it("rejects a URL pointing at a different host than configured", async () => {
+      process.env["GH_HOST"] = "ghe.example.com";
+      await expect(
+        gistCommand(["view", `https://gist.github.com/OWNER/${GIST_ID}`]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("truncates content over the limit and adds a footer", async () => {
+      const longContent = "x".repeat(2000);
+      mockedGhJson.mockResolvedValue(
+        gistDetail({
+          files: {
+            "big.txt": {
+              filename: "big.txt",
+              size: 2000,
+              content: longContent,
+            },
+          },
+        }),
+      );
+      const result = await gistCommand(["view", GIST_ID]);
+      expect(result).toContain("... (truncated,");
+      expect(result).toContain("2000 chars total");
+      expect(result).toContain("use --full");
+    });
+
+    it("truncated content is byte-exact up to the cut with no cleanup rewriting", async () => {
+      // Diffs and shell code both start lines with '>'. cleanBody() would
+      // collapse 3+ such lines to "[quoted text removed]" — that must NOT
+      // happen for gist content.
+      const codeWithAngles = Array.from(
+        { length: 10 },
+        (_, i) => `> line ${i}`,
+      ).join("\n");
+      const longCode = codeWithAngles.repeat(20); // well over 1500 chars
+      mockedGhJson.mockResolvedValue(
+        gistDetail({
+          files: {
+            "diff.patch": {
+              filename: "diff.patch",
+              size: longCode.length,
+              content: longCode,
+            },
+          },
+        }),
+      );
+      const result = await gistCommand(["view", GIST_ID]);
+      // The first line must be intact — no "[quoted text removed]" rewriting
+      expect(result).toContain("> line 0");
+      expect(result).not.toContain("[quoted text removed]");
+    });
+
+    it("full hint is absent when content is short enough", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail()); // ring.erl is 42 chars
+      const result = await gistCommand(["view", GIST_ID]);
+      expect(result).not.toContain("... (truncated,");
+    });
+
+    it("--full returns complete content without the truncation footer", async () => {
+      const longContent = "y".repeat(2000);
+      mockedGhJson.mockResolvedValue(
+        gistDetail({
+          files: {
+            "big.txt": { filename: "big.txt", size: 2000, content: longContent },
+          },
+        }),
+      );
+      const result = await gistCommand(["view", GIST_ID, "--full"]);
+      expect(result).not.toContain("... (truncated,");
+      // Content must be complete — check the tail chars are present
+      expect(result).toContain(longContent.slice(-10));
+    });
+
+    it("--files lists file names only and omits content", async () => {
+      mockedGhJson.mockResolvedValue(
+        gistDetail({
+          files: {
+            "ring.erl": { filename: "ring.erl", size: 42, content: "module code" },
+            "readme.md": { filename: "readme.md", size: 10, content: "# Readme" },
+          },
+        }),
+      );
+      const result = await gistCommand(["view", GIST_ID, "--files"]);
+      expect(result).toContain("ring.erl");
+      expect(result).toContain("readme.md");
+      expect(result).not.toContain("module code");
+      expect(result).not.toContain("# Readme");
+    });
+
+    it("-f/--filename emits only that file", async () => {
+      mockedGhJson.mockResolvedValue(
+        gistDetail({
+          files: {
+            "ring.erl": { filename: "ring.erl", size: 42, content: "module code" },
+            "readme.md": { filename: "readme.md", size: 10, content: "# Readme" },
+          },
+        }),
+      );
+      const result = await gistCommand(["view", GIST_ID, "--filename", "ring.erl"]);
+      expect(result).toContain("ring.erl");
+      expect(result).toContain("module code");
+      expect(result).not.toContain("readme.md");
+      expect(result).not.toContain("# Readme");
+    });
+
+    it("-f short form works for --filename", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      const result = await gistCommand(["view", GIST_ID, "-f", "ring.erl"]);
+      expect(result).toContain("ring.erl");
+      expect(result).toContain("-module(ring)");
+    });
+
+    it("-f with unknown filename throws VALIDATION_ERROR", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      await expect(
+        gistCommand(["view", GIST_ID, "-f", "nonexistent.txt"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("-r/--raw is accepted as a no-op and changes nothing", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      const withoutRaw = await gistCommand(["view", GIST_ID]);
+      vi.resetAllMocks();
+      mockedGhJson.mockResolvedValue(gistDetail());
+      const withRaw = await gistCommand(["view", GIST_ID, "--raw"]);
+      expect(withRaw).toBe(withoutRaw);
+    });
+
+    it("-w/--web is rejected with VALIDATION_ERROR", async () => {
+      await expect(
+        gistCommand(["view", GIST_ID, "--web"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("-w short form is also rejected", async () => {
+      await expect(
+        gistCommand(["view", GIST_ID, "-w"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("emits contextual help suggestions", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      const result = await gistCommand(["view", GIST_ID]);
       expect(result).toContain("help[");
     });
   });

--- a/test/commands/gist.test.ts
+++ b/test/commands/gist.test.ts
@@ -159,13 +159,13 @@ describe("gistCommand", () => {
       expect(capturedArgs).toContain("notes.md");
     });
 
-    it("add-from-stdin: passes correct argv to ghExecWithStdin", async () => {
-      // Blocker 3 regression guard: --add with piped stdin must use stdin
-      // path (`--add <name> -`), not the disk-read path.
+    it("add-from-stdin: explicit '-' sentinel routes to ghExecWithStdin", async () => {
+      // Add-from-stdin is signalled by the explicit trailing `-`, NOT by
+      // TTY-ness — so it works in the non-TTY agent context this tool targets.
       mockedIsStdinTTY.mockReturnValue(false);
       mockedReadStdin.mockResolvedValue("brand new content");
 
-      await gistCommand(["edit", "abc123", "--add", "brand-new.txt"]);
+      await gistCommand(["edit", "abc123", "--add", "brand-new.txt", "-"]);
 
       const [capturedArgs, capturedContent] =
         mockedGhExecWithStdin.mock.calls[0];
@@ -180,8 +180,11 @@ describe("gistCommand", () => {
       expect(capturedContent).toBe("brand new content");
     });
 
-    it("add-from-disk: passes correct argv to ghExec (no stdin)", async () => {
-      // Stdin is a TTY → disk path; no '-' sentinel, no ghExecWithStdin.
+    it("add-from-disk: no '-' sentinel routes to ghExec even in non-TTY (bug #1b regression)", async () => {
+      // Agents run with a non-TTY stdin. Without an explicit `-`, --add must
+      // read from disk, NOT be misrouted to the stdin branch (the old bug).
+      mockedIsStdinTTY.mockReturnValue(false);
+
       await gistCommand(["edit", "abc123", "--add", "/tmp/new.txt"]);
 
       const [capturedArgs] = mockedGhExec.mock.calls[0];
@@ -195,8 +198,29 @@ describe("gistCommand", () => {
       expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
     });
 
-    it("remove: passes correct argv to ghExec", async () => {
+    it("remove: routes to ghExec in non-TTY agent context (bug #1a regression)", async () => {
+      // The old guard rejected --remove whenever stdin was non-TTY (always, for
+      // agents) with a bogus "piped content requires --filename/--add". Remove
+      // needs no stdin and must simply run.
+      mockedIsStdinTTY.mockReturnValue(false);
+
       await gistCommand(["edit", "abc123", "--remove", "old.txt"]);
+
+      const [capturedArgs] = mockedGhExec.mock.calls[0];
+      expect(capturedArgs).toEqual([
+        "gist",
+        "edit",
+        "abc123",
+        "--remove",
+        "old.txt",
+      ]);
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+    });
+
+    it("selector is order-insensitive: flags may precede the id", async () => {
+      mockedIsStdinTTY.mockReturnValue(false);
+
+      await gistCommand(["edit", "--remove", "old.txt", "abc123"]);
 
       const [capturedArgs] = mockedGhExec.mock.calls[0];
       expect(capturedArgs).toEqual([
@@ -275,6 +299,7 @@ describe("gistCommand", () => {
         "abc123",
         "--add",
         "new.txt",
+        "-",
         "--desc",
         "with new file",
       ]);
@@ -325,13 +350,40 @@ describe("gistCommand", () => {
     // (b) is what actually closes the interactivity story: if gh is called
     // even when the guard fires, the test is worthless.
 
-    it("guard: piped stdin without --filename or --add throws VALIDATION_ERROR and does not call gh", async () => {
-      mockedIsStdinTTY.mockReturnValue(false); // piped content present
-      // No --filename or --add given — only --remove, which doesn't consume stdin
+    it("guard: lone '-' sentinel without --filename or --add throws and does not call gh", async () => {
+      mockedIsStdinTTY.mockReturnValue(false);
+      // A bare stdin sentinel with no file selector: gh would prompt which file
+      // to write, so we reject up-front.
       await expect(
-        gistCommand(["edit", "abc123", "--remove", "x.txt", "--desc", "wait"]),
+        gistCommand(["edit", "abc123", "-"]),
       ).rejects.toThrow(/--filename|--add/);
       expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+    });
+
+    it("remove + desc in non-TTY context succeeds via ghExec (not a guard error)", async () => {
+      // Under the old TTY-inference this combination was wrongly rejected in the
+      // agent (non-TTY) context. It writes no stdin and must simply run.
+      mockedIsStdinTTY.mockReturnValue(false);
+      const result = await gistCommand([
+        "edit",
+        "abc123",
+        "--remove",
+        "x.txt",
+        "--desc",
+        "updated",
+      ]);
+      expect(result).toBeDefined();
+      const [capturedArgs] = mockedGhExec.mock.calls[0];
+      expect(capturedArgs).toEqual([
+        "gist",
+        "edit",
+        "abc123",
+        "--remove",
+        "x.txt",
+        "--desc",
+        "updated",
+      ]);
       expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
     });
 

--- a/test/commands/gist.test.ts
+++ b/test/commands/gist.test.ts
@@ -6,11 +6,12 @@ vi.mock("../../src/gh.js", () => ({
   ghRaw: vi.fn(),
 }));
 
-import { ghJson } from "../../src/gh.js";
+import { ghJson, ghExec } from "../../src/gh.js";
 import { AxiError } from "../../src/errors.js";
 import { gistCommand, GIST_HELP } from "../../src/commands/gist.js";
 
 const mockedGhJson = vi.mocked(ghJson);
+const mockedGhExec = vi.mocked(ghExec);
 
 function gist(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -226,6 +227,117 @@ describe("gistCommand", () => {
       await expect(
         gistCommand(["list", "--limit", "-5"]),
       ).rejects.toThrow(AxiError);
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes the gist and reports what was deleted", async () => {
+      mockedGhExec.mockResolvedValue("");
+      const result = await gistCommand(["delete", "abc1230000000000000000000000000a"]);
+      expect(result).toContain("abc1230000000000000000000000000a");
+    });
+
+    // Mutation-test anchor: if --yes is removed from the ghExec call, the argv
+    // assertion below will fail. Verified by reverting the --yes and watching
+    // this test go red, then restoring.
+    it("always passes --yes to gh gist delete", async () => {
+      mockedGhExec.mockResolvedValue("");
+      await gistCommand(["delete", "abc1230000000000000000000000000a"]);
+      const capturedArgs = mockedGhExec.mock.calls[0]![0] as string[];
+      expect(capturedArgs).toContain("--yes");
+    });
+
+    it("passes the selector to gh gist delete as argv", async () => {
+      mockedGhExec.mockResolvedValue("");
+      await gistCommand(["delete", "abc1230000000000000000000000000a"]);
+      const capturedArgs = mockedGhExec.mock.calls[0]![0] as string[];
+      expect(capturedArgs).toContain("abc1230000000000000000000000000a");
+      expect(capturedArgs[0]).toBe("gist");
+      expect(capturedArgs[1]).toBe("delete");
+    });
+
+    it("throws VALIDATION_ERROR when no selector is given", async () => {
+      await expect(gistCommand(["delete"])).rejects.toThrow(AxiError);
+    });
+
+    it("throws VALIDATION_ERROR for surplus positional arguments", async () => {
+      mockedGhExec.mockResolvedValue("");
+      await expect(
+        gistCommand(["delete", "abc1230000000000000000000000000a", "extra"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("accepts a gist URL as the selector", async () => {
+      mockedGhExec.mockResolvedValue("");
+      const url = "https://gist.github.com/octocat/abc1230000000000000000000000000a";
+      const result = await gistCommand(["delete", url]);
+      expect(result).toContain(url);
+      const capturedArgs = mockedGhExec.mock.calls[0]![0] as string[];
+      expect(capturedArgs).toContain(url);
+      expect(capturedArgs).toContain("--yes");
+    });
+
+    it("emits contextual help suggestions", async () => {
+      mockedGhExec.mockResolvedValue("");
+      const result = await gistCommand(["delete", "abc1230000000000000000000000000a"]);
+      expect(result).toContain("help[");
+      expect(result).toContain("gist list");
+    });
+
+    it("never passes ctx to ghExec — gist is user-scoped", async () => {
+      mockedGhExec.mockResolvedValue("");
+      await gistCommand(["delete", "abc1230000000000000000000000000a"]);
+      expect(mockedGhExec.mock.calls[0]![1]).toBeUndefined();
+    });
+  });
+
+  describe("clone", () => {
+    it("clones the gist and reports ok", async () => {
+      mockedGhExec.mockResolvedValue("");
+      const result = await gistCommand(["clone", "abc1230000000000000000000000000a"]);
+      expect(result).toContain("ok");
+    });
+
+    it("passes the selector to gh gist clone as argv", async () => {
+      mockedGhExec.mockResolvedValue("");
+      await gistCommand(["clone", "abc1230000000000000000000000000a"]);
+      const capturedArgs = mockedGhExec.mock.calls[0]![0] as string[];
+      expect(capturedArgs[0]).toBe("gist");
+      expect(capturedArgs[1]).toBe("clone");
+      expect(capturedArgs).toContain("abc1230000000000000000000000000a");
+    });
+
+    it("throws VALIDATION_ERROR when no selector is given", async () => {
+      await expect(gistCommand(["clone"])).rejects.toThrow(AxiError);
+    });
+
+    it("throws VALIDATION_ERROR for surplus positional arguments", async () => {
+      mockedGhExec.mockResolvedValue("");
+      await expect(
+        gistCommand(["clone", "abc1230000000000000000000000000a", "extra"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("accepts a gist URL as the selector", async () => {
+      mockedGhExec.mockResolvedValue("");
+      const url = "https://gist.github.com/octocat/abc1230000000000000000000000000a";
+      const result = await gistCommand(["clone", url]);
+      expect(result).toContain("ok");
+      const capturedArgs = mockedGhExec.mock.calls[0]![0] as string[];
+      expect(capturedArgs).toContain(url);
+    });
+
+    it("emits contextual help suggestions", async () => {
+      mockedGhExec.mockResolvedValue("");
+      const result = await gistCommand(["clone", "abc1230000000000000000000000000a"]);
+      expect(result).toContain("help[");
+      expect(result).toContain("gist list");
+    });
+
+    it("never passes ctx to ghExec — gist is user-scoped", async () => {
+      mockedGhExec.mockResolvedValue("");
+      await gistCommand(["clone", "abc1230000000000000000000000000a"]);
+      expect(mockedGhExec.mock.calls[0]![1]).toBeUndefined();
     });
   });
 });

--- a/test/commands/gist.test.ts
+++ b/test/commands/gist.test.ts
@@ -3,15 +3,25 @@ import { vi, describe, it, expect, beforeEach } from "vitest";
 vi.mock("../../src/gh.js", () => ({
   ghJson: vi.fn(),
   ghExec: vi.fn(),
+  ghExecWithStdin: vi.fn(),
   ghRaw: vi.fn(),
 }));
 
-import { ghJson, ghExec } from "../../src/gh.js";
+vi.mock("../../src/stdin.js", () => ({
+  isStdinTTY: vi.fn(),
+  readStdin: vi.fn(),
+}));
+
+import { ghJson, ghExec, ghExecWithStdin } from "../../src/gh.js";
+import { isStdinTTY, readStdin } from "../../src/stdin.js";
 import { AxiError } from "../../src/errors.js";
 import { gistCommand, GIST_HELP } from "../../src/commands/gist.js";
 
 const mockedGhJson = vi.mocked(ghJson);
 const mockedGhExec = vi.mocked(ghExec);
+const mockedGhExecWithStdin = vi.mocked(ghExecWithStdin);
+const mockedIsStdinTTY = vi.mocked(isStdinTTY);
+const mockedReadStdin = vi.mocked(readStdin);
 
 function gist(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -34,9 +44,20 @@ function gist(overrides: Record<string, unknown> = {}): Record<string, unknown> 
 const ID_ALPHA = "aaaa0000000000000000000000000000"; // used as the public gist
 const ID_BRAVO = "bbbb1111111111111111111111111111"; // used as the secret gist
 
+// A URL whose last path segment is the gist ID. Used as the mock return value
+// from gh gist create to test ID extraction.
+const CREATE_ID = "cc2233445566778899aabbccddeeff00";
+const CREATE_URL = `https://gist.github.com/octocat/${CREATE_ID}`;
+
 describe("gistCommand", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    // Default for create: gh prints the gist URL to stdout.
+    mockedGhExec.mockResolvedValue(`${CREATE_URL}\n`);
+    mockedGhExecWithStdin.mockResolvedValue(`${CREATE_URL}\n`);
+    // Default: stdin is piped (not a TTY) with some content.
+    mockedIsStdinTTY.mockReturnValue(false);
+    mockedReadStdin.mockResolvedValue("file content");
   });
 
   describe("router", () => {
@@ -52,6 +73,7 @@ describe("gistCommand", () => {
       const result = await gistCommand(["frobnicate"]);
       expect(result).toContain("Unknown subcommand: frobnicate");
       expect(result).toContain("list");
+      expect(result).toContain("create");
     });
   });
 
@@ -338,6 +360,272 @@ describe("gistCommand", () => {
       mockedGhExec.mockResolvedValue("");
       await gistCommand(["clone", "abc1230000000000000000000000000a"]);
       expect(mockedGhExec.mock.calls[0]![1]).toBeUndefined();
+    });
+  });
+
+  // ─── gist create ──────────────────────────────────────────────────────────
+  //
+  // Design: writes go through `gh gist create` (not the API) so gh's binary
+  // sniffing and blank-file rejection stay in effect. Visibility is required
+  // and mutually exclusive. Two file-on-disk input forms (positionals, --file)
+  // must not be mixed. Content may also be piped via stdin + --filename.
+  // No ctx parameter — gist is user-scoped (AGENTS.md "User-scoped commands").
+
+  describe("create", () => {
+    // ── Visibility validation ───────────────────────────────────────────────
+
+    it("rejects when neither --public nor --secret is given", async () => {
+      await expect(
+        gistCommand(["create", "a.py"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("rejects when both --public and --secret are given", async () => {
+      await expect(
+        gistCommand(["create", "a.py", "--public", "--secret"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    // ── Positional file form ────────────────────────────────────────────────
+
+    it("creates a public gist from positional files and reports id+url+visibility", async () => {
+      const result = await gistCommand(["create", "a.py", "b.py", "--public"]);
+      expect(result).toContain(CREATE_ID);
+      expect(result).toContain(CREATE_URL);
+      expect(result).toContain("public");
+    });
+
+    it("passes positional file paths to gh argv", async () => {
+      // Mutation target: if `ghArgs.push(...paths)` is removed, "a.py" and "b.py"
+      // disappear from the argv and this test fails.
+      await gistCommand(["create", "a.py", "b.py", "--public"]);
+      const args = mockedGhExec.mock.calls[0][0] as string[];
+      expect(args).toContain("a.py");
+      expect(args).toContain("b.py");
+    });
+
+    // ── --file flag form ────────────────────────────────────────────────────
+
+    it("creates a gist from --file flags and reports id", async () => {
+      const result = await gistCommand([
+        "create",
+        "--file",
+        "a.py",
+        "--file",
+        "b.py",
+        "--public",
+      ]);
+      expect(result).toContain(CREATE_ID);
+    });
+
+    it("passes every --file value to gh argv (repeatable, no silent drops)", async () => {
+      // Mutation target: if only the first --file value is consumed (first-only
+      // bug, #55/#57/#75) the second value "b.py" is absent and this test fails.
+      await gistCommand([
+        "create",
+        "--file",
+        "a.py",
+        "--file",
+        "b.py",
+        "--public",
+      ]);
+      const args = mockedGhExec.mock.calls[0][0] as string[];
+      expect(args).toContain("a.py");
+      expect(args).toContain("b.py");
+    });
+
+    it("rejects mixing positional paths with --file", async () => {
+      await expect(
+        gistCommand(["create", "a.py", "--file", "b.py", "--public"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("rejects a dangling --file with no value following it", async () => {
+      // takeAllFlags throws VALIDATION_ERROR when a flag's value is missing.
+      await expect(
+        gistCommand(["create", "--file", "--public"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("rejects a blank --file= value", async () => {
+      await expect(
+        gistCommand(["create", "--file=", "--public"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    // ── Stdin / --filename form ─────────────────────────────────────────────
+
+    it("creates a gist from piped stdin with --filename", async () => {
+      const result = await gistCommand([
+        "create",
+        "--filename",
+        "foo.txt",
+        "--public",
+      ]);
+      expect(result).toContain(CREATE_ID);
+      expect(mockedGhExecWithStdin).toHaveBeenCalledOnce();
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it("passes --filename value to gh argv in stdin form", async () => {
+      // Mutation target: if `ghArgs.push("--filename", filename)` is removed,
+      // --filename and foo.txt disappear from gh argv and this test fails.
+      await gistCommand(["create", "--filename", "foo.txt", "--public"]);
+      const args = mockedGhExecWithStdin.mock.calls[0][0] as string[];
+      expect(args).toContain("--filename");
+      expect(args).toContain("foo.txt");
+    });
+
+    it("pipes stdin content to gh in stdin form", async () => {
+      mockedReadStdin.mockResolvedValue("the content");
+      await gistCommand(["create", "--filename", "foo.txt", "--public"]);
+      const input = mockedGhExecWithStdin.mock.calls[0][1] as string;
+      expect(input).toBe("the content");
+    });
+
+    it("rejects stdin form when stdin is a TTY (no pipe detected)", async () => {
+      mockedIsStdinTTY.mockReturnValue(true);
+      await expect(
+        gistCommand(["create", "--filename", "foo.txt", "--public"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("rejects mixing --filename with positional paths", async () => {
+      await expect(
+        gistCommand(["create", "a.py", "--filename", "foo.txt", "--public"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("rejects mixing --filename with --file", async () => {
+      await expect(
+        gistCommand([
+          "create",
+          "--file",
+          "a.py",
+          "--filename",
+          "foo.txt",
+          "--public",
+        ]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    // ── Description flag ────────────────────────────────────────────────────
+
+    it("passes --desc to gh argv as -d", async () => {
+      await gistCommand(["create", "a.py", "--public", "--desc", "My notes"]);
+      const args = mockedGhExec.mock.calls[0][0] as string[];
+      expect(args).toContain("-d");
+      expect(args).toContain("My notes");
+    });
+
+    it("also accepts -d short form for description", async () => {
+      await gistCommand(["create", "a.py", "--public", "-d", "Short desc"]);
+      const args = mockedGhExec.mock.calls[0][0] as string[];
+      expect(args).toContain("-d");
+      expect(args).toContain("Short desc");
+    });
+
+    // ── --public flag in gh argv ─────────────────────────────────────────────
+
+    it("passes --public to gh argv for public gists", async () => {
+      // Mutation target: if `ghArgs.push("--public")` is removed, gh creates a
+      // secret gist instead and this test fails.
+      await gistCommand(["create", "a.py", "--public"]);
+      const args = mockedGhExec.mock.calls[0][0] as string[];
+      expect(args).toContain("--public");
+    });
+
+    it("does NOT pass --public or --secret to gh argv for secret gists (gh defaults to secret)", async () => {
+      await gistCommand(["create", "a.py", "--secret"]);
+      const args = mockedGhExec.mock.calls[0][0] as string[];
+      expect(args).not.toContain("--public");
+      expect(args).not.toContain("--secret");
+    });
+
+    // ── Output content ──────────────────────────────────────────────────────
+
+    it("reports the gist id extracted from the URL last path segment", async () => {
+      const result = await gistCommand(["create", "a.py", "--public"]);
+      // id is the last path segment of the URL
+      expect(result).toContain(CREATE_ID);
+    });
+
+    it("reports the full gist url", async () => {
+      const result = await gistCommand(["create", "a.py", "--public"]);
+      expect(result).toContain(CREATE_URL);
+    });
+
+    it("reports visibility: secret for secret gists", async () => {
+      const result = await gistCommand(["create", "a.py", "--secret"]);
+      expect(result).toContain("secret");
+    });
+
+    it("includes the unlisted-not-private help line for secret gists", async () => {
+      const result = await gistCommand(["create", "a.py", "--secret"]);
+      expect(result).toContain("unlisted");
+      expect(result).toContain("not private");
+    });
+
+    it("omits the unlisted-not-private help line for public gists", async () => {
+      const result = await gistCommand(["create", "a.py", "--public"]);
+      expect(result).not.toContain("unlisted");
+    });
+
+    // ── User-scoped (no ctx forwarded to gh) ─────────────────────────────────
+
+    it("never passes ctx to ghExec — gist create is user-scoped", async () => {
+      // ghExec is called without a ctx argument. The second argument (ctx) must
+      // be undefined, matching the same structural guarantee as gist list.
+      await gistCommand(["create", "a.py", "--public"]);
+      expect(mockedGhExec.mock.calls[0][2]).toBeUndefined();
+    });
+
+    // ── Unknown single-dash flag rejection ──────────────────────────────────
+    //
+    // Single-dash gh shorthands must be rejected, not forwarded as file paths.
+    // The critical case is -p (gh's --public): `gist create a.py --secret -p`
+    // builds argv ["gist","create","a.py","-p"] which gh interprets as public,
+    // creating a public gist while the wrapper reports visibility: secret —
+    // a silent wrong-answer-at-exit-0 leak. -w/--web and -f/--filename trigger
+    // gh interactivity in similar fashion.
+    //
+    // Each test asserts BOTH that an AxiError is thrown AND that ghExec was
+    // never called — the regression the reviewer caught is that gh runs at all.
+
+    it("rejects -p (gh --public shorthand) and does not call ghExec", async () => {
+      await expect(
+        gistCommand(["create", "a.py", "--secret", "-p"]),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+    });
+
+    it("rejects -w (gh --web shorthand) and does not call ghExec", async () => {
+      await expect(
+        gistCommand(["create", "a.py", "--public", "-w"]),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it("rejects -f (gh --filename shorthand) and does not call ghExec", async () => {
+      await expect(
+        gistCommand(["create", "a.py", "--public", "-f"]),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it("rejects unknown long flags that are not known to createGist", async () => {
+      await expect(
+        gistCommand(["create", "a.py", "--public", "--unknown-flag"]),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    // ── Help / suggestions ──────────────────────────────────────────────────
+
+    it("ends with a help block", async () => {
+      const result = await gistCommand(["create", "a.py", "--public"]);
+      expect(result).toContain("help[");
     });
   });
 });

--- a/test/commands/gist.test.ts
+++ b/test/commands/gist.test.ts
@@ -426,6 +426,31 @@ describe("gistCommand", () => {
       expect(mockedGhExec).not.toHaveBeenCalled();
     });
 
+    // The same destructive-guard hole closed for `gist delete`: a dropped
+    // --dry-run must not let the remove proceed at exit 0.
+    it("guard: unknown flag alongside --remove throws and does not call gh", async () => {
+      await expect(
+        gistCommand(["edit", "abc123", "--remove", "old.txt", "--dry-run"]),
+      ).rejects.toThrow(/--dry-run/);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+    });
+
+    it("guard: a misspelled value flag is named rather than reported as a stray positional", async () => {
+      await expect(
+        gistCommand(["edit", "abc123", "--remov", "old.txt"]),
+      ).rejects.toThrow(/--remov/);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it("guard: the lone '-' stdin sentinel is not treated as an unknown flag", async () => {
+      mockedIsStdinTTY.mockReturnValue(false);
+      mockedReadStdin.mockResolvedValue("brand new content");
+      mockedGhExecWithStdin.mockResolvedValue("");
+      await gistCommand(["edit", "abc123", "--add", "new.txt", "-"]);
+      expect(mockedGhExecWithStdin).toHaveBeenCalled();
+    });
+
     it("guard: --add <name> - with empty stdin throws and never writes empty content", async () => {
       mockedIsStdinTTY.mockReturnValue(false);
       mockedReadStdin.mockResolvedValue("");
@@ -1498,6 +1523,55 @@ describe("gistCommand", () => {
       mockedGhJson.mockResolvedValue(gistDetail());
       const result = await gistCommand(["view", GIST_ID, "--full", "-r"]);
       expect(result).toContain("ring.erl");
+    });
+
+    // hasFlag only matches the bare token, so a boolean in =value form would
+    // otherwise pass the guard and then be silently ignored at exit 0.
+    it("rejects --full=true rather than accepting and ignoring it", async () => {
+      mockedGhJson.mockResolvedValue(
+        gistDetail({
+          files: {
+            "big.txt": {
+              filename: "big.txt",
+              size: 2000,
+              content: "z".repeat(2000),
+            },
+          },
+        }),
+      );
+      await expect(
+        gistCommand(["view", GIST_ID, "--full=true"]),
+      ).rejects.toThrow(/--full=true/);
+      expect(mockedGhJson).not.toHaveBeenCalled();
+    });
+
+    it("rejects --files=1 rather than accepting and ignoring it", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      await expect(
+        gistCommand(["view", GIST_ID, "--files=1"]),
+      ).rejects.toThrow(/--files=1/);
+      expect(mockedGhJson).not.toHaveBeenCalled();
+    });
+
+    it("rejects -r=x rather than accepting and ignoring it", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      await expect(
+        gistCommand(["view", GIST_ID, "-r=x"]),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhJson).not.toHaveBeenCalled();
+    });
+
+    it("rejects --web=true with the unsupported-browser error", async () => {
+      await expect(
+        gistCommand(["view", GIST_ID, "--web=true"]),
+      ).rejects.toThrow(/browser/);
+    });
+
+    it("still accepts -f/--filename in =value form", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      const result = await gistCommand(["view", GIST_ID, "--filename=ring.erl"]);
+      expect(result).toContain("ring.erl");
+      expect(result).toContain("-module(ring)");
     });
 
     // ── GitHub API server-side truncation ───────────────────────────────────

--- a/test/commands/gist.test.ts
+++ b/test/commands/gist.test.ts
@@ -112,6 +112,436 @@ describe("gistCommand", () => {
     });
   });
 
+  describe("edit", () => {
+    beforeEach(() => {
+      // Default: stdin is a TTY (no piped content) so most non-stdin tests work
+      // without extra setup. Override per-test when piped content is needed.
+      mockedIsStdinTTY.mockReturnValue(true);
+      mockedGhExec.mockResolvedValue("");
+      mockedGhExecWithStdin.mockResolvedValue("");
+    });
+
+    // ── argv assertions ─────────────────────────────────────────────────────
+
+    it("replace-from-stdin: passes correct argv to ghExecWithStdin with '-' source", async () => {
+      // Blocker 1 regression guard: `-` must appear before `--filename` so gh
+      // reads from stdin instead of opening $EDITOR.
+      mockedIsStdinTTY.mockReturnValue(false);
+      mockedReadStdin.mockResolvedValue("new content");
+
+      await gistCommand(["edit", "abc123", "--filename", "notes.md"]);
+
+      const [capturedArgs, capturedContent] =
+        mockedGhExecWithStdin.mock.calls[0];
+      expect(capturedArgs).toEqual([
+        "gist",
+        "edit",
+        "abc123",
+        "-",           // source positional — must be present and before --filename
+        "--filename",
+        "notes.md",
+      ]);
+      expect(capturedContent).toBe("new content");
+    });
+
+    it("replace-from-stdin: short -f flag is accepted", async () => {
+      mockedIsStdinTTY.mockReturnValue(false);
+      mockedReadStdin.mockResolvedValue("content");
+
+      await gistCommand(["edit", "abc123", "-f", "notes.md"]);
+
+      const [capturedArgs] = mockedGhExecWithStdin.mock.calls[0];
+      // '-' source must precede '--filename'
+      const dashIdx = capturedArgs.indexOf("-");
+      const fnIdx = capturedArgs.indexOf("--filename");
+      expect(dashIdx).toBeGreaterThanOrEqual(0);
+      expect(fnIdx).toBeGreaterThan(dashIdx);
+      expect(capturedArgs).toContain("notes.md");
+    });
+
+    it("add-from-stdin: passes correct argv to ghExecWithStdin", async () => {
+      // Blocker 3 regression guard: --add with piped stdin must use stdin
+      // path (`--add <name> -`), not the disk-read path.
+      mockedIsStdinTTY.mockReturnValue(false);
+      mockedReadStdin.mockResolvedValue("brand new content");
+
+      await gistCommand(["edit", "abc123", "--add", "brand-new.txt"]);
+
+      const [capturedArgs, capturedContent] =
+        mockedGhExecWithStdin.mock.calls[0];
+      expect(capturedArgs).toEqual([
+        "gist",
+        "edit",
+        "abc123",
+        "--add",
+        "brand-new.txt",
+        "-",           // content source: stdin
+      ]);
+      expect(capturedContent).toBe("brand new content");
+    });
+
+    it("add-from-disk: passes correct argv to ghExec (no stdin)", async () => {
+      // Stdin is a TTY → disk path; no '-' sentinel, no ghExecWithStdin.
+      await gistCommand(["edit", "abc123", "--add", "/tmp/new.txt"]);
+
+      const [capturedArgs] = mockedGhExec.mock.calls[0];
+      expect(capturedArgs).toEqual([
+        "gist",
+        "edit",
+        "abc123",
+        "--add",
+        "/tmp/new.txt",
+      ]);
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+    });
+
+    it("remove: passes correct argv to ghExec", async () => {
+      await gistCommand(["edit", "abc123", "--remove", "old.txt"]);
+
+      const [capturedArgs] = mockedGhExec.mock.calls[0];
+      expect(capturedArgs).toEqual([
+        "gist",
+        "edit",
+        "abc123",
+        "--remove",
+        "old.txt",
+      ]);
+    });
+
+    it("desc-only: routes through gh api PATCH to avoid multi-file prompt", async () => {
+      // Blocker 2 regression guard: desc-only must NOT call `gh gist edit`
+      // (which prompts on multi-file gists); it must PATCH /gists/<id>.
+      await gistCommand(["edit", "abc123", "--desc", "my new description"]);
+
+      const [capturedArgs] = mockedGhExec.mock.calls[0];
+      expect(capturedArgs).toEqual([
+        "api",
+        "-X",
+        "PATCH",
+        "/gists/abc123",
+        "-f",
+        "description=my new description",
+      ]);
+    });
+
+    it("desc-only: extracts bare id from a URL selector for the API call", async () => {
+      await gistCommand([
+        "edit",
+        "https://gist.github.com/octocat/deadbeef",
+        "--desc",
+        "updated",
+      ]);
+
+      const [capturedArgs] = mockedGhExec.mock.calls[0];
+      expect(capturedArgs).toContain("/gists/deadbeef");
+      expect(capturedArgs.join(" ")).not.toContain("gist.github.com");
+    });
+
+    it("desc-only: short -d flag is accepted", async () => {
+      await gistCommand(["edit", "abc123", "-d", "a description"]);
+
+      const [capturedArgs] = mockedGhExec.mock.calls[0];
+      expect(capturedArgs[0]).toBe("api");
+      expect(capturedArgs.join(" ")).toContain("description=a description");
+    });
+
+    it("filename+desc: includes both '-' source and '--desc' in argv", async () => {
+      mockedIsStdinTTY.mockReturnValue(false);
+      mockedReadStdin.mockResolvedValue("content");
+
+      await gistCommand([
+        "edit",
+        "abc123",
+        "--filename",
+        "notes.md",
+        "--desc",
+        "updated",
+      ]);
+
+      const [capturedArgs] = mockedGhExecWithStdin.mock.calls[0];
+      expect(capturedArgs).toContain("-");
+      expect(capturedArgs).toContain("--filename");
+      expect(capturedArgs).toContain("notes.md");
+      expect(capturedArgs).toContain("--desc");
+      expect(capturedArgs).toContain("updated");
+    });
+
+    it("add-from-stdin+desc: includes both '-' source and '--desc' in argv", async () => {
+      mockedIsStdinTTY.mockReturnValue(false);
+      mockedReadStdin.mockResolvedValue("content");
+
+      await gistCommand([
+        "edit",
+        "abc123",
+        "--add",
+        "new.txt",
+        "--desc",
+        "with new file",
+      ]);
+
+      const [capturedArgs] = mockedGhExecWithStdin.mock.calls[0];
+      expect(capturedArgs).toContain("--add");
+      expect(capturedArgs).toContain("-");
+      expect(capturedArgs).toContain("--desc");
+    });
+
+    it("add-from-disk+desc: includes both flags in argv to ghExec", async () => {
+      await gistCommand(["edit", "abc123", "--add", "/tmp/f.txt", "--desc", "d"]);
+
+      const [capturedArgs] = mockedGhExec.mock.calls[0];
+      expect(capturedArgs).toContain("--add");
+      expect(capturedArgs).toContain("--desc");
+    });
+
+    it("accepts a gist URL as the selector", async () => {
+      await gistCommand([
+        "edit",
+        "https://gist.github.com/octocat/abc123",
+        "--remove",
+        "file.txt",
+      ]);
+
+      const [capturedArgs] = mockedGhExec.mock.calls[0];
+      expect(capturedArgs[2]).toBe("https://gist.github.com/octocat/abc123");
+    });
+
+    it("never forwards ctx to ghExec (user-scoped)", async () => {
+      await gistCommand(["edit", "abc123", "--remove", "file.txt"]);
+      expect(mockedGhExec.mock.calls[0][1]).toBeUndefined();
+    });
+
+    it("never forwards ctx to ghExecWithStdin (user-scoped)", async () => {
+      mockedIsStdinTTY.mockReturnValue(false);
+      mockedReadStdin.mockResolvedValue("x");
+
+      await gistCommand(["edit", "abc123", "--filename", "x.txt"]);
+      expect(mockedGhExecWithStdin.mock.calls[0][2]).toBeUndefined();
+    });
+
+    // ── interactivity guards ─────────────────────────────────────────────────
+    // Each guard must:
+    //   a) throw AxiError with an actionable message naming the resolution
+    //   b) prove gh was never invoked (not.toHaveBeenCalled assertions)
+    // (b) is what actually closes the interactivity story: if gh is called
+    // even when the guard fires, the test is worthless.
+
+    it("guard: piped stdin without --filename or --add throws VALIDATION_ERROR and does not call gh", async () => {
+      mockedIsStdinTTY.mockReturnValue(false); // piped content present
+      // No --filename or --add given — only --remove, which doesn't consume stdin
+      await expect(
+        gistCommand(["edit", "abc123", "--remove", "x.txt", "--desc", "wait"]),
+      ).rejects.toThrow(/--filename|--add/);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+    });
+
+    it("guard: piped stdin with only --desc routes to API (not a guard error)", async () => {
+      // --desc-only is handled via API even when stdin is piped — the desc path
+      // does not read stdin and does not trigger guard 2.
+      mockedIsStdinTTY.mockReturnValue(false);
+      // No AxiError expected — the desc-only path is valid.
+      const result = await gistCommand(["edit", "abc123", "--desc", "hello"]);
+      expect(result).toBeDefined();
+      // Verify the API path was used, not gist edit
+      const [apiArgs] = mockedGhExec.mock.calls[0];
+      expect(apiArgs[0]).toBe("api");
+    });
+
+    it("guard: --filename without piped stdin throws VALIDATION_ERROR and does not call gh", async () => {
+      mockedIsStdinTTY.mockReturnValue(true); // no piped content
+      await expect(
+        gistCommand(["edit", "abc123", "--filename", "notes.md"]),
+      ).rejects.toThrow(/stdin/);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+    });
+
+    it("guard: no edit operation throws VALIDATION_ERROR and does not call gh", async () => {
+      await expect(gistCommand(["edit", "abc123"])).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+    });
+
+    it("guard: --filename and --add together throws VALIDATION_ERROR and does not call gh", async () => {
+      mockedIsStdinTTY.mockReturnValue(false);
+      mockedReadStdin.mockResolvedValue("x");
+      await expect(
+        gistCommand([
+          "edit",
+          "abc123",
+          "--filename",
+          "a.txt",
+          "--add",
+          "/tmp/b.txt",
+        ]),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+    });
+
+    it("guard: --filename and --remove together throws VALIDATION_ERROR and does not call gh", async () => {
+      mockedIsStdinTTY.mockReturnValue(false);
+      mockedReadStdin.mockResolvedValue("x");
+      await expect(
+        gistCommand([
+          "edit",
+          "abc123",
+          "--filename",
+          "a.txt",
+          "--remove",
+          "b.txt",
+        ]),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+    });
+
+    it("guard: --add and --remove together throws VALIDATION_ERROR and does not call gh", async () => {
+      await expect(
+        gistCommand([
+          "edit",
+          "abc123",
+          "--add",
+          "/tmp/a.txt",
+          "--remove",
+          "b.txt",
+        ]),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+    });
+
+    it("guard: missing id throws VALIDATION_ERROR and does not call gh", async () => {
+      await expect(gistCommand(["edit"])).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+    });
+
+    // ── output ───────────────────────────────────────────────────────────────
+
+    it("returns edited:ok with the gist id in output", async () => {
+      await gistCommand(["edit", "abc123", "--remove", "old.txt"]);
+      // No assertion on specific TOON key — just confirm it ran and output something
+    });
+
+    it("ends with contextual help suggestions", async () => {
+      const result = await gistCommand(["edit", "abc123", "--remove", "old.txt"]);
+      expect(result).toContain("help[");
+    });
+
+    it("suggestions reference gist list and gist rename", async () => {
+      const result = await gistCommand(["edit", "abc123", "--remove", "old.txt"]);
+      expect(result).toContain("gist list");
+      expect(result).toContain("gist rename");
+    });
+  });
+
+  describe("rename", () => {
+    beforeEach(() => {
+      mockedGhExec.mockResolvedValue("");
+    });
+
+    // ── argv assertions ─────────────────────────────────────────────────────
+
+    it("passes correct argv to ghExec", async () => {
+      await gistCommand(["rename", "abc123", "old.txt", "new.txt"]);
+
+      const [capturedArgs] = mockedGhExec.mock.calls[0];
+      expect(capturedArgs).toEqual([
+        "gist",
+        "rename",
+        "abc123",
+        "old.txt",
+        "new.txt",
+      ]);
+    });
+
+    it("accepts a gist URL as the selector", async () => {
+      await gistCommand([
+        "rename",
+        "https://gist.github.com/octocat/abc123",
+        "old.txt",
+        "new.txt",
+      ]);
+
+      const [capturedArgs] = mockedGhExec.mock.calls[0];
+      expect(capturedArgs[2]).toBe("https://gist.github.com/octocat/abc123");
+    });
+
+    it("never forwards ctx to ghExec (user-scoped)", async () => {
+      await gistCommand(["rename", "abc123", "old.txt", "new.txt"]);
+      expect(mockedGhExec.mock.calls[0][1]).toBeUndefined();
+    });
+
+    // ── arity validation ─────────────────────────────────────────────────────
+    // All arity errors must also prove gh was never called.
+
+    it("missing id throws VALIDATION_ERROR and does not call gh", async () => {
+      await expect(gistCommand(["rename"])).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it("missing old filename throws VALIDATION_ERROR and does not call gh", async () => {
+      await expect(gistCommand(["rename", "abc123"])).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it("missing new filename throws VALIDATION_ERROR and does not call gh", async () => {
+      await expect(
+        gistCommand(["rename", "abc123", "old.txt"]),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it("surplus positional throws VALIDATION_ERROR and does not call gh", async () => {
+      await expect(
+        gistCommand(["rename", "abc123", "old.txt", "new.txt", "extra"]),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it("unknown flag throws VALIDATION_ERROR and does not call gh", async () => {
+      await expect(
+        gistCommand(["rename", "abc123", "old.txt", "new.txt", "--force"]),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    // ── output ───────────────────────────────────────────────────────────────
+
+    it("output includes old and new names", async () => {
+      const result = await gistCommand([
+        "rename",
+        "abc123",
+        "old.txt",
+        "new.txt",
+      ]);
+      expect(result).toContain("old.txt");
+      expect(result).toContain("new.txt");
+    });
+
+    it("ends with contextual help suggestions", async () => {
+      const result = await gistCommand([
+        "rename",
+        "abc123",
+        "old.txt",
+        "new.txt",
+      ]);
+      expect(result).toContain("help[");
+    });
+
+    it("suggestions reference gist list and gist edit", async () => {
+      const result = await gistCommand([
+        "rename",
+        "abc123",
+        "old.txt",
+        "new.txt",
+      ]);
+      expect(result).toContain("gist list");
+      expect(result).toContain("gist edit");
+    });
+  });
+
   describe("list", () => {
     it("renders gists with a count line", async () => {
       mockedGhJson.mockResolvedValue([gist(), gist({ id: "abc" })]);

--- a/test/commands/gist.test.ts
+++ b/test/commands/gist.test.ts
@@ -414,6 +414,28 @@ describe("gistCommand", () => {
       expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
     });
 
+    // isStdinTTY() never fires in agent contexts, so an empty read is the only
+    // signal nothing was piped — writing it through would blank the file.
+    it("guard: --filename with empty stdin throws and never writes empty content", async () => {
+      mockedIsStdinTTY.mockReturnValue(false);
+      mockedReadStdin.mockResolvedValue("");
+      await expect(
+        gistCommand(["edit", "abc123", "--filename", "notes.md"]),
+      ).rejects.toThrow(/stdin/);
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it("guard: --add <name> - with empty stdin throws and never writes empty content", async () => {
+      mockedIsStdinTTY.mockReturnValue(false);
+      mockedReadStdin.mockResolvedValue("");
+      await expect(
+        gistCommand(["edit", "abc123", "--add", "new.txt", "-"]),
+      ).rejects.toThrow(/stdin/);
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
     it("guard: --filename and --add together throws VALIDATION_ERROR and does not call gh", async () => {
       mockedIsStdinTTY.mockReturnValue(false);
       mockedReadStdin.mockResolvedValue("x");
@@ -788,6 +810,35 @@ describe("gistCommand", () => {
         gistCommand(["list", "--limit", "-5"]),
       ).rejects.toThrow(AxiError);
     });
+
+    // A typo must fail loudly, not silently return the default 100 rows.
+    it("rejects an unknown flag instead of silently ignoring it", async () => {
+      mockedGhJson.mockResolvedValue([]);
+      await expect(
+        gistCommand(["list", "--limitt", "5"]),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhJson).not.toHaveBeenCalled();
+    });
+
+    it("names the unknown flag in the error", async () => {
+      mockedGhJson.mockResolvedValue([]);
+      await expect(
+        gistCommand(["list", "--limitt", "5"]),
+      ).rejects.toThrow(/--limitt/);
+    });
+
+    it("rejects an unknown flag in --flag=value form", async () => {
+      mockedGhJson.mockResolvedValue([]);
+      await expect(
+        gistCommand(["list", "--fieldz=url"]),
+      ).rejects.toThrow(AxiError);
+    });
+
+    it("still accepts --fields in --flag=value form", async () => {
+      mockedGhJson.mockResolvedValue([gist()]);
+      const result = await gistCommand(["list", "--fields=url"]);
+      expect(result).toContain("url");
+    });
   });
 
   describe("delete", () => {
@@ -849,6 +900,31 @@ describe("gistCommand", () => {
       await gistCommand(["delete", "abc1230000000000000000000000000a"]);
       expect(mockedGhExec.mock.calls[0]![1]).toBeUndefined();
     });
+
+    // A dropped guard flag would destroy the gist at exit 0 — the delete must
+    // never run when the caller passed something the wrapper does not understand.
+    it("rejects an unknown flag and never reaches gh", async () => {
+      mockedGhExec.mockResolvedValue("");
+      await expect(
+        gistCommand(["delete", "--dry-run", "abc1230000000000000000000000000a"]),
+      ).rejects.toThrow(AxiError);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it("names the unknown flag in the error", async () => {
+      mockedGhExec.mockResolvedValue("");
+      await expect(
+        gistCommand(["delete", "--dry-run", "abc1230000000000000000000000000a"]),
+      ).rejects.toThrow(/--dry-run/);
+    });
+
+    it("rejects a single-dash flag rather than treating it as the selector", async () => {
+      mockedGhExec.mockResolvedValue("");
+      await expect(
+        gistCommand(["delete", "-y", "abc1230000000000000000000000000a"]),
+      ).rejects.toThrow(/-y/);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
   });
 
   describe("clone", () => {
@@ -898,6 +974,22 @@ describe("gistCommand", () => {
       mockedGhExec.mockResolvedValue("");
       await gistCommand(["clone", "abc1230000000000000000000000000a"]);
       expect(mockedGhExec.mock.calls[0]![1]).toBeUndefined();
+    });
+
+    it("rejects an unknown flag and never reaches gh", async () => {
+      mockedGhExec.mockResolvedValue("");
+      await expect(
+        gistCommand(["clone", "--depth=1", "abc1230000000000000000000000000a"]),
+      ).rejects.toThrow(/--depth/);
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it("rejects a single-dash flag rather than treating it as the selector", async () => {
+      mockedGhExec.mockResolvedValue("");
+      await expect(
+        gistCommand(["clone", "-q", "abc1230000000000000000000000000a"]),
+      ).rejects.toThrow(/-q/);
+      expect(mockedGhExec).not.toHaveBeenCalled();
     });
   });
 
@@ -1026,6 +1118,15 @@ describe("gistCommand", () => {
       await expect(
         gistCommand(["create", "--filename", "foo.txt", "--public"]),
       ).rejects.toThrow(AxiError);
+    });
+
+    it("rejects an empty stdin read and never creates an empty gist", async () => {
+      mockedIsStdinTTY.mockReturnValue(false);
+      mockedReadStdin.mockResolvedValue("");
+      await expect(
+        gistCommand(["create", "--filename", "foo.txt", "--public"]),
+      ).rejects.toThrow(/stdin/);
+      expect(mockedGhExecWithStdin).not.toHaveBeenCalled();
     });
 
     it("rejects mixing --filename with positional paths", async () => {
@@ -1381,6 +1482,106 @@ describe("gistCommand", () => {
       mockedGhJson.mockResolvedValue(gistDetail());
       const result = await gistCommand(["view", GIST_ID]);
       expect(result).toContain("help[");
+    });
+
+    // ── Unknown flag rejection ──────────────────────────────────────────────
+
+    it("rejects an unknown flag instead of silently degrading the result", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      await expect(
+        gistCommand(["view", GIST_ID, "--ful"]),
+      ).rejects.toThrow(/--ful/);
+      expect(mockedGhJson).not.toHaveBeenCalled();
+    });
+
+    it("accepts every documented boolean flag", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      const result = await gistCommand(["view", GIST_ID, "--full", "-r"]);
+      expect(result).toContain("ring.erl");
+    });
+
+    // ── GitHub API server-side truncation ───────────────────────────────────
+
+    it("surfaces a note and raw_url when the API truncated the file", async () => {
+      mockedGhJson.mockResolvedValue(
+        gistDetail({
+          files: {
+            "huge.txt": {
+              filename: "huge.txt",
+              size: 5_000_000,
+              content: "partial bytes",
+              truncated: true,
+              raw_url: "https://gist.githubusercontent.com/octocat/raw/huge.txt",
+            },
+          },
+        }),
+      );
+      const result = await gistCommand(["view", GIST_ID]);
+      expect(result).toContain("truncated by the GitHub API");
+      expect(result).toContain(
+        "https://gist.githubusercontent.com/octocat/raw/huge.txt",
+      );
+    });
+
+    // --full cannot undo a server-side cap; claiming "no truncation" there
+    // would be a silent lie about missing bytes.
+    it("keeps the API truncation note under --full", async () => {
+      mockedGhJson.mockResolvedValue(
+        gistDetail({
+          files: {
+            "huge.txt": {
+              filename: "huge.txt",
+              size: 5_000_000,
+              content: "partial bytes",
+              truncated: true,
+              raw_url: "https://gist.githubusercontent.com/octocat/raw/huge.txt",
+            },
+          },
+        }),
+      );
+      const result = await gistCommand(["view", GIST_ID, "--full"]);
+      expect(result).toContain("truncated by the GitHub API");
+    });
+
+    it("still notes API truncation when raw_url is absent", async () => {
+      mockedGhJson.mockResolvedValue(
+        gistDetail({
+          files: {
+            "huge.txt": {
+              filename: "huge.txt",
+              size: 5_000_000,
+              content: "partial bytes",
+              truncated: true,
+            },
+          },
+        }),
+      );
+      const result = await gistCommand(["view", GIST_ID]);
+      expect(result).toContain("truncated by the GitHub API");
+    });
+
+    it("omits the API truncation note when truncated is false", async () => {
+      mockedGhJson.mockResolvedValue(gistDetail());
+      const result = await gistCommand(["view", GIST_ID]);
+      expect(result).not.toContain("truncated by the GitHub API");
+    });
+
+    it("surfaces the API truncation note in the -f single-file view", async () => {
+      mockedGhJson.mockResolvedValue(
+        gistDetail({
+          files: {
+            "huge.txt": {
+              filename: "huge.txt",
+              size: 5_000_000,
+              content: "partial bytes",
+              truncated: true,
+              raw_url: "https://gist.githubusercontent.com/octocat/raw/huge.txt",
+            },
+          },
+        }),
+      );
+      const result = await gistCommand(["view", GIST_ID, "-f", "huge.txt"]);
+      expect(result).toContain("truncated by the GitHub API");
     });
   });
 });

--- a/test/gistSelector.test.ts
+++ b/test/gistSelector.test.ts
@@ -31,9 +31,9 @@ describe("gistIdFromSelector", () => {
     });
 
     it("tolerates a trailing slash", () => {
-      expect(
-        gistIdFromSelector(`https://gist.github.com/OWNER/${ID}/`),
-      ).toBe(ID);
+      expect(gistIdFromSelector(`https://gist.github.com/OWNER/${ID}/`)).toBe(
+        ID,
+      );
     });
 
     // gh's own GistIDFromURL takes path segment [2], which yields "OWNER" for
@@ -67,9 +67,9 @@ describe("gistIdFromSelector", () => {
     });
 
     it("accepts gist.github.com by default", () => {
-      expect(
-        gistIdFromSelector(`https://gist.github.com/OWNER/${ID}`),
-      ).toBe(ID);
+      expect(gistIdFromSelector(`https://gist.github.com/OWNER/${ID}`)).toBe(
+        ID,
+      );
     });
 
     it("accepts github.com by default", () => {

--- a/test/gistSelector.test.ts
+++ b/test/gistSelector.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { gistIdFromSelector } from "../src/gistSelector.js";
+import { AxiError } from "../src/errors.js";
+
+const ID = "5b0e0062eb8e9654adad7bb1d81cc75f";
+
+afterEach(() => {
+  delete process.env["GH_HOST"];
+});
+
+describe("gistIdFromSelector", () => {
+  describe("bare ids", () => {
+    it("returns a bare gist id unchanged", () => {
+      expect(gistIdFromSelector(ID)).toBe(ID);
+    });
+
+    it("accepts a short numeric id", () => {
+      expect(gistIdFromSelector("1234")).toBe("1234");
+    });
+  });
+
+  describe("urls", () => {
+    it("extracts the id from an owner-scoped gist url", () => {
+      expect(gistIdFromSelector(`https://gist.github.com/OWNER/${ID}`)).toBe(
+        ID,
+      );
+    });
+
+    it("extracts the id from an ownerless gist url", () => {
+      expect(gistIdFromSelector(`https://gist.github.com/${ID}`)).toBe(ID);
+    });
+
+    it("tolerates a trailing slash", () => {
+      expect(
+        gistIdFromSelector(`https://gist.github.com/OWNER/${ID}/`),
+      ).toBe(ID);
+    });
+
+    // gh's own GistIDFromURL takes path segment [2], which yields "OWNER" for
+    // this GHE shape. Taking the last segment is correct for every shape.
+    it("extracts the id from a GHE /gist/OWNER/ID url", () => {
+      process.env["GH_HOST"] = "ghe.example.com";
+      expect(
+        gistIdFromSelector(`https://ghe.example.com/gist/OWNER/${ID}`),
+      ).toBe(ID);
+    });
+
+    it("accepts the bare configured host without a gist subdomain", () => {
+      process.env["GH_HOST"] = "ghe.example.com";
+      expect(gistIdFromSelector(`https://ghe.example.com/${ID}`)).toBe(ID);
+    });
+  });
+
+  describe("host validation", () => {
+    it("rejects a url pointing at a different host than configured", () => {
+      process.env["GH_HOST"] = "ghe.example.com";
+      expect(() =>
+        gistIdFromSelector(`https://gist.github.com/OWNER/${ID}`),
+      ).toThrow(AxiError);
+    });
+
+    it("names the configured host in the mismatch error", () => {
+      process.env["GH_HOST"] = "ghe.example.com";
+      expect(() =>
+        gistIdFromSelector(`https://gist.github.com/OWNER/${ID}`),
+      ).toThrow(/ghe\.example\.com/);
+    });
+
+    it("accepts gist.github.com by default", () => {
+      expect(
+        gistIdFromSelector(`https://gist.github.com/OWNER/${ID}`),
+      ).toBe(ID);
+    });
+
+    it("accepts github.com by default", () => {
+      expect(gistIdFromSelector(`https://github.com/OWNER/${ID}`)).toBe(ID);
+    });
+  });
+
+  describe("invalid input", () => {
+    it("rejects an empty selector", () => {
+      expect(() => gistIdFromSelector("")).toThrow(AxiError);
+    });
+
+    it("rejects a whitespace-only selector", () => {
+      expect(() => gistIdFromSelector("   ")).toThrow(AxiError);
+    });
+
+    it("rejects a url with no id segment", () => {
+      expect(() => gistIdFromSelector("https://gist.github.com/")).toThrow(
+        AxiError,
+      );
+    });
+
+    it("rejects a selector containing whitespace", () => {
+      expect(() => gistIdFromSelector("abc def")).toThrow(AxiError);
+    });
+
+    it("throws VALIDATION_ERROR for bad input", () => {
+      try {
+        gistIdFromSelector("");
+        expect.unreachable("should have thrown");
+      } catch (error) {
+        expect((error as AxiError).code).toBe("VALIDATION_ERROR");
+      }
+    });
+  });
+});

--- a/test/gistSelector.test.ts
+++ b/test/gistSelector.test.ts
@@ -105,4 +105,53 @@ describe("gistIdFromSelector", () => {
       }
     });
   });
+
+  // A bare selector is interpolated into the `/gists/<id>` API path, so it must
+  // be charset-validated (finding: unvalidated-bare-id).
+  describe("bare id charset validation", () => {
+    it("rejects a bare id containing a slash", () => {
+      expect(() => gistIdFromSelector("abc/def")).toThrow(AxiError);
+    });
+
+    it("rejects a dot-segment traversal attempt", () => {
+      expect(() => gistIdFromSelector("..")).toThrow(AxiError);
+    });
+
+    it("rejects a bare id with a path-traversal payload", () => {
+      expect(() => gistIdFromSelector("../repos/owner/repo")).toThrow(AxiError);
+    });
+
+    it("throws VALIDATION_ERROR (not a raw error) for a bad bare id", () => {
+      try {
+        gistIdFromSelector("bad/id");
+        expect.unreachable("should have thrown");
+      } catch (error) {
+        expect((error as AxiError).code).toBe("VALIDATION_ERROR");
+      }
+    });
+
+    it("rejects a url whose last segment is not a valid id", () => {
+      expect(() =>
+        gistIdFromSelector("https://gist.github.com/OWNER/bad..id"),
+      ).toThrow(AxiError);
+    });
+  });
+
+  // A malformed URL must surface as a structured VALIDATION_ERROR, not a raw
+  // TypeError from new URL() (finding: unguarded-url-parse).
+  describe("malformed url handling", () => {
+    it("throws AxiError for a URL with no host", () => {
+      expect(() => gistIdFromSelector("https://")).toThrow(AxiError);
+    });
+
+    it("surfaces VALIDATION_ERROR (not a raw TypeError) for a malformed URL", () => {
+      try {
+        gistIdFromSelector("https://");
+        expect.unreachable("should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AxiError);
+        expect((error as AxiError).code).toBe("VALIDATION_ERROR");
+      }
+    });
+  });
 });

--- a/test/help-examples.test.ts
+++ b/test/help-examples.test.ts
@@ -11,6 +11,7 @@ import { SECRET_HELP } from "../src/commands/secret.js";
 import { VARIABLE_HELP } from "../src/commands/variable.js";
 import { SEARCH_HELP } from "../src/commands/search.js";
 import { API_HELP } from "../src/commands/api.js";
+import { GIST_HELP } from "../src/commands/gist.js";
 import { TOP_HELP } from "../src/cli.js";
 
 /**
@@ -57,6 +58,7 @@ describe("Help output includes examples for every command family", () => {
   assertHelpHasExamples("VARIABLE_HELP", VARIABLE_HELP);
   assertHelpHasExamples("SEARCH_HELP", SEARCH_HELP);
   assertHelpHasExamples("API_HELP", API_HELP);
+  assertHelpHasExamples("GIST_HELP", GIST_HELP);
 });
 
 describe("--body-file discoverability", () => {

--- a/test/help-examples.test.ts
+++ b/test/help-examples.test.ts
@@ -70,22 +70,24 @@ describe("--body-file discoverability", () => {
 });
 
 describe("GIST_HELP subcommands", () => {
-  // Pin the subcommand count and names so a rebase that adds/removes gist
+  // Pin the subcommand count and names so a change that adds/removes gist
   // subcommands turns this into a visible test failure rather than a silent
-  // doc discrepancy. Post-rebase this branch sits on top of the create and
-  // delete/clone slices, so the family ships five subcommands.
-  it("declares exactly 5 subcommands", () => {
-    expect(GIST_HELP).toContain("subcommands[5]:");
+  // doc discrepancy. With edit + rename merged the gist family is complete at
+  // seven subcommands.
+  it("declares exactly 7 subcommands", () => {
+    expect(GIST_HELP).toContain("subcommands[7]:");
   });
 
-  it("names list, view, create, delete, and clone as the five subcommands", () => {
-    // The names appear on the indented line after "subcommands[5]:".
+  it("names all seven subcommands: list, view, edit, rename, create, delete, clone", () => {
+    // The names appear on the indented line after "subcommands[7]:".
     const lines = GIST_HELP.split("\n");
-    const headerIdx = lines.findIndex((l) => l.includes("subcommands[5]:"));
+    const headerIdx = lines.findIndex((l) => l.includes("subcommands[7]:"));
     expect(headerIdx).toBeGreaterThan(-1);
     const namesCombined = lines.slice(headerIdx, headerIdx + 2).join(" ");
     expect(namesCombined).toContain("list");
     expect(namesCombined).toContain("view");
+    expect(namesCombined).toContain("edit");
+    expect(namesCombined).toContain("rename");
     expect(namesCombined).toContain("create");
     expect(namesCombined).toContain("delete");
     expect(namesCombined).toContain("clone");

--- a/test/help-examples.test.ts
+++ b/test/help-examples.test.ts
@@ -69,6 +69,29 @@ describe("--body-file discoverability", () => {
   });
 });
 
+describe("GIST_HELP subcommands", () => {
+  // Pin the subcommand count and names so a rebase that adds/removes gist
+  // subcommands turns this into a visible test failure rather than a silent
+  // doc discrepancy. Post-rebase this branch sits on top of the create and
+  // delete/clone slices, so the family ships five subcommands.
+  it("declares exactly 5 subcommands", () => {
+    expect(GIST_HELP).toContain("subcommands[5]:");
+  });
+
+  it("names list, view, create, delete, and clone as the five subcommands", () => {
+    // The names appear on the indented line after "subcommands[5]:".
+    const lines = GIST_HELP.split("\n");
+    const headerIdx = lines.findIndex((l) => l.includes("subcommands[5]:"));
+    expect(headerIdx).toBeGreaterThan(-1);
+    const namesCombined = lines.slice(headerIdx, headerIdx + 2).join(" ");
+    expect(namesCombined).toContain("list");
+    expect(namesCombined).toContain("view");
+    expect(namesCombined).toContain("create");
+    expect(namesCombined).toContain("delete");
+    expect(namesCombined).toContain("clone");
+  });
+});
+
 describe("secret --env discoverability", () => {
   it("documents the --env/-e environment scope in secret help", () => {
     expect(SECRET_HELP).toContain("--env/-e <environment>");

--- a/test/integration/gist.integration.test.ts
+++ b/test/integration/gist.integration.test.ts
@@ -1,20 +1,48 @@
 /**
  * Integration tests for gist edit operations.
  *
- * These tests call real `gh` against a real GitHub gist, so they require:
+ * These tests drive the real `gistCommand` router against a real GitHub gist,
+ * so they require:
  *   - `gh` installed and authenticated with the `gist` scope
  *   - Network access
  *
  * Gate: run only when GIST_INTEGRATION=1 is set in the environment.
  * Run locally: GIST_INTEGRATION=1 pnpm test test/integration/gist.integration.test.ts
  *
- * Each test asserts the real before/after gist content to catch argv bugs
- * that unit tests (with mocked gh) cannot see — exactly the class of bug
- * found in review round 2 (blocker 1: missing `-` source, blocker 2:
- * desc-only on multi-file gist, blocker 3: add-from-stdin unimplemented).
+ * Critically, these go THROUGH `gistCommand` (not hand-built ghExec argv) so
+ * they exercise gh-axi's own flag routing end-to-end against real gh. The
+ * earlier version called ghExec directly and therefore validated gh's argv
+ * contract but none of gh-axi's routing — which is exactly how the TTY-inference
+ * bug (--remove rejected, --add <path> misrouted to stdin) slipped through.
+ *
+ * Only the stdin *source* is mocked (`readStdin`/`isStdinTTY`): the content a
+ * user would pipe is supplied via the mock, while the routing and the real gh
+ * invocation stay live.
  */
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { ghExec, ghExecWithStdin, ghJson } from "../../src/gh.js";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from "vitest";
+import { writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ghExec, ghJson } from "../../src/gh.js";
+import { gistCommand } from "../../src/commands/gist.js";
+import { isStdinTTY, readStdin } from "../../src/stdin.js";
+
+// Mock only the stdin source. gh itself stays real.
+vi.mock("../../src/stdin.js", () => ({
+  isStdinTTY: vi.fn(() => false),
+  readStdin: vi.fn(async () => ""),
+}));
+
+const mockedReadStdin = vi.mocked(readStdin);
+const mockedIsStdinTTY = vi.mocked(isStdinTTY);
 
 const RUN = process.env["GIST_INTEGRATION"] === "1";
 
@@ -59,6 +87,15 @@ describe.skipIf(!RUN)(
   () => {
     let gistId: string;
 
+    beforeEach(() => {
+      // Reset call history so per-test call assertions are isolated, then set
+      // the default: non-TTY stdin (the agent context) and no piped content.
+      mockedIsStdinTTY.mockClear();
+      mockedReadStdin.mockClear();
+      mockedIsStdinTTY.mockReturnValue(false);
+      mockedReadStdin.mockResolvedValue("");
+    });
+
     beforeAll(async () => {
       // Create a secret scratch gist with two files so we can test multi-file
       // operations (e.g., the desc-only blocker only reproduces on multi-file gists).
@@ -76,16 +113,12 @@ describe.skipIf(!RUN)(
       }
     });
 
-    it("replace file content from stdin (blocker 1 regression)", async () => {
-      // Verify the '-' source positional is required and present.
-      // Without '-', gh ignores piped bytes and opens $EDITOR instead.
+    it("replace file content from stdin via gistCommand (blocker 1 regression)", async () => {
       const before = await fetchGist(gistId);
       expect(before.files["notes.txt"]?.content).toBe("original content");
 
-      await ghExecWithStdin(
-        ["gist", "edit", gistId, "-", "--filename", "notes.txt"],
-        "replaced by integration test",
-      );
+      mockedReadStdin.mockResolvedValue("replaced by integration test");
+      await gistCommand(["edit", gistId, "--filename", "notes.txt"]);
 
       const after = await fetchGist(gistId);
       console.log(
@@ -99,21 +132,13 @@ describe.skipIf(!RUN)(
       );
     });
 
-    it("update description only via gh api PATCH (blocker 2 regression)", async () => {
-      // Verify the API PATCH route works on a multi-file gist without prompting.
-      // `gh gist edit <id> --desc <text>` on a 2-file gist errors "unsure what
-      // file to edit" — the API route bypasses that entirely.
+    it("update description only via gistCommand (blocker 2 regression)", async () => {
+      // desc-only on a 2-file gist must not prompt; gistCommand routes it
+      // through the REST API PATCH.
       const before = await fetchGist(gistId);
       const descBefore = before.description;
 
-      await ghExec([
-        "api",
-        "-X",
-        "PATCH",
-        `/gists/${gistId}`,
-        "-f",
-        "description=updated by integration test",
-      ]);
+      await gistCommand(["edit", gistId, "--desc", "updated by integration test"]);
 
       const after = await fetchGist(gistId);
       console.log(`  description before: ${descBefore}`);
@@ -121,15 +146,14 @@ describe.skipIf(!RUN)(
       expect(after.description).toBe("updated by integration test");
     });
 
-    it("add a new file from piped stdin (blocker 3 regression)", async () => {
-      // Verify --add <name> - reads from stdin and creates a new file.
+    it("add a new file from piped stdin via gistCommand (blocker 3 regression)", async () => {
+      // --add <name> - reads from stdin and creates a new file. The explicit
+      // `-` sentinel is what selects the stdin path.
       const before = await fetchGist(gistId);
       expect(before.files["brand-new.txt"]).toBeUndefined();
 
-      await ghExecWithStdin(
-        ["gist", "edit", gistId, "--add", "brand-new.txt", "-"],
-        "added from stdin by integration test",
-      );
+      mockedReadStdin.mockResolvedValue("added from stdin by integration test");
+      await gistCommand(["edit", gistId, "--add", "brand-new.txt", "-"]);
 
       const after = await fetchGist(gistId);
       console.log(`  brand-new.txt before: (not present)`);
@@ -141,12 +165,38 @@ describe.skipIf(!RUN)(
       );
     });
 
-    it("remove a file", async () => {
-      // Verify the remove path works.
+    it("add a file from disk via gistCommand in non-TTY context (bug #1b regression)", async () => {
+      // Without an explicit `-`, --add must read from disk even though the
+      // agent stdin is non-TTY. The old code misrouted this to the stdin branch
+      // and never read the file.
+      const diskName = `gh-axi-gist-disk-${gistId}.txt`;
+      const before = await fetchGist(gistId);
+      expect(before.files[diskName]).toBeUndefined();
+
+      const diskPath = join(tmpdir(), diskName);
+      await writeFile(diskPath, "added from disk by integration test", "utf8");
+      try {
+        await gistCommand(["edit", gistId, "--add", diskPath]);
+      } finally {
+        await rm(diskPath, { force: true });
+      }
+
+      const after = await fetchGist(gistId);
+      const added = Object.values(after.files).find(
+        (f) => f.content === "added from disk by integration test",
+      );
+      console.log(`  from-disk file present after: ${added ? "yes" : "no"}`);
+      expect(added).toBeDefined();
+      expect(mockedReadStdin).not.toHaveBeenCalled();
+    });
+
+    it("remove a file via gistCommand in non-TTY context (bug #1a regression)", async () => {
+      // The old TTY-inference rejected --remove in non-TTY (agent) contexts.
+      // Through gistCommand it must simply remove the file.
       const before = await fetchGist(gistId);
       expect(before.files["brand-new.txt"]).toBeDefined();
 
-      await ghExec(["gist", "edit", gistId, "--remove", "brand-new.txt"]);
+      await gistCommand(["edit", gistId, "--remove", "brand-new.txt"]);
 
       const after = await fetchGist(gistId);
       console.log(`  brand-new.txt before: (present)`);

--- a/test/integration/gist.integration.test.ts
+++ b/test/integration/gist.integration.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Integration tests for gist edit operations.
+ *
+ * These tests call real `gh` against a real GitHub gist, so they require:
+ *   - `gh` installed and authenticated with the `gist` scope
+ *   - Network access
+ *
+ * Gate: run only when GIST_INTEGRATION=1 is set in the environment.
+ * Run locally: GIST_INTEGRATION=1 pnpm test test/integration/gist.integration.test.ts
+ *
+ * Each test asserts the real before/after gist content to catch argv bugs
+ * that unit tests (with mocked gh) cannot see — exactly the class of bug
+ * found in review round 2 (blocker 1: missing `-` source, blocker 2:
+ * desc-only on multi-file gist, blocker 3: add-from-stdin unimplemented).
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { ghExec, ghExecWithStdin, ghJson } from "../../src/gh.js";
+
+const RUN = process.env["GIST_INTEGRATION"] === "1";
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+interface GistFile {
+  filename: string;
+  content: string;
+}
+
+interface GistResponse {
+  id: string;
+  description: string;
+  files: Record<string, GistFile>;
+}
+
+async function createGist(
+  description: string,
+  files: Record<string, string>,
+): Promise<string> {
+  // Build the argv using repeated -f flags for gh api
+  const argv: string[] = ["api", "-X", "POST", "/gists", "-f", `description=${description}`];
+  for (const [name, content] of Object.entries(files)) {
+    argv.push("-f", `files[${name}][content]=${content}`);
+  }
+  const result = await ghJson<GistResponse>(argv);
+  return result.id;
+}
+
+async function fetchGist(id: string): Promise<GistResponse> {
+  return ghJson<GistResponse>(["api", `/gists/${id}`]);
+}
+
+async function deleteGist(id: string): Promise<void> {
+  await ghExec(["api", "-X", "DELETE", `/gists/${id}`]);
+}
+
+// ── test suite ─────────────────────────────────────────────────────────────
+
+describe.skipIf(!RUN)(
+  "gist edit — integration (real gh, real gist, GIST_INTEGRATION=1)",
+  () => {
+    let gistId: string;
+
+    beforeAll(async () => {
+      // Create a secret scratch gist with two files so we can test multi-file
+      // operations (e.g., the desc-only blocker only reproduces on multi-file gists).
+      gistId = await createGist("gh-axi integration test scratch", {
+        "notes.txt": "original content",
+        "second.txt": "second file original",
+      });
+      console.log(`Created scratch gist: ${gistId}`);
+    });
+
+    afterAll(async () => {
+      if (gistId) {
+        await deleteGist(gistId);
+        console.log(`Deleted scratch gist: ${gistId}`);
+      }
+    });
+
+    it("replace file content from stdin (blocker 1 regression)", async () => {
+      // Verify the '-' source positional is required and present.
+      // Without '-', gh ignores piped bytes and opens $EDITOR instead.
+      const before = await fetchGist(gistId);
+      expect(before.files["notes.txt"]?.content).toBe("original content");
+
+      await ghExecWithStdin(
+        ["gist", "edit", gistId, "-", "--filename", "notes.txt"],
+        "replaced by integration test",
+      );
+
+      const after = await fetchGist(gistId);
+      console.log(
+        `  notes.txt before: ${before.files["notes.txt"]?.content ?? "n/a"}`,
+      );
+      console.log(
+        `  notes.txt after:  ${after.files["notes.txt"]?.content ?? "n/a"}`,
+      );
+      expect(after.files["notes.txt"]?.content).toBe(
+        "replaced by integration test",
+      );
+    });
+
+    it("update description only via gh api PATCH (blocker 2 regression)", async () => {
+      // Verify the API PATCH route works on a multi-file gist without prompting.
+      // `gh gist edit <id> --desc <text>` on a 2-file gist errors "unsure what
+      // file to edit" — the API route bypasses that entirely.
+      const before = await fetchGist(gistId);
+      const descBefore = before.description;
+
+      await ghExec([
+        "api",
+        "-X",
+        "PATCH",
+        `/gists/${gistId}`,
+        "-f",
+        "description=updated by integration test",
+      ]);
+
+      const after = await fetchGist(gistId);
+      console.log(`  description before: ${descBefore}`);
+      console.log(`  description after:  ${after.description}`);
+      expect(after.description).toBe("updated by integration test");
+    });
+
+    it("add a new file from piped stdin (blocker 3 regression)", async () => {
+      // Verify --add <name> - reads from stdin and creates a new file.
+      const before = await fetchGist(gistId);
+      expect(before.files["brand-new.txt"]).toBeUndefined();
+
+      await ghExecWithStdin(
+        ["gist", "edit", gistId, "--add", "brand-new.txt", "-"],
+        "added from stdin by integration test",
+      );
+
+      const after = await fetchGist(gistId);
+      console.log(`  brand-new.txt before: (not present)`);
+      console.log(
+        `  brand-new.txt after:  ${after.files["brand-new.txt"]?.content ?? "n/a"}`,
+      );
+      expect(after.files["brand-new.txt"]?.content).toBe(
+        "added from stdin by integration test",
+      );
+    });
+
+    it("remove a file", async () => {
+      // Verify the remove path works.
+      const before = await fetchGist(gistId);
+      expect(before.files["brand-new.txt"]).toBeDefined();
+
+      await ghExec(["gist", "edit", gistId, "--remove", "brand-new.txt"]);
+
+      const after = await fetchGist(gistId);
+      console.log(`  brand-new.txt before: (present)`);
+      console.log(
+        `  brand-new.txt after:  ${after.files["brand-new.txt"] === undefined ? "(removed)" : "still present"}`,
+      );
+      expect(after.files["brand-new.txt"]).toBeUndefined();
+    });
+  },
+);

--- a/test/integration/gist.integration.test.ts
+++ b/test/integration/gist.integration.test.ts
@@ -64,7 +64,14 @@ async function createGist(
   files: Record<string, string>,
 ): Promise<string> {
   // Build the argv using repeated -f flags for gh api
-  const argv: string[] = ["api", "-X", "POST", "/gists", "-f", `description=${description}`];
+  const argv: string[] = [
+    "api",
+    "-X",
+    "POST",
+    "/gists",
+    "-f",
+    `description=${description}`,
+  ];
   for (const [name, content] of Object.entries(files)) {
     argv.push("-f", `files[${name}][content]=${content}`);
   }
@@ -138,7 +145,12 @@ describe.skipIf(!RUN)(
       const before = await fetchGist(gistId);
       const descBefore = before.description;
 
-      await gistCommand(["edit", gistId, "--desc", "updated by integration test"]);
+      await gistCommand([
+        "edit",
+        gistId,
+        "--desc",
+        "updated by integration test",
+      ]);
 
       const after = await fetchGist(gistId);
       console.log(`  description before: ${descBefore}`);


### PR DESCRIPTION
## Intent

Add a first-class gist command family to gh-axi: list, view, create, edit, rename, delete, clone. Reads go through gh api /gists, writes through gh gist; handlers are user-scoped (no --repo, which gh gist rejects). Follows AXI principles: minimal default schemas with --fields, head-slice content truncation with --full, definitive empty states, structured errors with nonzero exit. Selector parsing is order-insensitive and charset-validated before hitting the /gists/<id> API path; gist edit uses gh's explicit '-' stdin sentinel (TTY-independent) so --add <path> (disk), --add <name> - (stdin), and --remove work correctly in the non-TTY agent context. Ships unit tests plus gated real-gh integration tests routed through gistCommand. Preserves the per-slice commit history (5 tracer-bullet slices + 1 review-fix commit).

## What Changed

- New `gist` command family in `src/commands/gist.ts`, registered in `src/cli.ts` (top-level help now lists 15 commands). Reads go through `gh api /gists` and writes through `gh gist`; handlers are user-scoped and never forward the repo context, since `gh gist`/`gh api /gists` reject `--repo`. Follows the existing AXI conventions: minimal default schemas with `--fields`, head-sliced content with `--full`, definitive empty states, and structured errors with nonzero exit.
- `src/gistSelector.ts` parses gist selectors order-insensitively from bare IDs or URLs and charset-validates them before they reach the `/gists/<id>` path. `gist edit` uses gh's explicit `-` stdin sentinel so `--add <path>` (disk), `--add <name> -` (stdin), and `--remove` all work in a non-TTY context; every subcommand rejects unknown flags, boolean `=value` forms, and empty piped stdin rather than silently degrading. `gist view` surfaces a note when the API reports a file as truncated.
- Docs and discovery updated: README command table and examples, generated `skills/gh-axi/SKILL.md` via `src/skill.ts`, and gist entries in `src/suggestions.ts`. Tests add unit coverage for the commands and selector, help-example checks, and `GIST_INTEGRATION`-gated real-`gh` integration tests routed through `gistCommand`.

## Risk Assessment

✅ Low: The branch is additive and well-bounded (a new user-scoped command family with no behavioral changes to existing commands), both round-2 findings are fixed correctly with targeted tests and no regressions across the 28 existing edit-suite invocations, and the only remaining issue is a misleading error message on an already-loud, non-destructive failure path.

## Testing

Ran the full unit suite (877 passed, 5 skipped by the integration gate), then enabled the gate and ran the 5 real-gh integration tests, which passed against a live scratch gist routed through gistCommand. The primary evidence is a CLI transcript driving the real binary through the complete gist lifecycle against real GitHub gists — create, list, view, edit (all four ops), rename, clone, delete, plus a 404 confirming teardown — alongside truncation with and without --full, a 12-case structured-error matrix all exiting non-zero, repo-context isolation checks, and a stub-gh render of the empty state. Two harness problems were mine and were fixed and re-run (a relative tsx path broke the clone step; one --public list hit a transient api.github.com timeout). One genuine environment limit: gist clone cannot use ssh here since gh is set to the ssh protocol with no usable key — raw `gh gist clone` fails identically — so I demonstrated clone over https via an ephemeral GH_CONFIG_DIR and a short-lived public scratch gist, leaving user config untouched. This change is CLI-only with no rendered UI surface, so no screenshots apply; the terminal transcripts are the end-user surface. All scratch gists were deleted, temp dirs removed, and the worktree is clean.

<details>
<summary>Evidence: Full gist CLI lifecycle transcript (create → list → view → edit → rename → clone → delete, truncation, 12 structured errors)</summary>

```text
##############################################################
# 0. HELP — the command family surface
##############################################################

==============================================================
$ gh-axi gist --help
--------------------------------------------------------------
usage: gh-axi gist <subcommand> [flags]
subcommands[7]:
  list, view <id|url>, edit <id|url>, rename <id|url> <old> <new>, create, delete <id|url>, clone <id|url>
flags{list}:
  --limit <n> (default 100), --public, --secret, --fields <field,...>
flags{view}:
  --files (file names only), -f/--filename <name> (single file), --full (no truncation), -r/--raw (no-op), -w/--web (rejected)
flags{edit}:
  --filename/-f <name> (replace from piped stdin), --add/-a <path> (from disk) or --add/-a <name> - (from piped stdin), --remove/-r <name>, --desc/-d <text>
flags{create}:
  --public (required, mutually exclusive with --secret)
  --secret (required, mutually exclusive with --public)
  --file <path> (repeatable), --filename <name> (for piped content)
  -d/--desc <text>
examples:
  gh-axi gist list
  gh-axi gist list --public --limit 20
  gh-axi gist list --fields url,owner,created
  gh-axi gist view 5b0e0062eb8e9654adad7bb1d81cc75f
  gh-axi gist view https://gist.github.com/octocat/5b0e0062eb8e9654adad7bb1d81cc75f
  gh-axi gist view 5b0e0062eb8e9654adad7bb1d81cc75f --files
  echo 'new content' | gh-axi gist edit <id|url> --filename notes.md
  echo 'new file' | gh-axi gist edit <id|url> --add new.txt -
  gh-axi gist edit <id|url> --add ./local.txt
  gh-axi gist edit <id|url> --remove old-file.txt --desc "updated description"
  gh-axi gist rename <id|url> old.txt new.txt
  gh-axi gist create notes.md --public --desc "My notes"
  gh-axi gist create --file a.py --file b.py --secret
  echo "content" | gh-axi gist create --filename hello.txt --public
  gh-axi gist delete <id|url>
  gh-axi gist clone <id|url>(node:75836) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit 0]

##############################################################
# 1. CREATE — explicit visibility required, stdin form
##############################################################

==============================================================
$ echo 'hello from the gh-axi gist family' | gh-axi gist create --filename hello.txt --secret --desc 'gh-axi e2e lifecycle gist'
--------------------------------------------------------------
(node:75846) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
created:
  id: 3c6521422a255f5cac2c7cbd5337a1ab
  url: "https://gist.github.com/bauti-defi/3c6521422a255f5cac2c7cbd5337a1ab"
  visibility: secret
help[2]:
  a secret gist is unlisted, not private — anyone with the URL can read it
  Run `gh-axi gist list` to see all your gists
[exit 0]

>>> lifecycle gist id captured: 3c6521422a255f5cac2c7cbd5337a1ab

##############################################################
# 2. LIST — minimal default schema, --fields, --limit, filters
##############################################################

==============================================================
$ gh-axi gist list --limit 5
--------------------------------------------------------------
(node:75881) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
count: 5 (showing first 5)
gists[5]{id,description,files,visibility}:
  3c6521422a255f5cac2c7cbd5337a1ab,gh-axi e2e lifecycle gist,1,secret
  b2770d2f971fe6753aaadc1c37a03a21,"twitterapi.io — filter rule silently stops polling while reporting is_effect=1 (56h outage, 2026-07-22/24)",1,secret
  ffc8fc22fada6cce950c7f0391c32450,"twitterapi.io — filter rule silently stops polling while reporting is_effect=1 (56h outage, 2026-07-22/24)",1,secret
  1732a9c34b0bc56870c2d0d18d837dcb,DAMM ETH Algo Fund — short + long descriptions,1,secret
  b0725291ae286faa2d50e64ff3b0327b,DAMM-ETH Algo Fund — permission upgrade walkthrough (internal audit),1,secret
help[2]:
  Run `gh-axi gist view <id>` to view a gist's files and metadata
  Run `gh-axi gist list --fields url,owner,created` to add extra fields
[exit 0]

==============================================================
$ gh-axi gist list --limit 3 --fields url,owner,created
--------------------------------------------------------------
(node:75900) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
count: 3 (showing first 3)
gists[3]{id,description,files,visibility,url,owner,created}:
  3c6521422a255f5cac2c7cbd5337a1ab,gh-axi e2e lifecycle gist,1,secret,"https://gist.github.com/bauti-defi/3c6521422a255f5cac2c7cbd5337a1ab",bauti-defi,just now
  b2770d2f971fe6753aaadc1c37a03a21,"twitterapi.io — filter rule silently stops polling while reporting is_effect=1 (56h outage, 2026-07-22/24)",1,secret,"https://gist.github.com/bauti-defi/b2770d2f971fe6753aaadc1c37a03a21",bauti-defi,2d ago
  ffc8fc22fada6cce950c7f0391c32450,"twitterapi.io — filter rule silently stops polling while reporting is_effect=1 (56h outage, 2026-07-22/24)",1,secret,"https://gist.github.com/bauti-defi/ffc8fc22fada6cce950c7f0391c32450",bauti-defi,2d ago
help[2]:
  Run `gh-axi gist view <id>` to view a gist's files and metadata
  Run `gh-axi gist list --fields url,owner,created` to add extra fields
[exit 0]

==============================================================
$ gh-axi gist list --public --limit 3
--------------------------------------------------------------
(node:75921) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
error: "Get \"https://api.github.com/gists?per_page=100\": read tcp 192.168.0.17:53442->4.228.31.149:443: read: operation timed out"
code: UNKNOWN
[exit 1]

##############################################################
# 3. VIEW — metadata + content, bare id
##############################################################

==============================================================
$ gh-axi gist view 3c6521422a255f5cac2c7cbd5337a1ab
--------------------------------------------------------------
(node:76490) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
gist:
  id: 3c6521422a255f5cac2c7cbd5337a1ab
  description: gh-axi e2e lifecycle gist
  visibility: secret
  files: 1
  created: 2m ago
  updated: 2m ago
  comments: 0
  url: "https://gist.github.com/bauti-defi/3c6521422a255f5cac2c7cbd5337a1ab"
  owner: bauti-defi
files[1]{filename,size,content}:
  hello.txt,33 bytes,hello from the gh-axi gist family
help[2]:
  Run `gh-axi gist view 3c6521422a255f5cac2c7cbd5337a1ab --files` to list file names only
  Run `gh-axi gist list` to see all your gists
[exit 0]

##############################################################
# 4. VIEW — URL selector form (order-insensitive flags too)
##############################################################

==============================================================
$ gh-axi gist view https://gist.github.com/bauti-defi/3c6521422a255f5cac2c7cbd5337a1ab --files
--------------------------------------------------------------
(node:76509) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
files[1]{filename}:
  hello.txt
help[2]:
  Run `gh-axi gist view 3c6521422a255f5cac2c7cbd5337a1ab --files` to list file names only
  Run `gh-axi gist list` to see all your gists
[exit 0]

==============================================================
$ gh-axi gist view --files 3c6521422a255f5ca

... [21875 bytes truncated] ...

####################################
# 8. CLONE
##############################################################

==============================================================
$ gh-axi gist clone 3c6521422a255f5cac2c7cbd5337a1ab
--------------------------------------------------------------
/var/folders/l4/mbz859l97mlgc6t8lxrftjd40000gn/T/no-mistakes-evidence/01KYHSZ48820Z7AF7GVG62ASZZ/drive-gist-cli.sh: line 17: node_modules/.bin/tsx: No such file or directory
[exit 127]
--- cloned working tree ---
big.txt
create.out
from-disk.txt

##############################################################
# 9. STRUCTURED ERRORS — every one must exit non-zero
##############################################################

==============================================================
$ gh-axi gist create --filename x.txt
--------------------------------------------------------------
error: "gist create requires --public or --secret; neither was given\nA secret gist is unlisted (anyone with the URL can read it), not private."
code: VALIDATION_ERROR
(node:76845) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit 2]

==============================================================
$ gh-axi gist create --filename x.txt --public --secret
--------------------------------------------------------------
error: "--public and --secret are mutually exclusive"
code: VALIDATION_ERROR
(node:76863) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit 2]

==============================================================
$ gh-axi gist view 3c6521422a255f5cac2c7cbd5337a1ab --ful
--------------------------------------------------------------
error: "Unknown flag(s): --ful"
code: VALIDATION_ERROR
(node:76890) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit 2]

==============================================================
$ gh-axi gist view 3c6521422a255f5cac2c7cbd5337a1ab --full=true
--------------------------------------------------------------
error: "Unknown flag(s): --full=true"
code: VALIDATION_ERROR
(node:76906) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit 2]

==============================================================
$ gh-axi gist view 3c6521422a255f5cac2c7cbd5337a1ab -w
--------------------------------------------------------------
error: "-w/--web is not supported: opening a browser is a no-op in agent contexts"
code: VALIDATION_ERROR
(node:76923) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit 2]

==============================================================
$ gh-axi gist view ../../etc/passwd
--------------------------------------------------------------
error: "Invalid gist id: \"../../etc/passwd\""
code: VALIDATION_ERROR
help[1]: A gist id is alphanumeric; pass a bare id or a full gist URL
(node:76941) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit 2]

==============================================================
$ gh-axi gist view https://evil.example.com/octocat/abc123
--------------------------------------------------------------
error: "Gist URL host \"evil.example.com\" does not match the configured host \"github.com\""
code: VALIDATION_ERROR
(node:76957) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit 2]

==============================================================
$ gh-axi gist edit 3c6521422a255f5cac2c7cbd5337a1ab
--------------------------------------------------------------
error: "nothing to edit; pass --filename <name> with piped content, --add <path|name>, --remove <name>, or --desc <text>"
code: VALIDATION_ERROR
(node:76973) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit 2]

==============================================================
$ gh-axi gist edit 3c6521422a255f5cac2c7cbd5337a1ab --remove a.txt --dry-run
--------------------------------------------------------------
error: "Unknown flag(s): --dry-run"
code: VALIDATION_ERROR
(node:76989) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit 2]

==============================================================
$ gh-axi gist list --limitt 5
--------------------------------------------------------------
error: "Unknown flag(s): --limitt"
code: VALIDATION_ERROR
(node:77015) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit 2]

==============================================================
$ gh-axi gist list --limit abc
--------------------------------------------------------------
error: "--limit must be a positive integer, got: abc"
code: VALIDATION_ERROR
(node:77032) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit 2]

==============================================================
$ gh-axi gist bogus-subcommand
--------------------------------------------------------------
error: "Unknown subcommand: bogus-subcommand"
code: VALIDATION_ERROR
help[1]:
  Available subcommands: list, view, edit, rename, create, delete, clone
(node:77054) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit 0]

==============================================================
$ echo '' | gh-axi gist edit 3c6521422a255f5cac2c7cbd5337a1ab --filename renamed-hello.txt
--------------------------------------------------------------
(node:77071) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
error: no content received on stdin; nothing was piped
code: VALIDATION_ERROR
help[1]: "Example: echo 'content' | gh-axi gist edit <id|url> --filename <name>"
[exit 2]

##############################################################
# 10. DELETE — lifecycle teardown
##############################################################

==============================================================
$ gh-axi gist delete 3c6521422a255f5cac2c7cbd5337a1ab
--------------------------------------------------------------
(node:77089) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
deleted: 3c6521422a255f5cac2c7cbd5337a1ab
help[1]:
  Run `gh-axi gist list` to see remaining gists
[exit 0]

==============================================================
$ gh-axi gist view 3c6521422a255f5cac2c7cbd5337a1ab
--------------------------------------------------------------
(node:77110) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
error: "gh: Not Found (HTTP 404)"
code: NOT_FOUND
[exit 1]

>>> lifecycle gist 3c6521422a255f5cac2c7cbd5337a1ab deleted; the view above must fail NOT_FOUND.
```
</details>
<details>
<summary>Evidence: Gated real-gh integration test log (5/5 passed, shows before/after gist state per operation)</summary>

<code>notes.txt before: original content&#10;notes.txt after: replaced by integration test&#10;description before: gh-axi integration test scratch&#10;description after: updated by integration test&#10;brand-new.txt before: (not present)&#10;brand-new.txt after: added from stdin by integration test&#10;from-disk file present after: yes&#10;brand-new.txt before: (present)&#10;brand-new.txt after: (removed)&#10;&#10;Test Files 1 passed (1)&#10;Tests 5 passed (5)</code>

```text
$ vitest run test/integration/gist.integration.test.ts

 RUN  v3.2.4 /Users/bautista/.no-mistakes/worktrees/5a450c443633/01KYHSZ48820Z7AF7GVG62ASZZ

stdout | test/integration/gist.integration.test.ts > gist edit — integration (real gh, real gist, GIST_INTEGRATION=1)
Created scratch gist: 48d37483240972b28cc7f42ca1a4308c

stdout | test/integration/gist.integration.test.ts > gist edit — integration (real gh, real gist, GIST_INTEGRATION=1) > replace file content from stdin via gistCommand (blocker 1 regression)
  notes.txt before: original content
  notes.txt after:  replaced by integration test

stdout | test/integration/gist.integration.test.ts > gist edit — integration (real gh, real gist, GIST_INTEGRATION=1) > update description only via gistCommand (blocker 2 regression)
  description before: gh-axi integration test scratch
  description after:  updated by integration test

stdout | test/integration/gist.integration.test.ts > gist edit — integration (real gh, real gist, GIST_INTEGRATION=1) > add a new file from piped stdin via gistCommand (blocker 3 regression)
  brand-new.txt before: (not present)
  brand-new.txt after:  added from stdin by integration test

stdout | test/integration/gist.integration.test.ts > gist edit — integration (real gh, real gist, GIST_INTEGRATION=1) > add a file from disk via gistCommand in non-TTY context (bug #1b regression)
  from-disk file present after: yes

stdout | test/integration/gist.integration.test.ts > gist edit — integration (real gh, real gist, GIST_INTEGRATION=1) > remove a file via gistCommand in non-TTY context (bug #1a regression)
  brand-new.txt before: (present)
  brand-new.txt after:  (removed)

stdout | test/integration/gist.integration.test.ts > gist edit — integration (real gh, real gist, GIST_INTEGRATION=1)
Deleted scratch gist: 48d37483240972b28cc7f42ca1a4308c

 ✓ test/integration/gist.integration.test.ts (5 tests) 16174ms
   ✓ gist edit — integration (real gh, real gist, GIST_INTEGRATION=1) > replace file content from stdin via gistCommand (blocker 1 regression)  3133ms
   ✓ gist edit — integration (real gh, real gist, GIST_INTEGRATION=1) > update description only via gistCommand (blocker 2 regression)  1816ms
   ✓ gist edit — integration (real gh, real gist, GIST_INTEGRATION=1) > add a new file from piped stdin via gistCommand (blocker 3 regression)  3054ms
   ✓ gist edit — integration (real gh, real gist, GIST_INTEGRATION=1) > add a file from disk via gistCommand in non-TTY context (bug #1b regression)  3148ms
   ✓ gist edit — integration (real gh, real gist, GIST_INTEGRATION=1) > remove a file via gistCommand in non-TTY context (bug #1a regression)  3146ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  10:13:08
   Duration  16.54s (transform 103ms, setup 0ms, collect 120ms, tests 16.17s, environment 0ms, prepare 53ms)
```
</details>
<details>
<summary>Evidence: gist clone end-to-end over https (real clone, verified working tree + git remote)</summary>

<code>$ gh-axi gist clone 89518a33f5dae17c7fc81ffd4d9c3561&#10;clone: ok&#10;gist: 89518a33f5dae17c7fc81ffd4d9c3561&#10;help[1]:&#10;Run `gh-axi gist list` to see your gists&#10;[exit 0]&#10;&#10;--- working tree produced by the clone ---&#10;./89518a33f5dae17c7fc81ffd4d9c3561/clone-me.txt&#10;--- content round-tripped out of the clone ---&#10;gh-axi clone smoke test&#10;--- it is a real git repo pointing at the gist ---&#10;origin https://gist.github.com/89518a33f5dae17c7fc81ffd4d9c3561.git (fetch)</code>

```text
##############################################################
# 1. Create a short-lived PUBLIC scratch gist to clone
##############################################################
created:
  id: 89518a33f5dae17c7fc81ffd4d9c3561
  url: "https://gist.github.com/bauti-defi/89518a33f5dae17c7fc81ffd4d9c3561"
  visibility: public
help[1]:
  Run `gh-axi gist list` to see all your gists
>>> scratch gist id: 89518a33f5dae17c7fc81ffd4d9c3561

##############################################################
# 2. gist clone
##############################################################

==============================================================
$ gh-axi gist clone 89518a33f5dae17c7fc81ffd4d9c3561   (cwd: /tmp/gh-axi-gist-e2e.ysytTu/clonetest2)
--------------------------------------------------------------
clone: ok
gist: 89518a33f5dae17c7fc81ffd4d9c3561
help[1]:
  Run `gh-axi gist list` to see your gists
[exit 0]

--- working tree produced by the clone ---
./89518a33f5dae17c7fc81ffd4d9c3561/clone-me.txt

--- content round-tripped out of the clone ---
gh-axi clone smoke test
--- it is a real git repo pointing at the gist ---
origin	https://gist.github.com/89518a33f5dae17c7fc81ffd4d9c3561.git (fetch)
origin	https://gist.github.com/89518a33f5dae17c7fc81ffd4d9c3561.git (push)
36cb4fa 

##############################################################
# 3. Teardown — delete the scratch gist
##############################################################

==============================================================
$ gh-axi gist delete 89518a33f5dae17c7fc81ffd4d9c3561   (cwd: /Users/bautista/.no-mistakes/worktrees/5a450c443633/01KYHSZ48820Z7AF7GVG62ASZZ)
--------------------------------------------------------------
deleted: 89518a33f5dae17c7fc81ffd4d9c3561
help[1]:
  Run `gh-axi gist list` to see remaining gists
[exit 0]

==============================================================
$ gh-axi gist view 89518a33f5dae17c7fc81ffd4d9c3561   (cwd: /Users/bautista/.no-mistakes/worktrees/5a450c443633/01KYHSZ48820Z7AF7GVG62ASZZ)
--------------------------------------------------------------
error: "gh: Not Found (HTTP 404)"
code: NOT_FOUND
[exit 1]
>>> the view above must fail NOT_FOUND — scratch gist is gone.
```
</details>
<details>
<summary>Evidence: Visibility filters (--public / --secret) returning correctly partitioned results</summary>

```text
##############################################################
# A. LIST --public / --secret (visibility filters, retried)
##############################################################

==============================================================
$ gh-axi gist list --public --limit 3   (cwd: /Users/bautista/.no-mistakes/worktrees/5a450c443633/01KYHSZ48820Z7AF7GVG62ASZZ)
--------------------------------------------------------------
count: 3 (showing first 3)
gists[3]{id,description,files,visibility}:
  ebeb91e98449528230c214b5a28f4c5f,Steakhouse's looping machine on Robinhood Chain — on-chain investigation of the spUSDG/USDG Morpho market (steakUSDG lender + Box Turbo looping engine),1,public
  7c4062e04c6fb6efa3fa76affe5d8e80,DAMM-ETH v1.2 (IPOR-inclusive) — Capabilities Reference,1,public
  15bb88ec4a0bd6234fda652a0fbdd8f5,Global CLAUDE.md,1,public
help[2]:
  Run `gh-axi gist view <id>` to view a gist's files and metadata
  Run `gh-axi gist list --fields url,owner,created` to add extra fields
[exit 0]

==============================================================
$ gh-axi gist list --secret --limit 3   (cwd: /Users/bautista/.no-mistakes/worktrees/5a450c443633/01KYHSZ48820Z7AF7GVG62ASZZ)
--------------------------------------------------------------
count: 3 (showing first 3)
gists[3]{id,description,files,visibility}:
  b2770d2f971fe6753aaadc1c37a03a21,"twitterapi.io — filter rule silently stops polling while reporting is_effect=1 (56h outage, 2026-07-22/24)",1,secret
  ffc8fc22fada6cce950c7f0391c32450,"twitterapi.io — filter rule silently stops polling while reporting is_effect=1 (56h outage, 2026-07-22/24)",1,secret
  1732a9c34b0bc56870c2d0d18d837dcb,DAMM ETH Algo Fund — short + long descriptions,1,secret
help[2]:
  Run `gh-axi gist view <id>` to view a gist's files and metadata
  Run `gh-axi gist list --fields url,owner,created` to add extra fields
[exit 0]

##############################################################
# B. CLONE — create a scratch gist, clone it, verify the tree
##############################################################
created:
  id: 2d054d411409508a639929b1275f0896
  url: "https://gist.github.com/bauti-defi/2d054d411409508a639929b1275f0896"
  visibility: secret
help[2]:
  a secret gist is unlisted, not private — anyone with the URL can read it
  Run `gh-axi gist list` to see all your gists
>>> clone scratch gist id: 2d054d411409508a639929b1275f0896

==============================================================
$ gh-axi gist clone 2d054d411409508a639929b1275f0896   (cwd: /tmp/gh-axi-gist-e2e.ysytTu/clonetest)
--------------------------------------------------------------
error: Cloning into '2d054d411409508a639929b1275f0896'...
code: UNKNOWN
[exit 1]

--- git-tracked contents of the clone ---

--- file content round-tripped through the clone ---

--- git remote of the clone (proves it is a real gist repo) ---

##############################################################
# C. TEARDOWN
##############################################################

==============================================================
$ gh-axi gist delete 2d054d411409508a639929b1275f0896   (cwd: /Users/bautista/.no-mistakes/worktrees/5a450c443633/01KYHSZ48820Z7AF7GVG62ASZZ)
--------------------------------------------------------------
deleted: 2d054d411409508a639929b1275f0896
help[1]:
  Run `gh-axi gist list` to see remaining gists
[exit 0]
```
</details>
<details>
<summary>Evidence: Definitive empty state rendered by the real CLI</summary>

<code>$ gh-axi gist list (against an account with zero gists)&#10;count: 0&#10;gists[0]:&#10;help[1]:&#10;Run `gh-axi api /gists` to see gist data via the raw API</code>

```text
==============================================================
$ gh-axi gist list        (against an account with zero gists)
--------------------------------------------------------------
count: 0
gists[0]:
help[1]:
  Run `gh-axi api /gists` to see gist data via the raw API
[exit ]

==============================================================
$ gh-axi gist list --public   (filter matches nothing)
--------------------------------------------------------------
count: 0
gists[0]:
help[1]:
  Run `gh-axi api /gists` to see gist data via the raw API
[exit ]
```
</details>
<details>
<summary>Evidence: Preserved per-slice commit history (5 tracer-bullet slices + review fix)</summary>

<code>590189a no-mistakes(review): reject boolean =value forms and unknown gist edit flags&#10;1b85de2 no-mistakes(review): reject unknown gist flags, guard empty stdin, surface API truncation&#10;6fd6a00 fix(gist): use explicit stdin sentinel and validate selectors (#11)&#10;89791de feat(gist): add gist edit and gist rename (slice 4) (#9)&#10;56365a7 feat(gist): gist view + selector parsing + content truncation (slice 2) (#10)&#10;24b9e43 feat(gist): gist create — dual input forms, explicit visibility (slice #3) (#8)&#10;297f3e0 feat(gist): add gist delete and gist clone (slice 5) (#7)&#10;bd8a9f0 feat(gist): gist command family + gist list (slice 1a) (#6)</code>

```text
590189a no-mistakes(review): reject boolean =value forms and unknown gist edit flags
1b85de2 no-mistakes(review): reject unknown gist flags, guard empty stdin, surface API truncation
6fd6a00 fix(gist): use explicit stdin sentinel and validate selectors (#11)
89791de feat(gist): add gist edit and gist rename (slice 4) (#9)
56365a7 feat(gist): gist view + selector parsing + content truncation (slice 2) (#10)
24b9e43 feat(gist): gist create — dual input forms, explicit visibility (slice #3) (#8)
297f3e0 feat(gist): add gist delete and gist clone (slice 5) (#7)
bd8a9f0 feat(gist): gist command family + gist list (slice 1a) (#6)
```
</details>
<details>
<summary>Evidence: Structured error matrix excerpt (all exit 2, path traversal + foreign host rejected before the API call)</summary>

```text
$ gh-axi gist view ../../etc/passwd
error: "Invalid gist id: \"../../etc/passwd\""
code: VALIDATION_ERROR
help[1]: A gist id is alphanumeric; pass a bare id or a full gist URL
[exit 2]

$ gh-axi gist view https://evil.example.com/octocat/abc123
error: "Gist URL host \"evil.example.com\" does not match the configured host \"github.com\""
code: VALIDATION_ERROR
[exit 2]

$ gh-axi gist view <id> --full=true
error: "Unknown flag(s): --full=true"
code: VALIDATION_ERROR
[exit 2]

$ gh-axi gist edit <id> --remove a.txt --dry-run
error: "Unknown flag(s): --dry-run"
code: VALIDATION_ERROR
[exit 2]

$ echo '' | gh-axi gist edit <id> --filename renamed-hello.txt
error: no content received on stdin; nothing was piped
code: VALIDATION_ERROR
[exit 2]
```
</details>
<details>
<summary>Evidence: Harness scripts used to produce the transcripts</summary>

```text
#!/bin/bash
# End-to-end CLI transcript for the gh-axi gist command family.
# Drives the REAL binary (tsx bin/gh-axi.ts) against REAL GitHub gists.
set -uo pipefail

REPO="$1"
WORK="$2"
cd "$REPO"

AXI="node_modules/.bin/tsx bin/gh-axi.ts"

run() {
  echo ""
  echo "=============================================================="
  echo "\$ gh-axi $*"
  echo "--------------------------------------------------------------"
  $AXI "$@" 2>&1
  echo "[exit $?]"
}

runpipe() {
  local input="$1"; shift
  echo ""
  echo "=============================================================="
  echo "\$ echo '$input' | gh-axi $*"
  echo "--------------------------------------------------------------"
  printf '%s' "$input" | $AXI "$@" 2>&1
  echo "[exit $?]"
}

echo "##############################################################"
echo "# 0. HELP — the command family surface"
echo "##############################################################"
run gist --help

echo ""
echo "##############################################################"
echo "# 1. CREATE — explicit visibility required, stdin form"
echo "##############################################################"
# One create; its output is both the transcript evidence and the lifecycle id.
echo ""
echo "=============================================================="
echo "\$ echo 'hello from the gh-axi gist family' | gh-axi gist create --filename hello.txt --secret --desc 'gh-axi e2e lifecycle gist'"
echo "--------------------------------------------------------------"
printf 'hello from the gh-axi gist family' | $AXI gist create --filename hello.txt --secret --desc "gh-axi e2e lifecycle gist" 2>&1 | tee "$WORK/create.out"
echo "[exit ${PIPESTATUS[1]}]"
GID=$(grep -E '^ *id:' "$WORK/create.out" | head -1 | sed 's/.*id: *//')
echo ""
echo ">>> lifecycle gist id captured: $GID"

echo ""
echo "##############################################################"
echo "# 2. LIST — minimal default schema, --fields, --limit, filters"
echo "##############################################################"
run gist list --limit 5
run gist list --limit 3 --fields url,owner,created
run gist list --public --limit 3

echo ""
echo "##############################################################"
echo "# 3. VIEW — metadata + content, bare id"
echo "##############################################################"
run gist view "$GID"

echo ""
echo "##############################################################"
echo "# 4. VIEW — URL selector form (order-insensitive flags too)"
echo "##############################################################"
run gist view "https://gist.github.com/bauti-defi/$GID" --files
run gist view --files "$GID"

echo ""
echo "##############################################################"
echo "# 5. EDIT — --add <name> - (stdin), --add <path> (disk), --remove, --desc"
echo "##############################################################"
runpipe "content piped into a brand new file" gist edit "$GID" --add from-stdin.txt -
printf 'this file came from disk\n' > "$WORK/from-disk.txt"
run gist edit "$GID" --add "$WORK/from-disk.txt"
run gist view "$GID" --files
run gist edit "$GID" --desc "description updated via gh-axi gist edit"
run gist edit "$GID" --remove from-stdin.txt
run gist view "$GID" --files

echo ""
echo "##############################################################"
echo "# 6. CONTENT TRUNCATION — head-slice by default, --full to opt out"
echo "##############################################################"
python3 -c "print('x' * 40 + ' line')" > /dev/null
python3 - <<'PY' > "$WORK/big.txt"
for i in range(120):
    print(f"line {i:03d}: " + "y" * 40)
PY
run gist edit "$GID" --add "$WORK/big.txt"
echo ""
echo ">>> default view of big.txt (truncated head-slice):"
run gist view "$GID" -f big.txt
echo ""
echo ">>> same file with --full (first 12 + last 3 lines shown here for brevity):"
$AXI gist view "$GID" -f big.txt --full 2>&1 | head -14
echo "   ...   "
$AXI gist view "$GID" -f big.txt --full 2>&1 | tail -4

echo ""
echo "##############################################################"
echo "# 7. RENAME"
echo "##############################################################"
run gist rename "$GID" hello.txt renamed-hello.txt
run gist view "$GID" --files

echo ""
echo "##############################################################"
echo "# 8. CLONE"
echo "##############################################################"
cd "$WORK"
run gist clone "$GID"
echo "--- cloned working tree ---"
ls -1 "$WORK/$GID" 2>/dev/null || ls -1 "$WORK"
cd "$REPO"

echo ""
echo "##############################################################"
echo "# 9. STRUCTURED ERRORS — every one must exit non-zero"
echo "##############################################################"
run gist create --filename x.txt
run gist create --filename x.txt --public --secret
run gist view "$GID" --ful
run gist view "$GID" --full=true
run gist view "$GID" -w
run gist view "../../etc/passwd"
run gist view "https://evil.example.com/octocat/abc123"
run gist edit "$GID"
run gist edit "$GID" --remove a.txt --dry-run
run gist list --limitt 5
run gist list --limit abc
run gist bogus-subcommand
runpipe "" gist edit "$GID" --filename renamed-hello.txt

echo ""
echo "##############################################################"
echo "# 10. DELETE — lifecycle teardown"
echo "##############################################################"
run gist delete "$GID"
run gist view "$GID"
echo ""
echo ">>> lifecycle gist $GID deleted; the view above must fail NOT_FOUND."
```
</details>
- Outcome: ⚠️ 2 infos across 1 run (11m18s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `AGENTS.md` - branch carries 6 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (12 file(s)) into the PR:
- 6fd6a00 fix(gist): use explicit stdin sentinel and validate selectors (#11)
- 89791de feat(gist): add gist edit and gist rename (slice 4) (#9)
- 56365a7 feat(gist): gist view + selector parsing + content truncation (slice 2) (#10)
- 24b9e43 feat(gist): gist create — dual input forms, explicit visibility (slice #3) (#8)
- 297f3e0 feat(gist): add gist delete and gist clone (slice 5) (#7)
- bd8a9f0 feat(gist): gist command family + gist list (slice 1a) (#6)

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `src/commands/gist.ts:327` - deleteGist and cloneGist build positionals with `args.filter(a =&gt; !a.startsWith(&#34;--&#34;))` and never reject unknown flags, unlike createGist (line 415) and renameGist (line 660) which both throw on unrecognized flags. Two consequences: (a) any unknown `--flag` is silently dropped — `gh-axi gist delete --dry-run &lt;id&gt;` ignores the guard flag and destroys the gist at exit 0; (b) a single-dash token is treated as a positional, so `gh-axi gist delete -y &lt;id&gt;` picks `-y` as the selector and reports `Unexpected argument: &lt;id&gt;`. Use `startsWith(&#34;-&#34;)` for the positional filter and add the same unknown-flag rejection createGist already has.
- ⚠️ `src/commands/gist.ts:153` - `GistFile.truncated` is declared in the interface (line 87) but never read. GET /gists/&lt;id&gt; caps each file&#39;s `content` at 1 MB and sets `truncated: true` (files over 10 MB return no content at all). `makeFileSchema(full)` renders `item.content` verbatim, and `truncateGistContent` returns early when `full` is set, so `gh-axi gist view &lt;id&gt; --full` on a 5 MB gist file prints the first 1 MB with no footer and no indication anything is missing — while the help text at line 29 documents `--full` as &#34;(no truncation)&#34;. Surface a note (and the file&#39;s raw_url) when `file.truncated === true`.
- ⚠️ `src/commands/gist.ts:599` - `gist edit --filename` reads stdin with no empty-content guard, diverging from `resolveValue` in src/secretValue.ts which explicitly throws when `readStdin()` returns a zero-length string. Because this tool always runs with a non-TTY stdin in agent contexts (the reasoning stated at gist.ts:525-527), the `isStdinTTY()` check at line 588 never fires there, so `gh-axi gist edit &lt;id&gt; --filename notes.md` with nothing actually piped either resolves `content === &#34;&#34;` and issues `gh gist edit &lt;id&gt; - --filename notes.md` with empty content — replacing the file&#39;s contents with nothing — or, if stdin is an inherited pipe with no writer, blocks forever waiting for &#39;end&#39;, which AGENTS.md states AXI commands must never do. `createGist`&#39;s stdin form (line 474) has the same gap. Reject zero-length stdin with a VALIDATION_ERROR the way resolveValue does.
- ℹ️ `src/commands/gist.ts:187` - viewGist and listGists never validate that every flag they were given is one they understand — viewGist&#39;s positional filter drops anything starting with `-`, and listGists only reads `--public`/`--secret`/`--fields`/`--limit` by name. A typo silently degrades the result at exit 0: `gh-axi gist view &lt;id&gt; --ful` returns truncated content as if `--full` had been honoured, and `gh-axi gist list --limitt 5` returns 100 rows. createGist and renameGist already reject unknown flags loudly; apply the same check here for consistency.
- ℹ️ `src/commands/gist.ts:291` - `paginate = limit &gt; PAGE_SIZE || filtering` passes `--paginate` to `gh api`, which follows every Link header with no cap. `gh-axi gist list --secret` on an account with 5,000 gists issues 50 API calls to display at most 100 rows, and `--limit 101` does the same for 101 rows. The comment at lines 280-285 justifies exhaustive fetching for the visibility-filter case (the endpoint has no visibility param), but the `limit &gt; PAGE_SIZE` case could stop after ceil(limit/PAGE_SIZE) pages via a manual page loop instead of `--paginate`. Worth confirming the fetch cost is an accepted tradeoff.
- ℹ️ `src/gistSelector.ts:82` - `extractIdFromUrl` takes the last non-empty path segment, and the doc comment at lines 12-14 claims this is correct for all URL shapes where gh&#39;s index-2 rule is &#34;wrong&#34;. It is correct for the three listed shapes, but GitHub also serves revision URLs (`https://gist.github.com/OWNER/ID/&lt;40-hex-sha&gt;`), where last-segment yields the revision SHA. That SHA is alphanumeric so `validateBareId` passes it through, and `GET /gists/&lt;revsha&gt;` 404s — a shape gh&#39;s index-2 rule resolves correctly. Fails loudly rather than silently, but the resolution rule is a design call worth confirming (e.g. drop a trailing 40-hex segment, or take index 2 after stripping a leading `gist` segment for GHE).
- ℹ️ `src/commands/gist.ts:181` - `takeBoolFlag(args, &#34;-r&#34;)` and `takeBoolFlag(args, &#34;--raw&#34;)` discard their return values, and their mutation of `args` has no observable effect: the only later read is `args.slice(1).filter(a =&gt; !a.startsWith(&#34;-&#34;))` at line 187, which already excludes both tokens. Both calls can be deleted without behavior change; the no-op contract for `-r/--raw` is already carried by the help text at line 29 and the test at gist.test.ts:1359.
- ℹ️ `src/commands/gist.ts:628` - The intent states &#34;Reads go through gh api /gists, writes through gh gist&#34;, but the description-only edit performs a write via `gh api -X PATCH /gists/&lt;id&gt; -f description=...` rather than `gh gist edit`. The inline comment at lines 622-626 gives a sound reason (bare `gh gist edit --desc` enters the content-edit loop and errors &#34;unsure what file to edit&#34; on multi-file gists), and the integration test at test/integration/gist.integration.test.ts:135 pins the behavior — so this reads as deliberate rather than accidental. Flagging only so the deviation from the stated read/write split is an explicit decision; it also means desc-only edits take a different gh code path (and `--desc=&#34;&#34;` clears the description rather than being ignored, unlike createGist&#39;s truthiness check at line 457).

🔧 Fix: reject unknown gist flags, guard empty stdin, surface API truncation
3 issues (2 warnings, 1 info) still open:
- ⚠️ `src/commands/gist.ts:116` - `rejectUnknownFlags` compares `a.split(&#34;=&#34;)[0]` against the known list, which is correct for value flags but creates a hole for viewGist&#39;s boolean whitelist at line 239. `gh-axi gist view &lt;id&gt; --full=true` normalizes to `--full`, passes the guard, and then `hasFlag(args, &#34;--full&#34;)` at line 229 (an exact `args.includes` match) returns false — so the flag is accepted and silently ignored, producing truncated output at exit 0. Same for `--files=1`, `-r=x`, `--raw=x`. This is the precise silent-degradation class the guard was added to close, and the new tests only cover the unknown-flag `=` case (`--fieldz=url`), not an accepted-but-ignored known boolean. Note the `split(&#34;=&#34;)` normalization is only ever exercised by viewGist — every other call site passes `known: []`, where the value flags were already consumed by `takeFlag` — so matching boolean tokens exactly (or rejecting `--full=` forms outright) closes it without affecting `--fields=url`.
- ⚠️ `src/commands/gist.ts:598` - editGist is the only gist subcommand left without `rejectUnknownFlags` — view, list, delete, clone, create, and rename all now reject unrecognized flags. Its positional filter at line 598 drops anything starting with `-`, so a flag-shaped typo with no value is silently swallowed: `gh-axi gist edit &lt;id&gt; --remove old.txt --dry-run` ignores `--dry-run` and removes the file, the same destructive-guard hole just closed for `gist delete`. Typos that do carry a value fail, but with a misleading message (`gist edit &lt;id&gt; --remov old.txt` reports `Unexpected argument: old.txt` rather than naming `--remov`). Add the same guard after the takeFlag block at line 588, whitelisting `-` (the stdin sentinel) plus the short/long aliases so the `--add &lt;name&gt; -` path keeps working.
- ℹ️ `src/commands/gist.ts:322` - `takeFlag` returns `undefined` and splices the token when a value flag is the last argument, so the new `rejectUnknownFlags` call at line 326 never sees it. The result is an inconsistency introduced by this commit: `gh-axi gist list --limitt 5` now fails loudly, but `gh-axi gist list --limit` (value omitted) silently falls back to 100 rows, `--fields` with no value silently adds no columns, and `gh-axi gist view &lt;id&gt; -f` (line 232) silently renders every file instead of one. Have the handlers treat a consumed-but-valueless flag as a VALIDATION_ERROR, matching how `takeAllFlags`/`requireFlagValue` in src/args.ts:55 already reject a dangling `--file`.

🔧 Fix: reject boolean =value forms and unknown gist edit flags
1 info still open:
- ℹ️ `src/commands/gist.ts:470` - createGist validates visibility at lines 464-476, before `rejectUnknownFlags(remaining, [])` at line 494. `takeBoolFlag` matches the bare token only, so `gh-axi gist create a.py --public=true` leaves both `wantPublic` and `wantSecret` false and throws &#34;gist create requires --public or --secret; neither was given&#34; — which contradicts what the caller actually typed and never names `--public=true`. This is the same accepted-vs-named problem just fixed for viewGist&#39;s booleans; the difference is that here it fails loudly and creates nothing, so it is a message-quality issue rather than a silent-degradation one. Note the dangerous combination is already safe: `--public=true --secret` reaches the guard at line 494 and is rejected before any gh call, so visibility can never silently flip. Moving the visibility validation to just after line 494 makes the guard name the offending token first, matching delete/clone/view/list/edit/rename.

</details>

<details>
<summary>⚠️ **Test** - 2 infos</summary>

- ℹ️ `src/commands/gist.ts:815` - `gh-axi gist bogus-subcommand` prints a structured VALIDATION_ERROR but exits 0 (when stdout is not a TTY), because gistCommand&#39;s default branch `return`s renderError() instead of throwing. This brushes against the intent&#39;s &#34;structured errors with nonzero exit&#34;. It is NOT introduced by this change: label, repo, release, secret, variable, workflow and run all use the identical `return renderError(...)` pattern and reproduce exit 0 under the same conditions. gist is consistent with its siblings; flagging only so the exit-0 path is a conscious repo-wide choice rather than an oversight.
- ℹ️ `src/errors.ts:124` - When the underlying `gh gist clone` fails, gh-axi surfaces only the first stderr line, which for git is the benign progress message &#34;Cloning into &#39;&lt;id&gt;&#39;...&#34; — the real cause (&#34;Host key verification failed&#34; / &#34;Permission denied (publickey)&#34;) is dropped, yielding `error: Cloning into &#39;...&#39;` with `code: UNKNOWN`. This cost real diagnosis time during testing. It stems from the shared `firstErrorLine()` in src/errors.ts used by every ghExec caller (repo clone included), so it is pre-existing and not a regression from this change.
- <code>`pnpm test` — full suite, 877 passed / 5 skipped (gated integration)</code>
- <code>`GIST_INTEGRATION=1 pnpm test test/integration/gist.integration.test.ts` — 5/5 passed against a real scratch gist routed through gistCommand</code>
- <code>Full CLI lifecycle against real gists: `gist create --filename &lt;n&gt; --secret` (stdin form), `gist create &lt;path&gt; --public` (positional form), `gist list --limit 5`, `gist list --fields url,owner,created`, `gist list --public/--secret --limit 3`, `gist view &lt;id&gt;`, `gist view &lt;url&gt; --files`, `gist view --files &lt;id&gt;` (order-insensitive), `gist view &lt;id&gt; -f &lt;file&gt;`, `gist edit &lt;id&gt; --add &lt;name&gt; -`, `gist edit &lt;id&gt; --add &lt;path&gt;`, `gist edit &lt;id&gt; --desc`, `gist edit &lt;id&gt; --remove`, `gist rename &lt;id&gt; &lt;old&gt; &lt;new&gt;`, `gist clone &lt;id&gt;`, `gist delete &lt;id&gt;`</code>
- <code>Truncation: viewed a 6120-char file with and without `--full` (head-sliced at 1500 chars with footer vs. all 120 lines)</code>
- <code>Structured-error matrix, all exit 2: `gist create --filename x.txt` (no visibility), `--public --secret`, `gist view &lt;id&gt; --ful`, `--full=true`, `-w`, `gist view ../../etc/passwd`, `gist view https://evil.example.com/...`, `gist edit &lt;id&gt;` (nothing to edit), `gist edit &lt;id&gt; --remove a.txt --dry-run`, `gist list --limitt 5`, `gist list --limit abc`, empty piped stdin to `gist edit --filename`</code>
- <code>User-scoping: `gist list -R kunchenguid/gh-axi --limit 2` and `GH_REPO=kunchenguid/gh-axi gist list --limit 2` both succeed, proving repo context is never forwarded to `gh api /gists`</code>
- <code>Empty state: drove the real CLI against a stub `gh` returning `[]` for `gist list` and `gist list --public`</code>
- `Cross-family exit-code comparison for unknown subcommands across gist/label/repo/release/secret/variable/workflow/run`
- <code>`git log --oneline fe384b3..590189a` — confirmed per-slice history preserved</code>
- <code>Cleanup verification: `git status --porcelain` clean; `gh api /gists` shows no leftover scratch gists</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `src/suggestions.ts:73` - src/suggestions.ts:73 emits the session-hook dashboard hint `commands: issue, pr, run, release, repo, label, secret, variable`, which does not include the new `gist` family. It is a runtime output string rather than a documentation file, so updating it would change CLI behavior and is outside this pass&#39;s mandate. Note the list already omitted `workflow`, `project`, `search`, and `api` before this change, so it may be a deliberately curated short list — that&#39;s the judgment call. If it is meant to be exhaustive, `gist` should be added there in a functional change.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
