### PR TITLE
chore(ci): skip pull_request runs for release-please output-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # release-please opens its release PR with GITHUB_TOKEN, which creates a
+    # pull_request run that can only sit in action_required. Its output set is
+    # exactly these files, so excluding them means no run is ever created.
+    paths-ignore:
+      - .release-please-manifest.json
+      - CHANGELOG.md
+      - package.json
 
 jobs:
   build-and-test:

--- a/.github/workflows/guard-generated-files.yml
+++ b/.github/workflows/guard-generated-files.yml
@@ -5,6 +5,13 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - main
+    # Never create a run for a release-please PR. The job-level author exemption
+    # below cannot do this: it is evaluated inside a run, and a GITHUB_TOKEN PR's
+    # run is created in action_required and never starts.
+    paths-ignore:
+      - .release-please-manifest.json
+      - CHANGELOG.md
+      - package.json
 
 permissions:
   contents: read

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -6,6 +6,13 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches:
       - main
+    # Never create a run for a release-please PR. The job-level author exemption
+    # below cannot do this: it is evaluated inside a run, and a GITHUB_TOKEN PR's
+    # run is created in action_required and never starts.
+    paths-ignore:
+      - .release-please-manifest.json
+      - CHANGELOG.md
+      - package.json
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ The SDK also appends a `"built-in":` section to the top-level `--help` output at
 Releases are cut by release-please from conventional commit messages on `main`; merging the bot's release PR triggers `npm publish` via `.github/workflows/release-please.yml`.
 Do not hand-edit `CHANGELOG.md` or `.release-please-manifest.json` (a guard workflow blocks PRs that touch them), and regenerate `skills/gh-axi/SKILL.md` with `pnpm run build:skill` instead of editing it directly.
 
+Every `pull_request` workflow (`ci.yml`, `guard-generated-files.yml`, `no-mistakes-required.yml`) uses `paths-ignore` for the release-please output set (`.release-please-manifest.json`, `CHANGELOG.md`, `package.json`) so release PRs create zero runs. Job-level bot `if`s stay as defense in depth. `test/release-ci-exclusions.test.ts` derives that set from `release-please-config.json` and fails if a workflow drifts; update the ignore lists when adding `extra-files` or changing `release-type`.
+
 ## GitHub Enterprise host support (`src/host.ts`, `src/cli.ts`)
 
 `gh-axi` targets a custom GitHub host (e.g. a GHE server like `ghe.example.com`) via a global `--hostname <host>` flag or the `GH_HOST` env var; explicit `--hostname` wins.

--- a/test/release-ci-exclusions.test.ts
+++ b/test/release-ci-exclusions.test.ts
@@ -1,0 +1,231 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const workflowsDir = join(root, ".github", "workflows");
+
+/**
+ * Derive the exact release-please output set from config + workflow inputs.
+ * Keep this aligned with the fleet audit rule in firstmate's release-please CI
+ * report: node -> package.json (+ package-lock.json if present), changelog,
+ * extra-files, and the manifest path.
+ */
+function expectedReleaseOutputs(): string[] {
+  const config = JSON.parse(
+    readFileSync(join(root, "release-please-config.json"), "utf8"),
+  ) as {
+    "release-type"?: string;
+    "changelog-path"?: string;
+    "version-file"?: string;
+    "extra-files"?: Array<string | { path?: string }>;
+    packages?: Record<
+      string,
+      {
+        "release-type"?: string;
+        "changelog-path"?: string;
+        "version-file"?: string;
+        "extra-files"?: Array<string | { path?: string }>;
+      }
+    >;
+  };
+  const pkg = config.packages?.["."] ?? {};
+  const releaseType = pkg["release-type"] ?? config["release-type"] ?? "node";
+  const changelog =
+    pkg["changelog-path"] ?? config["changelog-path"] ?? "CHANGELOG.md";
+
+  const expected: string[] = [changelog];
+  switch (releaseType) {
+    case "simple":
+      expected.push(
+        pkg["version-file"] ?? config["version-file"] ?? "version.txt",
+      );
+      break;
+    case "node":
+      expected.push("package.json");
+      if (existsSync(join(root, "package-lock.json"))) {
+        expected.push("package-lock.json");
+      }
+      break;
+    case "go":
+      break;
+    default:
+      throw new Error(
+        `unsupported release-please release-type for ignore derivation: ${releaseType}`,
+      );
+  }
+
+  const extra = pkg["extra-files"] ?? config["extra-files"] ?? [];
+  for (const entry of extra) {
+    const path = typeof entry === "string" ? entry : entry?.path;
+    if (path) expected.push(path);
+  }
+
+  let manifest = ".release-please-manifest.json";
+  const releaseWorkflow = readFileSync(
+    join(workflowsDir, "release-please.yml"),
+    "utf8",
+  );
+  const manifestMatch = releaseWorkflow.match(/manifest-file:\s*(\S+)/);
+  if (manifestMatch) manifest = manifestMatch[1];
+  expected.push(manifest);
+
+  return [...new Set(expected)];
+}
+
+function loadWorkflowOn(filePath: string): Record<string, unknown> | null {
+  const doc = parse(readFileSync(filePath, "utf8")) as
+    | Record<string | boolean, unknown>
+    | null;
+  if (!doc || typeof doc !== "object") return null;
+  // YAML 1.1 may parse a bare `on:` key as boolean true.
+  const on = doc.on ?? doc[true];
+  if (!on || typeof on !== "object" || Array.isArray(on)) return null;
+  return on as Record<string, unknown>;
+}
+
+type PullRequestFilter =
+  | { kind: "unfiltered" }
+  | { kind: "paths-ignore"; paths: string[] }
+  | { kind: "paths"; paths: string[] };
+
+function pullRequestFilterCoverage(pr: unknown): PullRequestFilter {
+  if (pr == null) {
+    return { kind: "unfiltered" };
+  }
+  if (typeof pr !== "object" || Array.isArray(pr)) {
+    // `pull_request:` bare form means no path filter.
+    return { kind: "unfiltered" };
+  }
+
+  const record = pr as Record<string, unknown>;
+  if (Array.isArray(record["paths-ignore"])) {
+    return {
+      kind: "paths-ignore",
+      paths: record["paths-ignore"].map(String),
+    };
+  }
+
+  if (Array.isArray(record.paths)) {
+    return { kind: "paths", paths: record.paths.map(String) };
+  }
+
+  return { kind: "unfiltered" };
+}
+
+function globMatch(pattern: string, path: string): boolean {
+  // Minimal support for the `**` / `*` patterns used in workflow path filters.
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "::DOUBLE::")
+    .replace(/\*/g, "[^/]*")
+    .replace(/::DOUBLE::/g, ".*");
+  return new RegExp(`^${escaped}$`).test(path);
+}
+
+function isCovered(filter: PullRequestFilter, releasePath: string): boolean {
+  if (filter.kind === "unfiltered") return false;
+
+  if (filter.kind === "paths-ignore") {
+    return filter.paths.includes(releasePath);
+  }
+
+  // paths allow-list: a release path is "covered" (will not create a run on its
+  // own) when no positive pattern matches it, or a later negation excludes it.
+  let matched = false;
+  for (const pattern of filter.paths) {
+    if (pattern.startsWith("!")) {
+      const negated = pattern.slice(1);
+      if (
+        matched &&
+        (negated === releasePath || globMatch(negated, releasePath))
+      ) {
+        matched = false;
+      }
+      continue;
+    }
+    if (pattern === releasePath || globMatch(pattern, releasePath)) {
+      matched = true;
+    }
+  }
+  // Covered means the path does NOT cause the workflow to run.
+  return !matched;
+}
+
+describe("release-please CI exclusions", () => {
+  const expected = expectedReleaseOutputs();
+
+  it("derives the node release-output set for this repository", () => {
+    expect(expected).toEqual([
+      "CHANGELOG.md",
+      "package.json",
+      ".release-please-manifest.json",
+    ]);
+  });
+
+  it("every pull_request workflow ignores the full release-output set", () => {
+    const files = readdirSync(workflowsDir).filter((name) =>
+      name.endsWith(".yml"),
+    );
+    const prWorkflows: { name: string; filter: PullRequestFilter }[] = [];
+
+    for (const name of files) {
+      const filePath = join(workflowsDir, name);
+      const on = loadWorkflowOn(filePath);
+      if (!on || !("pull_request" in on)) continue;
+      prWorkflows.push({
+        name,
+        filter: pullRequestFilterCoverage(on.pull_request),
+      });
+    }
+
+    expect(prWorkflows.map((w) => w.name).sort()).toEqual([
+      "ci.yml",
+      "guard-generated-files.yml",
+      "no-mistakes-required.yml",
+    ]);
+
+    const failures: string[] = [];
+    for (const { name, filter } of prWorkflows) {
+      const missing = expected.filter((path) => !isCovered(filter, path));
+      if (missing.length > 0) {
+        failures.push(`${name} missing coverage for: ${missing.join(", ")}`);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("does not attach path filters to non-pull_request triggers on ci.yml", () => {
+    const on = loadWorkflowOn(join(workflowsDir, "ci.yml"));
+    expect(on).not.toBeNull();
+    expect(on!.push).toEqual({ branches: ["main"] });
+    const pr = on!.pull_request as Record<string, unknown>;
+    expect(pr.branches).toEqual(["main"]);
+    expect(pr["paths-ignore"]).toEqual([
+      ".release-please-manifest.json",
+      "CHANGELOG.md",
+      "package.json",
+    ]);
+    expect(on!.release).toBeUndefined();
+    expect(on!.workflow_dispatch).toBeUndefined();
+  });
+
+  it("keeps bot author exemptions on guard and no-mistakes jobs", () => {
+    const guard = readFileSync(
+      join(workflowsDir, "guard-generated-files.yml"),
+      "utf8",
+    );
+    const nmr = readFileSync(
+      join(workflowsDir, "no-mistakes-required.yml"),
+      "utf8",
+    );
+    expect(guard).toContain("github-actions[bot]");
+    expect(guard).toContain("release-please[bot]");
+    expect(nmr).toContain("github-actions[bot]");
+    expect(nmr).toContain("dependabot[bot]");
+    expect(nmr).toContain("release-please[bot]");
+  });
+});


### PR DESCRIPTION
## Summary

Release-please opens its release PR with `GITHUB_TOKEN`, which since 2026-07-01 creates `pull_request` workflow runs that sit forever in `action_required`. Job-level bot `if`s never evaluate because the run never starts.

This PR adds `paths-ignore` for the exact release-please output set (`.release-please-manifest.json`, `CHANGELOG.md`, `package.json`) to every `pull_request` workflow:

- `.github/workflows/ci.yml`
- `.github/workflows/guard-generated-files.yml`
- `.github/workflows/no-mistakes-required.yml`

Push/tag/release triggers are untouched. Existing bot author exemptions stay as defense in depth.

`test/release-ci-exclusions.test.ts` derives the expected output set from `release-please-config.json` and asserts every PR workflow covers it, so drift fails loudly.

## Validation

- YAML parse of all four workflows
- Focused vitest: `test/release-ci-exclusions.test.ts` (4 tests pass)
- Offline filter simulation: release PR #89 file set → zero runs; human PRs #88/#81/#70 → still run

## Notes for merge

Direct-PR delivery per captain override for the release-please CI fleet rollout. A red `Require no-mistakes` check is expected on this PR and is non-blocking (no required status checks in this repo). Do not merge while other checks are red.