### PR TITLE
feat(stack): add agent-safe stacked PR support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ This only works because `src/version.ts` is a LEAF module importing node builtin
 
 `gh-axi stack` is deliberately a strict adapter over the official `github/gh-stack` extension, not a second stack engine. Keep local metadata, Git mutation, rebase recovery, and Stacks API behavior upstream.
 Stack commands are cwd-bound. `cli.ts#withLocalRepoContext` rejects explicit repo flags and `GH_REPO`, strips the supported host flag, and never passes a `RepoContext` to `ghRaw`, because the extension does not accept `--repo`.
-Successful extension status is commonly written to stderr, and exits 2-10 represent actionable stack state. Preserve both streams and the exact `StackError.exitCode`; do not replace `ghRaw` with `ghExec` or generic `mapGhError`.
+Successful extension status is commonly written to stderr, and exits 2-10 represent actionable stack state. Preserve both streams and the exact `StackError.exitCode`, which reaches the shell only through `cli.ts`'s `formatError` hook; do not replace `ghRaw` with `ghExec` or generic `mapGhError`.
 Never expose an interactive path. Force `view --json`, `submit --auto`, and `merge --yes`; require arguments for commands that otherwise prompt. Keep `modify`, `switch`, `alias`, and `feedback` out unless upstream gains a useful headless interface.
 
 ## Maintaining this file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,13 @@ gh sometimes embeds remediation hints in errors with a different root cause, so 
 This only works because `src/version.ts` is a LEAF module importing node builtins only - `cli.ts` imports `VERSION` from it, never the reverse. Adding any non-builtin import to `src/version.ts` silently undoes the speedup.
 `test/version-fast-path.test.ts` guards it deterministically with a `module.register()` load-hook trace (`test/fixtures/module-trace-*.mjs`) plus a negative control on `--help`. Do not add a wall-clock timing assertion; it was proven flaky under CI contention.
 
+## Stacked PR support (`src/commands/stack.ts`)
+
+`gh-axi stack` is deliberately a strict adapter over the official `github/gh-stack` extension, not a second stack engine. Keep local metadata, Git mutation, rebase recovery, and Stacks API behavior upstream.
+Stack commands are cwd-bound. `cli.ts#withLocalRepoContext` rejects explicit repo flags and `GH_REPO`, strips the supported host flag, and never passes a `RepoContext` to `ghRaw`, because the extension does not accept `--repo`.
+Successful extension status is commonly written to stderr, and exits 2-10 represent actionable stack state. Preserve both streams and the exact `StackError.exitCode`; do not replace `ghRaw` with `ghExec` or generic `mapGhError`.
+Never expose an interactive path. Force `view --json`, `submit --auto`, and `merge --yes`; require arguments for commands that otherwise prompt. Keep `modify`, `switch`, `alias`, and `feedback` out unless upstream gains a useful headless interface.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ npx skills add kunchenguid/gh-axi --skill gh-axi -g
 That is the entire setup - no npm install needed.
 The skill teaches your agent to run gh-axi through `npx -y gh-axi`, so the CLI comes along on demand.
 You still need [`gh`](https://cli.github.com/) installed and authenticated via `gh auth login` (Node 20+ required).
+Stacked PR commands also require GitHub's official extension: `gh extension install github/gh-stack`.
 For GitHub Enterprise or another custom host, authenticate `gh` for that host and either pass `--hostname <host>` after the command or set `GH_HOST`.
 
 The skill is not a user-facing slash command (`user-invocable: false`).
@@ -85,6 +86,9 @@ gh-axi                          # dashboard - live state, no args needed
 gh-axi issue list               # list issues in current repo
 gh-axi issue subissue list 16   # list sub-issues for issue #16
 gh-axi pr view 42               # view pull request #42
+gh-axi stack init model api ui  # create or adopt a stack of branches
+gh-axi stack submit --open      # create ready-for-review stacked PRs without prompts
+gh-axi stack view               # inspect the current stack as token-efficient TOON
 gh-axi issue edit 42 --add-label bug --add-label chore  # repeat a flag per value
 gh-axi run list -R owner/repo   # list workflow runs for a specific repo
 gh-axi issue list --hostname git.example.com  # target a GitHub Enterprise host
@@ -130,6 +134,10 @@ When truncation happens, gh-axi best-effort saves the complete log to a temp fil
 `gh-axi pr checks <number>` and the `checks` summary of `gh-axi pr view <number>` bucket every entry of the PR's status-check rollup as `pass`, `fail`, `skip`, or `pending`, covering both check runs (GitHub Actions and similar) and legacy commit statuses (Vercel, `ci/circleci`, and similar).
 Cancelled, stale, timed-out, action-required, and startup-failure check runs count as failed, so a red PR is never reported as merely unfinished.
 
+`gh-axi stack` is a strict, non-interactive adapter over the official `github/gh-stack` extension. It supports `view`, `init`, `add`, `checkout`, `push`, `submit`, `sync`, `rebase`, `link`, `unstack`, `merge`, and branch navigation. It intentionally excludes the interactive `modify` and `switch` TUIs and the human-only `alias` and `feedback` utilities.
+Stack commands operate on local branches and `.git/gh-stack`, so run them from the target repository's working directory. They reject `-R`, `--repo`, and `GH_REPO` rather than pretending a remote repository is enough. `--hostname` remains available for authenticated GitHub Enterprise hosts.
+Agent-safe behavior is automatic: `stack view` requests JSON, `stack submit` adds `--auto`, and `stack merge` requires an explicit stack or PR target and adds `--yes`. Rebase conflicts and other extension exits retain their original exit codes and include recovery guidance.
+
 `gh-axi secret set <name>` reads the value only from piped stdin because secret flags would be visible in the `gh-axi` process argv.
 `gh-axi secret list` never prints values, matching `gh secret list`.
 `gh-axi secret list`, `set`, and `delete` accept `--env`/`-e <environment>` to scope a secret to a deployment environment; without it the repository scope is used.
@@ -152,6 +160,7 @@ JSON responses are normally stripped of noisy fields before TOON encoding, but a
 | ---------- | --------------------------------------------------------------------------- |
 | `issue`    | Issues — list, view, create, edit, close, reopen, comment, subissue         |
 | `pr`       | Pull requests — list, view, create, merge, review, checks                   |
+| `stack`    | Stacked branches and PRs - create, submit, sync, rebase, merge, navigate    |
 | `run`      | Existing workflow runs - list, view, watch, rerun, cancel, delete, download |
 | `workflow` | Workflows - list, view, run (trigger), enable, disable                      |
 | `release`  | Releases — list, view, create, edit, delete                                 |

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-axi
-description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist view`, `gist edit`, `gist rename`, `gist create`, `gist delete`, or `gist clone`."
+description: "Operate GitHub through the gh-axi CLI - issues, pull requests, stacked PRs, workflow runs, workflows, releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, managing stacked branches and PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist view`, `gist edit`, `gist rename`, `gist create`, `gist delete`, or `gist clone`."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -17,11 +17,12 @@ You do not need gh-axi installed globally - invoke it with `npx -y gh-axi <comma
 If gh-axi output shows a follow-up command starting with `gh-axi`, run it as `npx -y gh-axi ...` instead.
 
 gh-axi requires the [`gh`](https://cli.github.com/) CLI installed and authenticated (`gh auth login`). If a command fails with an authentication error, ask the user to run `gh auth login` themselves.
+Stack commands additionally require GitHub's official extension: `gh extension install github/gh-stack`.
 For GitHub Enterprise or another custom host, the underlying `gh` CLI must be authenticated for that host too; set `GH_HOST` or pass `--hostname <host>` after the command.
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, editing, renaming, creating, deleting, or cloning gists; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, merging, or stacking pull requests; managing stacked branches; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, editing, renaming, creating, deleting, or cloning gists; or calling the GitHub API directly.
 
 ## Workflow
 
@@ -33,12 +34,13 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 6. Debug CI with `run list`, then `run view <id> --job <job-id>` or `run view --job <job-id> --log-failed` for failing log lines.
    Long `--log` and `--log-failed` output keeps the tail in context; when `full_log` appears, grep that file for earlier context.
 7. Every response ends with contextual next-step hints under `help:` - follow them.
+8. Manage stacked PRs from the target repository's working directory. Start with `stack init <branch>`, add layers with `stack add <branch>`, create PRs with `stack submit --open`, and inspect them with `stack view`.
 
 ## Commands
 
 ```
-commands[15]:
-  (none)=dashboard, issue, pr, run, workflow, release, repo, label, gist, project, secret, variable, search, api, setup
+commands[16]:
+  (none)=dashboard, issue, pr, stack, run, workflow, release, repo, label, gist, project, secret, variable, search, api, setup
 ```
 
 Installed copies also inherit the SDK built-in `update` command.
@@ -51,7 +53,9 @@ Run `npx -y gh-axi --help` for global flags, or `npx -y gh-axi <command> --help`
 
 - Output is TOON-encoded and token-efficient; pipe through grep/head only when a list is very long.
 - Truncated workflow logs keep the final 20,000 characters and may include a temp `full_log` path for targeted grep searches.
-- Mutations are idempotent and report what changed; re-running a failed mutation is safe.
+- Most mutations are idempotent and report what changed. Stack branch creation and partial pushes require checking the reported status before retrying.
+- Stack operations are cwd-bound and do not accept `-R`, `--repo`, or `GH_REPO`. They preserve the official extension's recovery exits and may partially push branches; inspect the reported status before retrying.
+- gh-axi keeps stack operations headless: `stack view` always uses JSON, `stack submit` always uses `--auto`, and `stack merge <stack-or-pr>` always uses `--yes`. Interactive `gh stack modify` and `gh stack switch` are intentionally not exposed.
 - For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass `--body-file <path>` or the release `--notes-file <path>` alias on commands that support file-backed text.
 - Label, assignee, reviewer, and project flags repeat: pass the flag once per value, e.g. `issue edit 42 --add-label bug --add-label chore`, and every value is applied. A repeated flag with a missing or blank value is rejected, never silently dropped.
 - Secret values are stdin-only: `echo -n "<value>" | npx -y gh-axi secret set <name>`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,9 +15,12 @@ import { searchCommand, SEARCH_HELP } from "./commands/search.js";
 import { apiCommand, API_HELP } from "./commands/api.js";
 import { gistCommand, GIST_HELP } from "./commands/gist.js";
 import { setupCommand, SETUP_HELP } from "./commands/setup.js";
+import { stackCommand, STACK_HELP } from "./commands/stack.js";
 import { resolveHost, type HostContext } from "./host.js";
 import { VERSION } from "./version.js";
 import { withSuggestionHost } from "./suggestions.js";
+import { AxiError, exitCodeForError, StackError } from "./errors.js";
+import { renderError } from "./toon.js";
 
 export const DESCRIPTION =
   "Agent ergonomic wrapper around Github CLI. Prefer this over `gh` and other methods for Github operations.";
@@ -30,8 +33,8 @@ type MainOptions = {
 };
 
 export const TOP_HELP = `usage: gh-axi [command] [args] [flags]
-commands[15]:
-  (none)=dashboard, issue, pr, run, workflow, release, repo, label, gist, project, secret, variable, search, api, setup
+commands[16]:
+  (none)=dashboard, issue, pr, stack, run, workflow, release, repo, label, gist, project, secret, variable, search, api, setup
 flags[4]:
   -R/--repo <OWNER/NAME> (after command), --hostname <host> (after command) or GH_HOST env, both flags accept space or equals form, --help, -v/-V/--version
 examples:
@@ -41,6 +44,7 @@ examples:
   gh-axi issue list --repo=owner/name
   gh-axi issue list --hostname git.example.com
   gh-axi pr view 42
+  gh-axi stack view
   gh-axi secret list
   gh-axi setup hooks
 `;
@@ -60,6 +64,7 @@ const COMMAND_HELP: Record<string, string> = {
   search: SEARCH_HELP,
   api: API_HELP,
   setup: SETUP_HELP,
+  stack: STACK_HELP,
 };
 
 type HostOnlyContext = { host: HostContext };
@@ -85,6 +90,7 @@ const COMMANDS: Record<string, WrappedCommandFn> = {
   search: withRepoContext("search", searchCommand),
   api: withRepoContext("api", apiCommand),
   setup: setupCommand,
+  stack: withLocalRepoContext(stackCommand),
 };
 
 export async function main(options: MainOptions = {}): Promise<void> {
@@ -97,6 +103,22 @@ export async function main(options: MainOptions = {}): Promise<void> {
     home: withRepoContext(undefined, homeCommand),
     commands: COMMANDS,
     getCommandHelp: (command) => COMMAND_HELP[command],
+    formatError: (error) => {
+      const axiError =
+        error instanceof AxiError
+          ? error
+          : new AxiError(
+              error instanceof Error ? error.message : String(error),
+              "UNKNOWN",
+            );
+      return {
+        output: `${renderError(axiError.message, axiError.code, axiError.suggestions)}\n`,
+        exitCode:
+          error instanceof StackError
+            ? error.exitCode
+            : exitCodeForError(axiError),
+      };
+    },
     resolveContext: ({ command, args }) => {
       const { repoFlag, hostFlag } = parseRepoContextArgs(command, args);
       // Explicit --hostname wins over the GH_HOST env var. Setting GH_HOST here
@@ -128,6 +150,24 @@ function withRepoContext(
         repoContext(ctx),
       ),
     );
+}
+
+function withLocalRepoContext(handler: CommandFn): WrappedCommandFn {
+  return (args, ctx) => {
+    const parsed = parseRepoContextArgs("stack", args);
+    const repo = repoContext(ctx);
+    if (
+      parsed.repoFlag !== undefined ||
+      repo?.source === "env" ||
+      process.env["GH_REPO"]
+    ) {
+      throw new AxiError(
+        "stack commands operate on the repository in the current working directory and do not support -R, --repo, or GH_REPO",
+        "VALIDATION_ERROR",
+      );
+    }
+    return withSuggestionHost(ctx?.host, () => handler(parsed.strippedArgs));
+  };
 }
 
 function repoContext(ctx?: CliContext): RepoContext | undefined {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+import { encode } from "@toon-format/toon";
 import { runAxiCli } from "axi-sdk-js";
 import { resolveRepo, type RepoContext } from "./context.js";
 import { homeCommand } from "./commands/home.js";
@@ -20,7 +21,6 @@ import { resolveHost, type HostContext } from "./host.js";
 import { VERSION } from "./version.js";
 import { withSuggestionHost } from "./suggestions.js";
 import { AxiError, exitCodeForError, StackError } from "./errors.js";
-import { renderError } from "./toon.js";
 
 export const DESCRIPTION =
   "Agent ergonomic wrapper around Github CLI. Prefer this over `gh` and other methods for Github operations.";
@@ -111,8 +111,16 @@ export async function main(options: MainOptions = {}): Promise<void> {
               error instanceof Error ? error.message : String(error),
               "UNKNOWN",
             );
+      // Mirrors the SDK's defaultFormatError output byte-for-byte; the only
+      // difference this hook introduces is StackError's upstream exit code.
       return {
-        output: `${renderError(axiError.message, axiError.code, axiError.suggestions)}\n`,
+        output: `${encode({
+          error: axiError.message,
+          code: axiError.code,
+          ...(axiError.suggestions.length > 0
+            ? { help: axiError.suggestions }
+            : {}),
+        })}\n`,
         exitCode:
           error instanceof StackError
             ? error.exitCode
@@ -155,12 +163,7 @@ function withRepoContext(
 function withLocalRepoContext(handler: CommandFn): WrappedCommandFn {
   return (args, ctx) => {
     const parsed = parseRepoContextArgs("stack", args);
-    const repo = repoContext(ctx);
-    if (
-      parsed.repoFlag !== undefined ||
-      repo?.source === "env" ||
-      process.env["GH_REPO"]
-    ) {
+    if (parsed.repoFlag !== undefined || process.env["GH_REPO"]) {
       throw new AxiError(
         "stack commands operate on the repository in the current working directory and do not support -R, --repo, or GH_REPO",
         "VALIDATION_ERROR",

--- a/src/commands/stack.ts
+++ b/src/commands/stack.ts
@@ -10,12 +10,12 @@ type StackBranch = {
   isMerged: boolean;
   isQueued: boolean;
   needsRebase: boolean;
-  pr?: { number: number; url?: string; state: string };
+  pr?: { number: number; url?: string; state?: string };
 };
 
 type StackView = {
-  trunk: string;
-  currentBranch: string;
+  trunk?: string;
+  currentBranch?: string;
   branches: StackBranch[];
 };
 
@@ -46,6 +46,10 @@ examples:
 const REMOTE_FLAGS: FlagSpec = { "--remote": "value" };
 // eslint-disable-next-line no-control-regex -- upstream status may contain ANSI color sequences
 const ANSI_ESCAPE = new RegExp("\\u001b\\[[0-9;]*m", "g");
+const STATUS_MARKER = /^([✓✗⚠ℹ])\s*/;
+const FAILURE_MARKERS = ["✗", "⚠"];
+const FAILURE_DIAGNOSTIC =
+  /failed|could not|couldn't|cannot create|not .*updated automatically|remain stacked|not fully|skipping rebase/i;
 
 export async function stackCommand(args: string[]): Promise<string> {
   if (args.length === 0 || args.includes("--help")) return STACK_HELP;
@@ -110,7 +114,7 @@ export async function stackCommand(args: string[]): Promise<string> {
     case "up":
     case "down": {
       const positional = parseArgs(rest, {}, 0, 1);
-      if (positional[0] && !/^\d+$/.test(positional[0])) {
+      if (positional[0] && !/^[1-9]\d*$/.test(positional[0])) {
         throw validation(`${subcommand} distance must be a positive integer`);
       }
       return runStack(subcommand, rest);
@@ -127,20 +131,19 @@ export async function stackCommand(args: string[]): Promise<string> {
 
 async function stackView(): Promise<string> {
   const result = await execute(["stack", "view", "--json"]);
-  let view: StackView;
+  let parsed: unknown;
   try {
-    view = JSON.parse(result.stdout) as StackView;
+    parsed = JSON.parse(result.stdout);
   } catch {
-    throw new AxiError(
-      `Unexpected gh stack output: ${result.stdout.slice(0, 200)}`,
-      "UNKNOWN",
-    );
+    throw unexpectedOutput(result.stdout);
   }
+  if (!isStackView(parsed)) throw unexpectedOutput(result.stdout);
+  const view = parsed;
 
   return encode({
     stack: {
-      trunk: view.trunk,
-      current_branch: view.currentBranch,
+      trunk: view.trunk ?? null,
+      current_branch: view.currentBranch ?? null,
       branch_count: view.branches.length,
     },
     branches: view.branches.map((branch) => ({
@@ -150,7 +153,7 @@ async function stackView(): Promise<string> {
         ? "merged"
         : branch.isQueued
           ? "queued"
-          : (branch.pr?.state.toLowerCase() ?? "local"),
+          : (branch.pr?.state?.toLowerCase() ?? "local"),
       needs_rebase: branch.needsRebase,
       pr: branch.pr?.number ?? null,
       url: branch.pr?.url ?? null,
@@ -158,16 +161,35 @@ async function stackView(): Promise<string> {
   });
 }
 
+function isStackView(value: unknown): value is StackView {
+  if (typeof value !== "object" || value === null) return false;
+  const branches = (value as { branches?: unknown }).branches;
+  return (
+    Array.isArray(branches) &&
+    branches.every((branch) => typeof branch === "object" && branch !== null)
+  );
+}
+
+function unexpectedOutput(stdout: string): AxiError {
+  return new AxiError(
+    `Unexpected gh stack output: ${stdout.slice(0, 200)}`,
+    "UNKNOWN",
+  );
+}
+
 async function runStack(action: string, args: string[]): Promise<string> {
   const result = await execute(["stack", action, ...args]);
   const messages = [...lines(result.stdout), ...lines(result.stderr)];
-  const aborted = messages.some((line) => /sync aborted/i.test(line));
-  const partial = messages.some((line) =>
-    /failed|could not|couldn't|cannot create|not .*updated automatically|remain stacked|not fully|skipping rebase/i.test(
-      line,
-    ),
+  // Classify only the extension's own marker-prefixed stderr diagnostics: stdout
+  // and unmarked lines echo user-supplied text (commit subjects, branch names)
+  // that would otherwise be misread as a failure report.
+  const diagnostics = statusDiagnostics(result.stderr);
+  const aborted = diagnostics.some(({ text }) => /sync aborted/i.test(text));
+  const partial = diagnostics.some(
+    ({ marker, text }) =>
+      FAILURE_MARKERS.includes(marker) && FAILURE_DIAGNOSTIC.test(text),
   );
-  const warned = result.stderr.includes("⚠");
+  const warned = diagnostics.some(({ marker }) => marker === "⚠");
   return encode({
     stack: {
       action,
@@ -344,8 +366,21 @@ function lines(output: string): string[] {
   return output
     .replace(ANSI_ESCAPE, "")
     .split("\n")
-    .map((line) => line.trim().replace(/^[✓✗⚠ℹ]\s*/, ""))
+    .map((line) => line.trim().replace(STATUS_MARKER, ""))
     .filter(Boolean);
+}
+
+function statusDiagnostics(stderr: string): { marker: string; text: string }[] {
+  return stderr
+    .replace(ANSI_ESCAPE, "")
+    .split("\n")
+    .flatMap((line) => {
+      const trimmed = line.trim();
+      const match = STATUS_MARKER.exec(trimmed);
+      if (!match) return [];
+      const text = trimmed.slice(match[0].length).trim();
+      return text ? [{ marker: match[1], text }] : [];
+    });
 }
 
 function validation(message: string): AxiError {

--- a/src/commands/stack.ts
+++ b/src/commands/stack.ts
@@ -1,0 +1,355 @@
+import { encode } from "@toon-format/toon";
+import { ghRaw, type ExecResult } from "../gh.js";
+import { AxiError, StackError } from "../errors.js";
+
+type StackBranch = {
+  name: string;
+  head?: string;
+  base?: string;
+  isCurrent: boolean;
+  isMerged: boolean;
+  isQueued: boolean;
+  needsRebase: boolean;
+  pr?: { number: number; url?: string; state: string };
+};
+
+type StackView = {
+  trunk: string;
+  currentBranch: string;
+  branches: StackBranch[];
+};
+
+type FlagSpec = Record<string, "boolean" | "value">;
+
+export const STACK_HELP = `usage: gh-axi stack <subcommand> [args] [flags]
+subcommands[16]:
+  view, init <branches...>, add [branch], checkout <stack|pr|url|branch>, push, submit, sync, rebase [branch], link <refs...>, unstack [stack], merge <stack|pr>, up [n], down [n], top, bottom, trunk
+flags{init}: --base <branch>
+flags{add}: --message <text>, --all, --update
+flags{push}: --remote <name>
+flags{submit}: --open, --remote <name> (--auto is always applied)
+flags{sync}: --prune, --remote <name>
+flags{rebase}: --downstack, --upstack, --no-trunk, --continue, --abort, --remote <name>, --committer-date-is-author-date, --preserve-dates
+flags{link}: --base <branch>, --open, --remote <name>
+flags{unstack}: --local
+flags{merge}: --merge-method <merge|squash|rebase>, --merge, --squash, --rebase (--yes is always applied)
+notes:
+  Requires the official extension: gh extension install github/gh-stack
+  Operates on the git repository in the current working directory; -R, --repo, and GH_REPO are not supported
+examples:
+  gh-axi stack init feature-model feature-api
+  gh-axi stack submit --open
+  gh-axi stack view
+  gh-axi stack rebase --continue
+  gh-axi stack merge 42 --squash`;
+
+const REMOTE_FLAGS: FlagSpec = { "--remote": "value" };
+// eslint-disable-next-line no-control-regex -- upstream status may contain ANSI color sequences
+const ANSI_ESCAPE = new RegExp("\\u001b\\[[0-9;]*m", "g");
+
+export async function stackCommand(args: string[]): Promise<string> {
+  if (args.length === 0 || args.includes("--help")) return STACK_HELP;
+
+  const [subcommand, ...rest] = args;
+  switch (subcommand) {
+    case "view":
+      parseArgs(rest, {}, 0, 0);
+      return stackView();
+    case "init":
+      parseArgs(rest, { "-b": "value", "--base": "value" }, 1);
+      return runStack(subcommand, rest);
+    case "add":
+      validateAdd(rest);
+      return runStack(subcommand, rest);
+    case "checkout":
+      parseArgs(rest, {}, 1, 1);
+      return runStack(subcommand, rest);
+    case "push":
+      parseArgs(rest, REMOTE_FLAGS, 0, 0);
+      return runStack(subcommand, rest);
+    case "submit":
+      parseArgs(rest, { ...REMOTE_FLAGS, "--open": "boolean" }, 0, 0);
+      return runStack(subcommand, [...rest, "--auto"]);
+    case "sync":
+      parseArgs(rest, { ...REMOTE_FLAGS, "--prune": "boolean" }, 0, 0);
+      return runStack(subcommand, rest);
+    case "rebase":
+      parseArgs(
+        rest,
+        {
+          ...REMOTE_FLAGS,
+          "--downstack": "boolean",
+          "--upstack": "boolean",
+          "--no-trunk": "boolean",
+          "--continue": "boolean",
+          "--abort": "boolean",
+          "--committer-date-is-author-date": "boolean",
+          "--preserve-dates": "boolean",
+        },
+        0,
+        1,
+      );
+      return runStack(subcommand, rest);
+    case "link":
+      parseArgs(
+        rest,
+        {
+          ...REMOTE_FLAGS,
+          "--base": "value",
+          "--open": "boolean",
+        },
+        2,
+      );
+      return runStack(subcommand, rest);
+    case "unstack":
+      parseArgs(rest, { "--local": "boolean" }, 0, 1);
+      return runStack(subcommand, rest);
+    case "merge":
+      validateMerge(rest);
+      return runStack(subcommand, [...rest, "--yes"]);
+    case "up":
+    case "down": {
+      const positional = parseArgs(rest, {}, 0, 1);
+      if (positional[0] && !/^\d+$/.test(positional[0])) {
+        throw validation(`${subcommand} distance must be a positive integer`);
+      }
+      return runStack(subcommand, rest);
+    }
+    case "top":
+    case "bottom":
+    case "trunk":
+      parseArgs(rest, {}, 0, 0);
+      return runStack(subcommand, rest);
+    default:
+      throw validation(`Unknown stack subcommand: ${subcommand}`);
+  }
+}
+
+async function stackView(): Promise<string> {
+  const result = await execute(["stack", "view", "--json"]);
+  let view: StackView;
+  try {
+    view = JSON.parse(result.stdout) as StackView;
+  } catch {
+    throw new AxiError(
+      `Unexpected gh stack output: ${result.stdout.slice(0, 200)}`,
+      "UNKNOWN",
+    );
+  }
+
+  return encode({
+    stack: {
+      trunk: view.trunk,
+      current_branch: view.currentBranch,
+      branch_count: view.branches.length,
+    },
+    branches: view.branches.map((branch) => ({
+      name: branch.name,
+      current: branch.isCurrent,
+      state: branch.isMerged
+        ? "merged"
+        : branch.isQueued
+          ? "queued"
+          : (branch.pr?.state.toLowerCase() ?? "local"),
+      needs_rebase: branch.needsRebase,
+      pr: branch.pr?.number ?? null,
+      url: branch.pr?.url ?? null,
+    })),
+  });
+}
+
+async function runStack(action: string, args: string[]): Promise<string> {
+  const result = await execute(["stack", action, ...args]);
+  const messages = [...lines(result.stdout), ...lines(result.stderr)];
+  const aborted = messages.some((line) => /sync aborted/i.test(line));
+  const partial = messages.some((line) =>
+    /failed|could not|couldn't|cannot create|not .*updated automatically|remain stacked|not fully|skipping rebase/i.test(
+      line,
+    ),
+  );
+  const warned = result.stderr.includes("⚠");
+  return encode({
+    stack: {
+      action,
+      status: aborted
+        ? "aborted"
+        : partial
+          ? "partial"
+          : warned
+            ? "warning"
+            : "ok",
+      messages: messages.length > 0 ? messages : ["completed"],
+    },
+  });
+}
+
+async function execute(args: string[]): Promise<ExecResult> {
+  const result = await ghRaw(args);
+  if (result.exitCode === 0) return result;
+
+  const diagnostics = [...lines(result.stderr), ...lines(result.stdout)];
+  const message =
+    diagnostics.join("\n") || `gh stack exited with code ${result.exitCode}`;
+  if (/unknown command ["']?stack/i.test(result.stderr)) {
+    throw new StackError(message, result.exitCode, [
+      "Run `gh extension install github/gh-stack` to install the official extension",
+    ]);
+  }
+
+  throw new StackError(
+    message,
+    result.exitCode,
+    stackRecovery(args[1] ?? "", result.exitCode),
+  );
+}
+
+function stackRecovery(action: string, exitCode: number): string[] {
+  switch (exitCode) {
+    case 2:
+      return ["Run `gh-axi stack init <branch>` to create or adopt a stack"];
+    case 3:
+      if (action === "rebase") {
+        return [
+          "Resolve conflicts, stage the files with `git add`, then run `gh-axi stack rebase --continue`",
+          "Run `gh-axi stack rebase --abort` to restore the stack",
+        ];
+      }
+      if (action === "sync") {
+        return [
+          "The sync restored the stack; run `gh-axi stack rebase` to resolve conflicts explicitly",
+        ];
+      }
+      if (action === "checkout") {
+        return [
+          "Reconcile the local and remote stack, or run `gh-axi stack unstack --local` before retrying checkout",
+        ];
+      }
+      return ["Resolve the reported conflict, then retry the stack operation"];
+    case 4:
+      return ["Run `gh auth status` and retry the command"];
+    case 6:
+      return ["Check out a branch that belongs to only one stack and retry"];
+    case 7:
+      return [
+        "Run `gh-axi stack rebase --continue` after resolving conflicts, or `gh-axi stack rebase --abort`",
+      ];
+    case 8:
+      return ["Wait for the other stack operation to finish, then retry"];
+    case 9:
+      return ["Enable stacked PRs for this repository before retrying"];
+    case 10:
+      return [
+        "Use `gh stack modify --continue` or `gh stack modify --abort` to recover the interrupted session",
+      ];
+    default:
+      return [];
+  }
+}
+
+function validateAdd(args: string[]): void {
+  const normalized = args.flatMap((arg) =>
+    arg === "-Am" ? ["-A", "-m"] : arg === "-um" ? ["-u", "-m"] : [arg],
+  );
+  const positional = parseArgs(
+    normalized,
+    {
+      "-m": "value",
+      "--message": "value",
+      "-A": "boolean",
+      "--all": "boolean",
+      "-u": "boolean",
+      "--update": "boolean",
+    },
+    0,
+    1,
+  );
+  const hasMessage = normalized.some(
+    (arg) =>
+      arg === "-m" || arg === "--message" || arg.startsWith("--message="),
+  );
+  const stagesAll = normalized.some((arg) => arg === "-A" || arg === "--all");
+  const stagesTracked = normalized.some(
+    (arg) => arg === "-u" || arg === "--update",
+  );
+  if (stagesAll && stagesTracked)
+    throw validation("Choose only --all or --update");
+  if ((stagesAll || stagesTracked) && !hasMessage) {
+    throw validation("--all and --update require --message");
+  }
+  if (positional.length === 0 && !hasMessage) {
+    throw validation("stack add requires a branch or --message");
+  }
+}
+
+function validateMerge(args: string[]): void {
+  parseArgs(
+    args,
+    {
+      "--merge-method": "value",
+      "--merge": "boolean",
+      "--squash": "boolean",
+      "--rebase": "boolean",
+    },
+    1,
+    1,
+  );
+  const methods = args.filter(
+    (arg) =>
+      ["--merge", "--squash", "--rebase", "--merge-method"].includes(arg) ||
+      arg.startsWith("--merge-method="),
+  );
+  if (methods.length > 1) throw validation("Choose only one merge method");
+}
+
+function parseArgs(
+  args: string[],
+  flags: FlagSpec,
+  minPositionals: number,
+  maxPositionals = Number.POSITIVE_INFINITY,
+): string[] {
+  const positional: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (!arg.startsWith("-")) {
+      positional.push(arg);
+      continue;
+    }
+    const [name, equalsValue] = arg.split("=", 2);
+    const kind = flags[name];
+    if (!kind) throw validation(`Unsupported stack flag: ${name}`);
+    if (kind === "boolean") {
+      if (equalsValue !== undefined)
+        throw validation(`${name} does not take a value`);
+      continue;
+    }
+    const valueFromEquals = equalsValue !== undefined;
+    const value = equalsValue ?? args[++index];
+    if (!value || (!valueFromEquals && value.startsWith("-")))
+      throw validation(`${name} requires a value`);
+  }
+  if (positional.length < minPositionals) {
+    throw validation(
+      `Expected at least ${minPositionals} stack argument${minPositionals === 1 ? "" : "s"}`,
+    );
+  }
+  if (positional.length > maxPositionals) {
+    throw validation(
+      `Expected at most ${maxPositionals} stack argument${maxPositionals === 1 ? "" : "s"}`,
+    );
+  }
+  return positional;
+}
+
+function lines(output: string): string[] {
+  return output
+    .replace(ANSI_ESCAPE, "")
+    .split("\n")
+    .map((line) => line.trim().replace(/^[✓✗⚠ℹ]\s*/, ""))
+    .filter(Boolean);
+}
+
+function validation(message: string): AxiError {
+  return new AxiError(message, "VALIDATION_ERROR", [
+    "Run `gh-axi stack --help` to see agent-safe forms",
+  ]);
+}

--- a/src/commands/stack.ts
+++ b/src/commands/stack.ts
@@ -47,9 +47,11 @@ const REMOTE_FLAGS: FlagSpec = { "--remote": "value" };
 // eslint-disable-next-line no-control-regex -- upstream status may contain ANSI color sequences
 const ANSI_ESCAPE = new RegExp("\\u001b\\[[0-9;]*m", "g");
 const STATUS_MARKER = /^([✓✗⚠ℹ])\s*/;
-const FAILURE_MARKERS = ["✗", "⚠"];
+const NON_FAILURE_MARKERS = ["✓", "ℹ"];
 const FAILURE_DIAGNOSTIC =
   /failed|could not|couldn't|cannot create|not .*updated automatically|remain stacked|not fully|skipping rebase/i;
+
+type Diagnostic = { marker: string; text: string };
 
 export async function stackCommand(args: string[]): Promise<string> {
   if (args.length === 0 || args.includes("--help")) return STACK_HELP;
@@ -179,17 +181,20 @@ function unexpectedOutput(stdout: string): AxiError {
 
 async function runStack(action: string, args: string[]): Promise<string> {
   const result = await execute(["stack", action, ...args]);
-  const messages = [...lines(result.stdout), ...lines(result.stderr)];
-  // Classify only the extension's own marker-prefixed stderr diagnostics: stdout
-  // and unmarked lines echo user-supplied text (commit subjects, branch names)
-  // that would otherwise be misread as a failure report.
-  const diagnostics = statusDiagnostics(result.stderr);
-  const aborted = diagnostics.some(({ text }) => /sync aborted/i.test(text));
-  const partial = diagnostics.some(
-    ({ marker, text }) =>
-      FAILURE_MARKERS.includes(marker) && FAILURE_DIAGNOSTIC.test(text),
+  // Classify from stderr only: stdout echoes user-supplied text (commit
+  // subjects, branch names) that reads like a failure report. Lines the
+  // extension itself marks as succeeded are excluded for the same reason;
+  // everything else, including unmarked git subprocess diagnostics, counts.
+  const stderrDiagnostics = diagnostics(result.stderr);
+  const messages = [
+    ...lines(result.stdout),
+    ...stderrDiagnostics.map(({ text }) => text),
+  ];
+  const aborted = stderrDiagnostics.some(({ text }) =>
+    /sync aborted/i.test(text),
   );
-  const warned = diagnostics.some(({ marker }) => marker === "⚠");
+  const partial = stderrDiagnostics.some(isFailureDiagnostic);
+  const warned = result.stderr.includes("⚠");
   return encode({
     stack: {
       action,
@@ -362,25 +367,25 @@ function parseArgs(
   return positional;
 }
 
-function lines(output: string): string[] {
+function diagnostics(output: string): Diagnostic[] {
   return output
-    .replace(ANSI_ESCAPE, "")
-    .split("\n")
-    .map((line) => line.trim().replace(STATUS_MARKER, ""))
-    .filter(Boolean);
-}
-
-function statusDiagnostics(stderr: string): { marker: string; text: string }[] {
-  return stderr
     .replace(ANSI_ESCAPE, "")
     .split("\n")
     .flatMap((line) => {
       const trimmed = line.trim();
       const match = STATUS_MARKER.exec(trimmed);
-      if (!match) return [];
-      const text = trimmed.slice(match[0].length).trim();
-      return text ? [{ marker: match[1], text }] : [];
+      const marker = match ? match[1] : "";
+      const text = match ? trimmed.slice(match[0].length).trim() : trimmed;
+      return text ? [{ marker, text }] : [];
     });
+}
+
+function lines(output: string): string[] {
+  return diagnostics(output).map(({ text }) => text);
+}
+
+function isFailureDiagnostic({ marker, text }: Diagnostic): boolean {
+  return !NON_FAILURE_MARKERS.includes(marker) && FAILURE_DIAGNOSTIC.test(text);
 }
 
 function validation(message: string): AxiError {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -12,6 +12,17 @@ export type ErrorCode =
 
 export { AxiError, exitCodeForError };
 
+export class StackError extends AxiError {
+  constructor(
+    message: string,
+    readonly exitCode: number,
+    suggestions: string[] = [],
+  ) {
+    super(message, "STACK_ERROR", suggestions);
+    this.name = "StackError";
+  }
+}
+
 interface ErrorPattern {
   pattern: RegExp;
   code: ErrorCode;

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -3,9 +3,9 @@ import { DESCRIPTION, TOP_HELP } from "./cli.js";
 // Trigger string Claude Code (and other agents) match against to auto-load the skill.
 // Kept terse and outcome-focused so it fires on "needs GitHub" intents.
 export const SKILL_DESCRIPTION =
-  "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, " +
+  "Operate GitHub through the gh-axi CLI - issues, pull requests, stacked PRs, workflow runs, workflows, " +
   "releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. " +
-  "Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, " +
+  "Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, managing stacked branches and PRs, " +
   "checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist view`, `gist edit`, `gist rename`, `gist create`, `gist delete`, or `gist clone`.";
 
 export const SKILL_AUTHOR = "Kun Chen (kunchenguid)";
@@ -67,11 +67,12 @@ You do not need gh-axi installed globally - invoke it with \`npx -y gh-axi <comm
 If gh-axi output shows a follow-up command starting with \`gh-axi\`, run it as \`npx -y gh-axi ...\` instead.
 
 gh-axi requires the [\`gh\`](https://cli.github.com/) CLI installed and authenticated (\`gh auth login\`). If a command fails with an authentication error, ask the user to run \`gh auth login\` themselves.
+Stack commands additionally require GitHub's official extension: \`gh extension install github/gh-stack\`.
 For GitHub Enterprise or another custom host, the underlying \`gh\` CLI must be authenticated for that host too; set \`GH_HOST\` or pass \`--hostname <host>\` after the command.
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, editing, renaming, creating, deleting, or cloning gists; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, merging, or stacking pull requests; managing stacked branches; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, editing, renaming, creating, deleting, or cloning gists; or calling the GitHub API directly.
 
 ## Workflow
 
@@ -83,6 +84,7 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 6. Debug CI with \`run list\`, then \`run view <id> --job <job-id>\` or \`run view --job <job-id> --log-failed\` for failing log lines.
    Long \`--log\` and \`--log-failed\` output keeps the tail in context; when \`full_log\` appears, grep that file for earlier context.
 7. Every response ends with contextual next-step hints under \`help:\` - follow them.
+8. Manage stacked PRs from the target repository's working directory. Start with \`stack init <branch>\`, add layers with \`stack add <branch>\`, create PRs with \`stack submit --open\`, and inspect them with \`stack view\`.
 
 ## Commands
 
@@ -100,7 +102,9 @@ Run \`npx -y gh-axi --help\` for global flags, or \`npx -y gh-axi <command> --he
 
 - Output is TOON-encoded and token-efficient; pipe through grep/head only when a list is very long.
 - Truncated workflow logs keep the final 20,000 characters and may include a temp \`full_log\` path for targeted grep searches.
-- Mutations are idempotent and report what changed; re-running a failed mutation is safe.
+- Most mutations are idempotent and report what changed. Stack branch creation and partial pushes require checking the reported status before retrying.
+- Stack operations are cwd-bound and do not accept \`-R\`, \`--repo\`, or \`GH_REPO\`. They preserve the official extension's recovery exits and may partially push branches; inspect the reported status before retrying.
+- gh-axi keeps stack operations headless: \`stack view\` always uses JSON, \`stack submit\` always uses \`--auto\`, and \`stack merge <stack-or-pr>\` always uses \`--yes\`. Interactive \`gh stack modify\` and \`gh stack switch\` are intentionally not exposed.
 - For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass \`--body-file <path>\` or the release \`--notes-file <path>\` alias on commands that support file-backed text.
 - Label, assignee, reviewer, and project flags repeat: pass the flag once per value, e.g. \`issue edit 42 --add-label bug --add-label chore\`, and every value is applied. A repeated flag with a missing or blank value is rejected, never silently dropped.
 - Secret values are stdin-only: \`echo -n "<value>" | npx -y gh-axi secret set <name>\`.

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -83,7 +83,8 @@ import { issueCommand } from "../src/commands/issue.js";
 import { prCommand } from "../src/commands/pr.js";
 import { releaseCommand } from "../src/commands/release.js";
 import { resolveRepo } from "../src/context.js";
-import { StackError } from "../src/errors.js";
+import { AxiError, StackError } from "../src/errors.js";
+import { encode } from "@toon-format/toon";
 
 const packageVersion = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
@@ -230,14 +231,21 @@ describe("main CLI", () => {
       }),
     ).toThrow(/current working directory/);
 
-    expect(() =>
-      options.commands.stack(["view"], {
-        owner: "env",
-        name: "repo",
-        nwo: "env/repo",
-        source: "env",
-      }),
-    ).toThrow(/GH_REPO/);
+    const originalGhRepo = process.env["GH_REPO"];
+    process.env["GH_REPO"] = "env/repo";
+    try {
+      expect(() =>
+        options.commands.stack(["view"], {
+          owner: "env",
+          name: "repo",
+          nwo: "env/repo",
+          source: "env",
+        }),
+      ).toThrow(/GH_REPO/);
+    } finally {
+      if (originalGhRepo === undefined) delete process.env["GH_REPO"];
+      else process.env["GH_REPO"] = originalGhRepo;
+    }
   });
 
   it("preserves stack-specific process exit codes", async () => {
@@ -249,6 +257,44 @@ describe("main CLI", () => {
 
     expect(formatted.exitCode).toBe(3);
     expect(formatted.output).toContain("STACK_ERROR");
+  });
+
+  it("formats non-stack errors exactly like the SDK default", async () => {
+    await main();
+    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+
+    const withHelp = options.formatError(
+      new AxiError('Repository "o/r" not found', "REPO_NOT_FOUND", [
+        "Run `gh-axi repo list` to see your repositories",
+        "Then retry",
+      ]),
+    );
+    expect(withHelp.output).toBe(
+      `${encode({
+        error: 'Repository "o/r" not found',
+        code: "REPO_NOT_FOUND",
+        help: ["Run `gh-axi repo list` to see your repositories", "Then retry"],
+      })}\n`,
+    );
+    expect(withHelp.output).toContain(
+      "help[2]: Run `gh-axi repo list` to see your repositories,Then retry",
+    );
+    expect(withHelp.exitCode).toBe(1);
+
+    const withoutHelp = options.formatError(
+      new AxiError("bad flag", "VALIDATION_ERROR"),
+    );
+    expect(withoutHelp.output).toBe(
+      `${encode({ error: "bad flag", code: "VALIDATION_ERROR" })}\n`,
+    );
+    expect(withoutHelp.output).not.toContain("help");
+    expect(withoutHelp.exitCode).toBe(2);
+
+    const plain = options.formatError(new Error("boom"));
+    expect(plain.output).toBe(
+      `${encode({ error: "boom", code: "UNKNOWN" })}\n`,
+    );
+    expect(plain.exitCode).toBe(1);
   });
 
   it("lists secret and variable in the top-level command index", () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -63,6 +63,10 @@ vi.mock("../src/commands/api.js", () => ({
   apiCommand: vi.fn().mockResolvedValue("api output"),
   API_HELP: "api help",
 }));
+vi.mock("../src/commands/stack.js", () => ({
+  stackCommand: vi.fn().mockResolvedValue("stack output"),
+  STACK_HELP: "stack help",
+}));
 
 vi.mock("../src/context.js", () => ({
   resolveRepo: vi.fn().mockReturnValue({
@@ -79,6 +83,7 @@ import { issueCommand } from "../src/commands/issue.js";
 import { prCommand } from "../src/commands/pr.js";
 import { releaseCommand } from "../src/commands/release.js";
 import { resolveRepo } from "../src/context.js";
+import { StackError } from "../src/errors.js";
 
 const packageVersion = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
@@ -199,7 +204,51 @@ describe("main CLI", () => {
     expect(options.getCommandHelp("issue")).toBe("issue help");
     expect(options.getCommandHelp("secret")).toBe("secret help");
     expect(options.getCommandHelp("variable")).toBe("variable help");
+    expect(options.getCommandHelp("stack")).toBe("stack help");
     expect(options.getCommandHelp("missing")).toBeUndefined();
+  });
+
+  it("keeps stack commands cwd-bound", async () => {
+    await main();
+    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+    const { stackCommand } = await import("../src/commands/stack.js");
+
+    await options.commands.stack(["view"], {
+      owner: "octo",
+      name: "repo",
+      nwo: "octo/repo",
+      source: "git",
+    });
+    expect(vi.mocked(stackCommand)).toHaveBeenCalledWith(["view"]);
+
+    expect(() =>
+      options.commands.stack(["view", "-R", "other/repo"], {
+        owner: "other",
+        name: "repo",
+        nwo: "other/repo",
+        source: "flag",
+      }),
+    ).toThrow(/current working directory/);
+
+    expect(() =>
+      options.commands.stack(["view"], {
+        owner: "env",
+        name: "repo",
+        nwo: "env/repo",
+        source: "env",
+      }),
+    ).toThrow(/GH_REPO/);
+  });
+
+  it("preserves stack-specific process exit codes", async () => {
+    await main();
+    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+    const formatted = options.formatError(
+      new StackError("rebase conflict", 3, ["resolve it"]),
+    );
+
+    expect(formatted.exitCode).toBe(3);
+    expect(formatted.output).toContain("STACK_ERROR");
   });
 
   it("lists secret and variable in the top-level command index", () => {

--- a/test/commands/stack.test.ts
+++ b/test/commands/stack.test.ts
@@ -149,6 +149,68 @@ describe("stackCommand", () => {
     expect(output).toContain("Push failed");
   });
 
+  it("does not read an echoed commit subject as a partial failure", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 0,
+      stdout: "[api 1a2b3c4] fix: could not parse dates\n",
+      stderr: '✓ Added commit "fix: could not parse dates" to api\n',
+    });
+
+    const output = await stackCommand([
+      "add",
+      "-A",
+      "-m",
+      "fix: could not parse dates",
+    ]);
+
+    expect(output).toContain("status: ok");
+  });
+
+  it("rejects a zero navigation distance", async () => {
+    await expect(stackCommand(["up", "0"])).rejects.toThrow(/positive integer/);
+    await expect(stackCommand(["down", "0"])).rejects.toThrow(
+      /positive integer/,
+    );
+    expect(mockedGhRaw).not.toHaveBeenCalled();
+  });
+
+  it("reports an unrecognized view payload instead of throwing a TypeError", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 0,
+      stdout: JSON.stringify({ trunk: "main" }),
+      stderr: "",
+    });
+
+    await expect(stackCommand(["view"])).rejects.toMatchObject({
+      code: "UNKNOWN",
+      message: expect.stringContaining("Unexpected gh stack output"),
+    });
+  });
+
+  it("tolerates a branch whose pr carries no state", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 0,
+      stderr: "",
+      stdout: JSON.stringify({
+        branches: [
+          {
+            name: "api",
+            isCurrent: true,
+            isMerged: false,
+            isQueued: false,
+            needsRebase: false,
+            pr: { number: 7 },
+          },
+        ],
+      }),
+    });
+
+    const output = await stackCommand(["view"]);
+
+    expect(output).toContain("trunk: null");
+    expect(output).toContain("api,true,local,false,7,null");
+  });
+
   it("does not report upstream warnings as clean success", async () => {
     mockedGhRaw.mockResolvedValue({
       exitCode: 0,

--- a/test/commands/stack.test.ts
+++ b/test/commands/stack.test.ts
@@ -149,6 +149,20 @@ describe("stackCommand", () => {
     expect(output).toContain("Push failed");
   });
 
+  it("reports unmarked git push diagnostics as partial", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr:
+        "error: failed to push some refs to 'https://github.com/o/r.git'\nhint: Updates were rejected because the remote contains work you do not have\n",
+    });
+
+    const output = await stackCommand(["push"]);
+
+    expect(output).toContain("status: partial");
+    expect(output).toContain("failed to push some refs");
+  });
+
   it("does not read an echoed commit subject as a partial failure", async () => {
     mockedGhRaw.mockResolvedValue({
       exitCode: 0,

--- a/test/commands/stack.test.ts
+++ b/test/commands/stack.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/gh.js", () => ({ ghRaw: vi.fn() }));
+
+import { ghRaw } from "../../src/gh.js";
+import { stackCommand, STACK_HELP } from "../../src/commands/stack.js";
+import { AxiError, StackError } from "../../src/errors.js";
+
+const mockedGhRaw = vi.mocked(ghRaw);
+
+describe("stackCommand", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns help without invoking gh", async () => {
+    expect(await stackCommand([])).toBe(STACK_HELP);
+    expect(mockedGhRaw).not.toHaveBeenCalled();
+  });
+
+  it("always views the stack as JSON and renders TOON", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 0,
+      stderr: "",
+      stdout: JSON.stringify({
+        trunk: "main",
+        currentBranch: "api",
+        branches: [
+          {
+            name: "model",
+            isCurrent: false,
+            isMerged: false,
+            isQueued: false,
+            needsRebase: false,
+            pr: {
+              number: 42,
+              url: "https://github.com/o/r/pull/42",
+              state: "OPEN",
+            },
+          },
+          {
+            name: "api",
+            isCurrent: true,
+            isMerged: false,
+            isQueued: false,
+            needsRebase: true,
+          },
+        ],
+      }),
+    });
+
+    const output = await stackCommand(["view"]);
+
+    expect(mockedGhRaw).toHaveBeenCalledWith(["stack", "view", "--json"]);
+    expect(output).toContain("current_branch: api");
+    expect(output).toContain("branch_count: 2");
+    expect(output).toContain("model,false,open,false,42");
+    expect(output).toContain("api,true,local,true,null,null");
+  });
+
+  it("forces submit into auto mode", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr: "✓ Pushed and synced 2 branches\n",
+    });
+
+    const output = await stackCommand(["submit", "--open"]);
+
+    expect(mockedGhRaw).toHaveBeenCalledWith([
+      "stack",
+      "submit",
+      "--open",
+      "--auto",
+    ]);
+    expect(output).toContain("status: ok");
+    expect(output).toContain("Pushed and synced 2 branches");
+  });
+
+  it("forces merge confirmation and requires a target", async () => {
+    await expect(stackCommand(["merge", "--squash"])).rejects.toBeInstanceOf(
+      AxiError,
+    );
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr: "Merged stack\n",
+    });
+
+    await stackCommand(["merge", "42", "--squash"]);
+
+    expect(mockedGhRaw).toHaveBeenCalledWith([
+      "stack",
+      "merge",
+      "42",
+      "--squash",
+      "--yes",
+    ]);
+  });
+
+  it("rejects interactive forms before invoking gh", async () => {
+    await expect(stackCommand(["init"])).rejects.toBeInstanceOf(AxiError);
+    await expect(stackCommand(["checkout"])).rejects.toBeInstanceOf(AxiError);
+    await expect(stackCommand(["add"])).rejects.toBeInstanceOf(AxiError);
+    expect(mockedGhRaw).not.toHaveBeenCalled();
+  });
+
+  it("allows message-driven add and validates staging flags", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr: "Created branch\n",
+    });
+
+    await stackCommand(["add", "-Am", "Add API"]);
+
+    expect(mockedGhRaw).toHaveBeenCalledWith([
+      "stack",
+      "add",
+      "-Am",
+      "Add API",
+    ]);
+    await expect(stackCommand(["add", "--all", "api"])).rejects.toThrow(
+      /require --message/,
+    );
+  });
+
+  it("reports a non-interactive sync abort distinctly", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr: "ℹ Sync aborted — no changes were made\n",
+    });
+
+    const output = await stackCommand(["sync"]);
+
+    expect(output).toContain("status: aborted");
+  });
+
+  it("reports successful syncs with failed steps as partial", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr:
+        "⚠ Push failed — branches may need force push after rebase\n✓ Branches synced\n",
+    });
+
+    const output = await stackCommand(["sync"]);
+
+    expect(output).toContain("status: partial");
+    expect(output).toContain("Push failed");
+  });
+
+  it("does not report upstream warnings as clean success", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr:
+        "⚠ the base branch uses a merge queue; ignoring the merge method\n",
+    });
+
+    const output = await stackCommand(["merge", "42"]);
+
+    expect(output).toContain("status: warning");
+  });
+
+  it("preserves stack exit codes and recovery guidance", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 3,
+      stdout: "",
+      stderr: "rebase conflict in src/a.ts\n",
+    });
+
+    try {
+      await stackCommand(["rebase"]);
+      expect.fail("expected StackError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(StackError);
+      expect((error as StackError).exitCode).toBe(3);
+      expect((error as StackError).suggestions.join(" ")).toContain(
+        "--continue",
+      );
+    }
+  });
+
+  it("uses fresh-rebase guidance after sync restores a conflict", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 3,
+      stdout: "  Run `gh stack rebase` to resolve conflicts interactively.\n",
+      stderr:
+        "✗ Conflict detected rebasing api onto model\n✓ All branches restored\n",
+    });
+
+    try {
+      await stackCommand(["sync"]);
+      expect.fail("expected StackError");
+    } catch (error) {
+      expect(error).toMatchObject({
+        message: expect.stringContaining("All branches restored"),
+        suggestions: [expect.stringContaining("stack rebase`")],
+      });
+      expect((error as StackError).suggestions.join(" ")).not.toContain(
+        "--continue",
+      );
+    }
+  });
+
+  it("uses reconciliation guidance for checkout composition conflicts", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 3,
+      stdout: "Local: model <- api\nRemote: model <- ui\n",
+      stderr: "local stack composition differs from remote\n",
+    });
+
+    await expect(stackCommand(["checkout", "42"])).rejects.toMatchObject({
+      suggestions: [expect.stringContaining("unstack --local")],
+    });
+  });
+
+  it("accepts equals-form values that begin with a dash", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr: "Created branch\n",
+    });
+
+    await stackCommand(["add", "--message=- fix API"]);
+
+    expect(mockedGhRaw).toHaveBeenCalledWith([
+      "stack",
+      "add",
+      "--message=- fix API",
+    ]);
+  });
+
+  it("suggests installing a missing extension", async () => {
+    mockedGhRaw.mockResolvedValue({
+      exitCode: 1,
+      stdout: "",
+      stderr: 'unknown command "stack" for "gh"\n',
+    });
+
+    await expect(stackCommand(["view"])).rejects.toMatchObject({
+      suggestions: [
+        expect.stringContaining("gh extension install github/gh-stack"),
+      ],
+    });
+  });
+
+  it("rejects unknown flags and subcommands", async () => {
+    await expect(stackCommand(["view", "--short"])).rejects.toThrow(
+      /Unsupported/,
+    );
+    await expect(stackCommand(["switch"])).rejects.toThrow(/Unknown/);
+  });
+});

--- a/test/skill.test.ts
+++ b/test/skill.test.ts
@@ -72,6 +72,14 @@ describe("createSkillMarkdown", () => {
     const markdown = createSkillMarkdown();
     expect(markdown).toContain("gh auth login");
   });
+
+  it("documents non-interactive stacked PR workflows", () => {
+    const skill = createSkillMarkdown();
+    expect(skill).toContain("gh extension install github/gh-stack");
+    expect(skill).toContain("stack submit --open");
+    expect(skill).toContain("Stack operations are cwd-bound");
+    expect(skill).toContain("stack view` always uses JSON");
+  });
 });
 
 describe("extractCommandsBlock", () => {


### PR DESCRIPTION
Closes #92

## Intent

Refresh an EXISTING open pull request on an upstream open-source repo we contribute to from outside: https://github.com/kunchenguid/gh-axi/pull/93 "feat(stack): add agent-safe stacked PR support". This is not new feature work; the feature was already written and reviewed into that PR. This run must UPDATE PR #93 in place (same PR number, same head branch feat/stack-support-core on our fork bpe-incom/gh-axi, base kunchenguid/gh-axi main). It must NOT open a second pull request against the upstream repo.

What the PR itself does (unchanged by this refresh): it adds a strict, non-interactive `gh-axi stack` adapter over GitHub's official `gh-stack` extension - agent-safe forms for stack view/submit/merge, interactive-only commands rejected, stderr diagnostics and stack-specific exit codes preserved with command-aware recovery guidance, stack operations bound to the current working directory with -R/--repo/GH_REPO rejected, the extension prerequisite documented, and the bundled agent skill regenerated. `gh-axi stack` is deliberately a thin adapter, NOT a second stack engine: local metadata, Git mutation, rebase recovery and Stacks API behaviour are intentionally left upstream in the extension. Interactive surfaces (`modify`, `switch`, `alias`, `feedback`) are deliberately omitted, and `view --json`, `submit --auto`, `merge --yes` are deliberately forced, because AXI commands must never hang waiting for interactive input.

Two problems were being fixed, and both are deliberate:

1. The PR no longer merged. It was opened 2026-08-05 and never touched while main moved through releases 0.1.29 and 0.1.30 plus some api/pr/repo fixes, so GitHub reported it CONFLICTING/DIRTY. I rebased feat/stack-support-core onto current origin/main. The only conflict was in AGENTS.md and it was purely additive: upstream appended "gh stderr classification" and "--version fast path" sections in the same place our PR appended its "Stacked PR support" section. I kept BOTH sides - no upstream content was dropped or resurrected, and no part of our feature was dropped to make a conflict go away. src/cli.ts and src/errors.ts auto-merged cleanly. The result is deliberately still a SINGLE commit (the PR's own), and the PR body's `Closes #92` reference is preserved.

2. The required check "PR must be raised via no-mistakes" is red. Per CONTRIBUTING.md this repo requires every human PR to main to be raised through `git push no-mistakes`; the check passes only if the PR body carries the deterministic signature the pipeline writes itself. The original PR was raised by hand so the marker is absent. Re-raising it through this pipeline is the entire point of this run - the marker must come from a genuine pipeline run that actually reviewed, tested and pushed this branch. It must never be hand-written into the PR body to turn the check green.

Deliberate decisions a reviewer reading only the diff would not know:

- Push target: origin is the UPSTREAM parent kunchenguid/gh-axi and we have NO write access to it. Every push must go to our fork https://github.com/bpe-incom/gh-axi.git, which is what the gate is configured to do. Force-pushing the fork branch is expected here (the rebase rewrote the commit), but only with --force-with-lease.
- skills/gh-axi/SKILL.md is a GENERATED file and must never be hand-edited; a "Generated files must not be hand-edited" CI check enforces this. I regenerated it with `pnpm run build:skill` after the rebase and it came back byte-identical to what was already committed, so it is correctly in sync.
- CHANGELOG.md, .release-please-manifest.json and package.json's `version` are release-please-owned and are deliberately NOT touched, per CONTRIBUTING.md and a guard workflow that blocks PRs touching them.
- `pnpm exec prettier --check .` reports 22 pre-existing files as unformatted, including CHANGELOG.md, src/toon.ts, src/fields.ts and several src/commands/*.ts and test/*.ts files. I verified these have ZERO overlap with the 10 files this PR changes, and .github/workflows/ci.yml runs no prettier step at all. Leaving them alone is deliberate: reformatting 22 unrelated files would be unwanted churn in someone else's repository, and one of them (CHANGELOG.md) is explicitly off-limits. Every file this PR actually touches is prettier-clean.
- There is a competing open PR, https://github.com/kunchenguid/gh-axi/pull/97, from another contributor wrapping the same gh-stack extension. It is deliberately left completely alone - do not modify, comment on, or reconcile against it.
- We are a guest in someone else's repository, so CONTRIBUTING.md is authoritative and its conventions win over any local habit.

Local verification already passing on the rebased branch before this run: `pnpm install --frozen-lockfile`, `pnpm run build`, `pnpm test` (910 passed, 5 skipped), `pnpm exec eslint .`, and `pnpm exec prettier --check` over every file the PR touches.

## What Changed

- Adds a `gh-axi stack` command family (`src/commands/stack.ts`) that wraps the official `github/gh-stack` extension as a strict, non-interactive adapter: `view`/`init`/`add`/`checkout`/`push`/`submit`/`sync`/`rebase`/`link`/`unstack`/`merge` plus branch navigation, with `view --json`, `submit --auto`, and `merge --yes` forced, and the interactive `modify`, `switch`, `alias`, and `feedback` surfaces rejected so a command can never block on a prompt. Extension output is classified into an `ok`/`warning`/`partial`/`aborted` status from stderr diagnostics only, so echoed commit subjects and branch names cannot be misread as failures, while unmarked git subprocess errors still register.
- Registers `stack` in `src/cli.ts` via a new `withLocalRepoContext` wrapper that rejects `-R`, `--repo`, and `GH_REPO` (stack state is cwd-bound and the extension takes no `--repo`), and adds a `formatError` hook that mirrors the SDK's error rendering byte-for-byte while preserving the upstream exit code carried by the new `StackError` class in `src/errors.ts`, so exits 2-10 reach the shell intact alongside command-aware recovery hints.
- Documents the `gh extension install github/gh-stack` prerequisite and the cwd binding in README.md and AGENTS.md, regenerates the bundled skill from `src/skill.ts`, and adds coverage in `test/commands/stack.test.ts`, `test/cli.test.ts`, and `test/skill.test.ts` (full suite: 916 passed, 5 skipped).

## Risk Assessment

✅ Low: Both requested changes landed exactly as specified with regression tests covering both classification directions, the deduplication is provably behavior-preserving for the `messages` field, and the only remaining items are a cosmetic name shadow and a deliberate, negligible asymmetry in the `warned` check.

## Testing

Ran the baseline toolchain (`pnpm install --frozen-lockfile`, `pnpm run build`, `pnpm test` → 916 passed / 5 skipped) plus the targeted stack, cli, and skill suites, then went beyond unit tests for the real end-user surface: because `github/gh-stack v0.1.0` is genuinely installed on this machine, I drove the built `dist/bin/gh-axi.js` against the actual extension in a throwaway git repo and captured a CLI transcript showing `stack init` really creating branches and `.git/gh-stack`, `stack view` rendering the live stack as TOON, the extension's own `⚠` diagnostic surfacing as `status: warning`, and a non-stack branch returning upstream exit 2 with `stack init` recovery guidance. For the paths that need GitHub write access I added a `gh` shim that echoes its own argv, which demonstrates the forced agent-safe flags (`view --json`, `submit --auto`, `merge --yes`), the ok/partial/aborted status mapping, preserved upstream exit codes 3 and 8 with command-aware recovery hints, and the install suggestion when the extension is absent. All interactive-only subcommands and every `-R`/`--repo`/`GH_REPO` form are rejected before `gh` is invoked. I also confirmed the intent's non-diff claims locally: the branch sits on the current main tip, AGENTS.md kept both upstream sections plus ours, `pnpm run build:skill` left the worktree clean so the generated SKILL.md is in sync, and the release-please-owned files are untouched. This change is CLI-only with no rendered UI, so the evidence is a CLI transcript rather than a screenshot. Two things I could not demonstrate from this stage, both by design: PR #93's remote state is still the pre-push snapshot (`mergeable_state: dirty`, "PR must be raised via no-mistakes" red) because the force-push-with-lease and the pipeline-written signature happen after testing. Everything I could exercise passed with no product defects.

<details>
<summary>Evidence: gh-axi stack end-to-end CLI transcript (real gh-stack extension + shim-driven scenarios)</summary>

```text
gh-axi stack — end-to-end CLI transcript
built binary: dist/bin/gh-axi.js (from commit db84089)
gh: gh version 2.97.0 (2026-07-31)   extension: gh stack	github/gh-stack	v0.1.0

############################################################
# PART 1 — REAL github/gh-stack extension, real git repo
############################################################

$ gh-axi stack view      # no stack yet: upstream exit 2 preserved + recovery guidance
error: "current branch \"main\" is not part of a stack"
code: STACK_ERROR
help[1]: Run `gh-axi stack init <branch>` to create or adopt a stack
  (exit 2)

$ gh-axi stack init feature-model feature-api
stack:
  action: init
  status: ok
  messages[6]: "Created stack: main ← feature-model ← feature-api",You're on feature-api (top of stack).,"What's next:","• commit your work as usual, then add a layer:  gh stack add","• see your stack any time:                      gh stack view","• when ready to open PRs:                       gh stack submit"
  (exit 0)

$ git branch --show-current  ->  feature-api
$ ls .git | grep gh-stack    ->  gh-stack
gh-stack.lock

$ gh-axi stack view
stack:
  trunk: main
  current_branch: feature-api
  branch_count: 2
branches[2]{name,current,state,needs_rebase,pr,url}:
  feature-model,false,local,false,null,null
  feature-api,true,local,false,null,null
  (exit 0)

$ echo hi > a.txt && git add a.txt && gh-axi stack add feature-ui -m 'feat: ui layer'
stack:
  action: add
  status: warning
  messages[3]: Created commit 26e48b2dd9a22c5aa5dc4f0812f73ba49615b792 on feature-api,Branch feature-api has no prior commits — adding your commit here instead of creating a new branch,"When you're ready for the next layer, run `gh stack add` again"
  (exit 0)

$ gh-axi stack down
stack:
  action: down
  status: ok
  messages[1]: "Checked out feature-model, 1 branch down"
$ gh-axi stack top
stack:
  action: top
  status: ok
  messages[1]: Switched to feature-api
$ gh-axi stack trunk
stack:
  action: trunk
  status: ok
  messages[1]: Switched to main

############################################################
# PART 2 — agent-safety guardrails (no gh invoked)
############################################################

-- interactive-only subcommands are not exposed --
$ gh-axi stack modify
error: "Unknown stack subcommand: modify"
code: VALIDATION_ERROR
help[1]: Run `gh-axi stack --help` to see agent-safe forms
  (exit 2)
$ gh-axi stack switch
error: "Unknown stack subcommand: switch"
code: VALIDATION_ERROR
help[1]: Run `gh-axi stack --help` to see agent-safe forms
  (exit 2)
$ gh-axi stack alias
error: "Unknown stack subcommand: alias"
code: VALIDATION_ERROR
help[1]: Run `gh-axi stack --help` to see agent-safe forms
  (exit 2)
$ gh-axi stack feedback
error: "Unknown stack subcommand: feedback"
code: VALIDATION_ERROR
help[1]: Run `gh-axi stack --help` to see agent-safe forms
  (exit 2)

-- stack is cwd-bound: -R / --repo / GH_REPO rejected --
$ gh-axi stack view -R owner/name
error: "stack commands operate on the repository in the current working directory and do not support -R, --repo, or GH_REPO"
code: VALIDATION_ERROR
  (exit 2)
$ gh-axi stack view --repo=owner/name
error: "stack commands operate on the repository in the current working directory and do not support -R, --repo, or GH_REPO"
code: VALIDATION_ERROR
  (exit 2)
$ GH_REPO=owner/name gh-axi stack view
error: "stack commands operate on the repository in the current working directory and do not support -R, --repo, or GH_REPO"
code: VALIDATION_ERROR
  (exit 2)

-- forms that would otherwise prompt require explicit arguments --
$ gh-axi stack merge
error: Expected at least 1 stack argument
code: VALIDATION_ERROR
help[1]: Run `gh-axi stack --help` to see agent-safe forms
  (exit 2)
$ gh-axi stack checkout
error: Expected at least 1 stack argument
code: VALIDATION_ERROR
help[1]: Run `gh-axi stack --help` to see agent-safe forms
  (exit 2)
$ gh-axi stack up 0
error: "Unknown stack subcommand: up 0"
code: VALIDATION_ERROR
help[1]: Run `gh-axi stack --help` to see agent-safe forms
  (exit 2)
$ gh-axi stack add
error: stack add requires a branch or --message
code: VALIDATION_ERROR
help[1]: Run `gh-axi stack --help` to see agent-safe forms
  (exit 2)
$ gh-axi stack add --all
error: "Unknown stack subcommand: add --all"
code: VALIDATION_ERROR
help[1]: Run `gh-axi stack --help` to see agent-safe forms
  (exit 2)
$ gh-axi stack view --interactive
error: "Unknown stack subcommand: view --interactive"
code: VALIDATION_ERROR
help[1]: Run `gh-axi stack --help` to see agent-safe forms
  (exit 2)

############################################################
# PART 3 — forced agent-safe flags & status/exit-code mapping
#          (a gh shim stands in for network-dependent paths;
#           it echoes the argv it received)
############################################################

$ gh-axi stack view          # upstream is always called with --json
stack:
  trunk: main
  current_branch: feature-api
  branch_count: 2
branches[2]{name,current,state,needs_rebase,pr,url}:
  feature-model,false,open,false,101,"https://github.com/o/r/pull/101"
  feature-api,true,open,true,102,"https://github.com/o/r/pull/102"
  (exit 0)
  upstream argv -> shim received argv: stack view --json

$ gh-axi stack submit --open   # --auto always appended
stack:
  action: submit
  status: ok
  messages[1]: "shim received argv: stack submit --open --auto"
  (exit 0)

$ gh-axi stack merge 42 --squash   # --yes always appended
stack:
  action: merge
  status: ok
  messages[1]: "shim received argv: stack merge 42 --squash --yes"
  (exit 0)

$ gh-axi stack submit          # success text on stderr is preserved
stack:
  action: submit
  status: ok
  messages[3]: Pushed 2 branches to origin,"Created PR #101 https://github.com/o/r/pull/101 (feature-model)","Created PR #102 https://github.com/o/r/pull/102 (feature-api)"
  (exit 0)

$ gh-axi stack push            # unmarked git failure line -> status: partial
stack:
  action: push
  status: partial
  messages[3]: Pushed feature-model to origin,"error: failed to push some refs to 'https://github.com/o/r.git'",1 of 2 branches pushed
  (exit 0)

$ gh-axi stack sync            # -> status: aborted
stack:
  action: sync
  status: aborted
  messages[1]: "sync aborted: uncommitted changes in the working tree"
  (exit 0)

$ gh-axi stack rebase          # upstream exit 3 preserved, rebase-specific recovery
error: "rebase stopped: conflict in src/app.ts"
code: STACK_ERROR
help[2]: "Resolve conflicts, stage the files with `git add`, then run `gh-axi stack rebase --continue`",Run `gh-axi stack rebase --abort` to restore the stack
  (exit 3)

$ gh-axi stack push            # upstream exit 8 preserved
error: another stack operation is in progress
code: STACK_ERROR
help[1]: "Wait for the other stack operation to finish, then retry"
  (exit 8)

$ gh-axi stack view            # extension absent -> install suggestion
error: "unknown command \"stack\" for \"gh\""
code: STACK_ERROR
help[1]: Run `gh extension install github/gh-stack` to install the official extension
  (exit 1)

############################################################
# PART 4 — discoverability
############################################################

$ gh-axi --help
usage: gh-axi [command] [args] [flags]
commands[16]:
  (none)=dashboard, issue, pr, stack, run, workflow, release, repo, label, gist, project, secret, variable, search, api, setup
flags[4]:
  -R/--repo <OWNER/NAME> (after command), --hostname <host> (after command) or GH_HOST env, both flags accept space or equals form, --help, -v/-V/--version
examples:
  gh-axi
  gh-axi issue list --state open
  gh-axi issue list -R owner/name
  gh-axi issue list --repo=owner/name
  gh-axi issue list --hostname git.example.com
  gh-axi pr view 42
  gh-axi stack view
  gh-axi secret list
  gh-axi setup hooks
"built-in":
  update: Upgrade `gh-axi.js` to the latest published version
  "update --check": Report current vs latest without installing

$ gh-axi stack --help
usage: gh-axi stack <subcommand> [args] [flags]
subcommands[16]:
  view, init <branches...>, add [branch], checkout <stack|pr|url|branch>, push, submit, sync, rebase [branch], link <refs...>, unstack [stack], merge <stack|pr>, up [n], down [n], top, bottom, trunk
flags{init}: --base <branch>
flags{add}: --message <text>, --all, --update
flags{push}: --remote <name>
flags{submit}: --open, --remote <name> (--auto is always applied)
flags{sync}: --prune, --remote <name>
flags{rebase}: --downstack, --upstack, --no-trunk, --continue, --abort, --remote <name>, --committer-date-is-author-date, --preserve-dates
flags{link}: --base <branch>, --open, --remote <name>
flags{unstack}: --local
flags{merge}: --merge-method <merge|squash|rebase>, --merge, --squash, --rebase (--yes is always applied)
notes:
  Requires the official extension: gh extension install github/gh-stack
  Operates on the git repository in the current working directory; -R, --repo, and GH_REPO are not supported
examples:
  gh-axi stack init feature-model feature-api
  gh-axi stack submit --open
  gh-axi stack view
  gh-axi stack rebase --continue
  gh-axi stack merge 42 --squash
```
</details>
<details>
<summary>Evidence: Real github/gh-stack extension driven through the built gh-axi binary</summary>

```text
$ gh-axi stack view # no stack yet: upstream exit 2 preserved + recovery guidance
error: "current branch \"main\" is not part of a stack"
code: STACK_ERROR
help[1]: Run `gh-axi stack init <branch>` to create or adopt a stack
(exit 2)

$ gh-axi stack init feature-model feature-api
stack:
action: init
status: ok
messages[6]: "Created stack: main ← feature-model ← feature-api",You're on feature-api (top of stack).,...
(exit 0)

$ git branch --show-current -> feature-api
$ ls .git | grep gh-stack -> gh-stack

$ gh-axi stack view
stack:
trunk: main
current_branch: feature-api
branch_count: 2
branches[2]{name,current,state,needs_rebase,pr,url}:
feature-model,false,local,false,null,null
feature-api,true,local,false,null,null
(exit 0)

$ echo hi > a.txt && git add a.txt && gh-axi stack add feature-ui -m 'feat: ui layer'
stack:
action: add
status: warning
messages[3]: Created commit 26e48b2... on feature-api,Branch feature-api has no prior commits — adding your commit here instead of creating a new branch,...
(exit 0)
```
</details>
<details>
<summary>Evidence: Forced agent-safe flags and status / exit-code mapping</summary>

```text
$ gh-axi stack view # upstream is always called with --json
stack:
trunk: main
current_branch: feature-api
branch_count: 2
branches[2]{name,current,state,needs_rebase,pr,url}:
feature-model,false,open,false,101,"https://github.com/o/r/pull/101"
feature-api,true,open,true,102,"https://github.com/o/r/pull/102"
upstream argv -> shim received argv: stack view --json

$ gh-axi stack submit --open # --auto always appended
messages[1]: "shim received argv: stack submit --open --auto"

$ gh-axi stack merge 42 --squash # --yes always appended
messages[1]: "shim received argv: stack merge 42 --squash --yes"

$ gh-axi stack push # unmarked git failure line -> status: partial
status: partial
messages[3]: Pushed feature-model to origin,"error: failed to push some refs to 'https://github.com/o/r.git'",1 of 2 branches pushed

$ gh-axi stack sync # -> status: aborted
status: aborted

$ gh-axi stack rebase # upstream exit 3 preserved, rebase-specific recovery
code: STACK_ERROR
help[2]: "Resolve conflicts, stage the files with `git add`, then run `gh-axi stack rebase --continue`",Run `gh-axi stack rebase --abort` to restore the stack
(exit 3)

$ gh-axi stack push # upstream exit 8 preserved
help[1]: "Wait for the other stack operation to finish, then retry"
(exit 8)

$ gh-axi stack view # extension absent -> install suggestion
help[1]: Run `gh extension install github/gh-stack` to install the official extension
```
</details>
<details>
<summary>Evidence: Agent-safety guardrails: interactive surfaces and repo scoping rejected</summary>

```text
$ gh-axi stack modify
error: "Unknown stack subcommand: modify"
code: VALIDATION_ERROR
help[1]: Run `gh-axi stack --help` to see agent-safe forms
(exit 2)
(same for switch, alias, feedback)

$ gh-axi stack view -R owner/name
error: "stack commands operate on the repository in the current working directory and do not support -R, --repo, or GH_REPO"
code: VALIDATION_ERROR
(exit 2)
(same for --repo=owner/name and GH_REPO=owner/name)

$ gh-axi stack merge
error: Expected at least 1 stack argument
$ gh-axi stack up 0
error: up distance must be a positive integer
$ gh-axi stack add --all
error: "--all and --update require --message"
$ gh-axi stack view --interactive
error: "Unsupported stack flag: --interactive"
```
</details>
- Outcome: ⚠️ 1 info across 1 run (5m58s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

- ⚠️ `AGENTS.md` - merge conflict rebasing onto refs/remotes/no-mistakes-push/feat/stack-support-core

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `src/cli.ts:115` - The new `formatError` hook is registered globally and changes error rendering for every command, not just `stack`. axi-sdk-js@0.1.10&#39;s `defaultFormatError` builds the whole error through a single TOON `encode({error, code, help})`, which inlines primitive arrays as `help[2]: do a,do b`. The new hook routes through gh-axi&#39;s local `toon.ts#renderError`, which emits `encode({error, code})` plus a multi-line `help[2]:\n  do a\n  do b` block. So every thrown AxiError across issue/pr/run/release/repo/secret/etc. (auth-required, repo-not-found, rate-limited, missing-scope) now prints its `help:` section in a different shape than before this PR. No test pins the previous SDK-formatted output, so the change is invisible in the 910-passing suite, and neither the PR description nor the intent mentions a global error-output change. Only the `exitCode` branch is actually needed for StackError; the `output` could be built to match the SDK&#39;s inline form (`encode({error, code, ...(suggestions.length ? {help: suggestions} : {})})`) so non-stack commands keep byte-identical error output. Confirm whether the reformat is intended before merging into an upstream repo we are guests in.
- ⚠️ `src/commands/stack.ts:144` - `stackView` carefully guards `JSON.parse` failure (lines 131-138) but then dereferences the parsed object without any shape check. `view.branches.length` throws `TypeError: Cannot read properties of undefined (reading &#39;length&#39;)` whenever `gh stack view --json` returns a payload lacking a `branches` key (empty stack, or a shape change in a future gh-stack release), and line 153&#39;s `branch.pr?.state.toLowerCase()` throws if a branch carries a `pr` object without `state` — the optional chain only guards `pr`, not `state`. Both escape as raw JS TypeErrors that `formatError` wraps as `code: UNKNOWN` with an unactionable message, defeating the deliberate &#39;Unexpected gh stack output&#39; guard directly above. Default `view.branches` to `[]` and guard `state` (e.g. `branch.pr?.state?.toLowerCase()`), or reuse the AxiError path when the shape is unrecognized.
- ⚠️ `src/commands/stack.ts:165` - The `partial` classifier applies a broad regex (`failed|could not|couldn&#39;t|cannot create|not .*updated automatically|remain stacked|not fully|skipping rebase`) to `messages`, which is the concatenation of the extension&#39;s stdout AND stderr — content that routinely echoes user-supplied text such as commit subjects and branch names. `gh-axi stack add -A -m &#34;fix: could not parse dates&#34;` exits 0 and echoes the commit subject, so the wrapper reports `status: partial` for a fully successful operation. Both the regenerated SKILL.md and README tell agents that stack operations &#39;may partially push branches; inspect the reported status before retrying&#39;, so a false `partial` can push an agent into re-running a mutation that already succeeded. Consider matching only on stderr diagnostic lines, or anchoring the patterns to the extension&#39;s own status markers rather than free-text substrings. This is a deliberate heuristic, so the narrowing is a product-behavior call.
- ℹ️ `src/cli.ts:161` - `repo?.source === &#34;env&#34;` is fully subsumed by the adjacent `process.env[&#34;GH_REPO&#34;]` check. `resolveRepo` (src/context.ts:23-26) only ever produces `source: &#34;env&#34;` when `process.env.GH_REPO` is set and parses as OWNER/NAME, and the env check also catches the malformed-GH_REPO case that yields `repo === undefined`. Dropping the `source === &#34;env&#34;` clause leaves behavior identical and makes the rejection rule read as the single condition it is.
- ℹ️ `src/commands/stack.ts:113` - The distance validator uses `/^\d+$/`, which accepts `0`, while the error it guards says &#39;must be a positive integer&#39;. `gh-axi stack up 0` and `gh-axi stack down 0` pass validation and are forwarded to the extension as a no-op navigation. Use `/^[1-9]\d*$/` to make the check match its own message.

🔧 Fix: match SDK error output and harden stack classifiers
3 issues (1 warning, 2 infos) still open:
- ⚠️ `src/commands/stack.ts:186` - The narrowing fixed the false positive but introduces the opposite blind spot. `statusDiagnostics` (line 373) keeps only stderr lines whose trimmed form starts with ✓/✗/⚠/ℹ, and `partial` is further gated on `FAILURE_MARKERS` (✗/⚠), so any UNMARKED stderr line is now ignored entirely for classification. gh-stack drives git subprocesses, and git&#39;s own stderr carries no markers: a `stack push`/`stack sync`/`stack submit` that exits 0 after emitting `error: failed to push some refs to ...` / `hint: Updates were rejected` now reports `status: ok`, which is precisely the partial-push case README.md:138 and the generated SKILL.md tell agents to inspect before retrying. AGENTS.md&#39;s own note hedges that extension status is only &#39;commonly&#39; written to stderr, so stdout-side markers are also dropped now. `warned` was likewise tightened from `result.stderr.includes(&#34;⚠&#34;)` to line-leading ⚠ only. Impact is bounded because `messages` (line 182) still carries the full stdout+stderr text, so the failure is visible to a reading agent — only the summary label is wrong. A middle ground that preserves the requested fix: also treat UNMARKED stderr lines matching FAILURE_DIAGNOSTIC as `partial`. The requested regression case is unaffected by that, because its echoed commit subject appears on a ✓-marked stderr line and on stdout, neither of which would qualify. Since the marker anchoring was an explicit decision, confirm before widening.
- ℹ️ `src/commands/stack.ts:182` - `runStack` parses `result.stderr` twice: `lines(result.stderr)` (line 182) strips ANSI, splits, trims, and removes the STATUS_MARKER prefix, then `statusDiagnostics(result.stderr)` (line 186) repeats the identical strip/split/trim and re-applies STATUS_MARKER to capture the marker it just discarded. Deriving both from one pass — e.g. have `statusDiagnostics` return `{marker, text}` for every non-empty line with `marker` empty when unprefixed, then map to `messages` — removes the duplicated pipeline and keeps the marker available in one place. Non-functional cleanup only.
- ℹ️ `src/commands/stack.ts:1` - Intent conformance note. The intent states: &#34;The result is deliberately still a SINGLE commit (the PR&#39;s own)&#34;, and the fix instructions add &#34;Keep the branch to a clean history&#34;. The branch now carries two commits: 5653d77 `feat(stack): add agent-safe stacked PR support` and 43a89c7 `no-mistakes(review): match SDK error output and harden stack classifiers`. This is an unavoidable consequence of applying the five requested review fixes in this run rather than a defect in the code, and the file-level constraints are all still met (no CHANGELOG.md / .release-please-manifest.json / package.json changes, skills/gh-axi/SKILL.md untouched and still in sync since src/skill.ts did not change, no unrelated files reformatted). Decide before the force-push-with-lease whether the review commit should be squashed into the feature commit to restore the stated single-commit shape, or left as a separate commit in the PR.

🔧 Fix: detect unmarked stderr failures, unify diagnostic parsing
2 infos still open:
- ℹ️ `src/commands/stack.ts:217` - The rename of `statusDiagnostics` to `diagnostics` collides with the pre-existing local in `execute`: line 217 declares `const diagnostics = [...lines(result.stderr), ...lines(result.stdout)]`, which shadows the module-level `diagnostics()` function (line 370) for the whole body of `execute`. It is harmless today because nothing in `execute` calls the function, but it is a live temporal-dead-zone trap: any future line added to `execute` above 217 that calls `diagnostics(result.stderr)` throws `ReferenceError: Cannot access &#39;diagnostics&#39; before initialization` at runtime rather than resolving the module helper. Rename one of the two — e.g. the local to `messages`/`output`, or the helper to `parseDiagnostics` — so the shared parser stays reachable everywhere in the file.
- ℹ️ `src/commands/stack.ts:197` - `warned = result.stderr.includes(&#34;⚠&#34;)` is now the only classification input that is a raw whole-blob substring test; `aborted` and `partial` both run per-line over `stderrDiagnostics`. Widening it back was explicitly requested, and the divergence from a marker-based check (`stderrDiagnostics.some(({marker}) =&gt; marker === &#34;⚠&#34;)`) is limited to two exotic edges: a ⚠ appearing mid-line inside echoed user text (raw says `warning`, marker-based says `ok`) and a bare ⚠ line with no text after it (raw says `warning`, marker-based drops it). Neither is worth changing on its own — noting it only because the unified `diagnostics()` pass now makes the marker available for free, so a future edit here should reach for `stderrDiagnostics` rather than re-reading the blob. No action needed.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `src/commands/stack.ts` - The branch carries three commits (5653d77 feat/stack plus 43a89c7 and db84089 &#39;no-mistakes(review)&#39; fixups), while the stated intent describes the PR as deliberately a single commit. Nothing is wrong with the code — the review commits are legitimate fixes and they add the 6 extra passing tests — but if the single-commit shape is a requirement, the branch needs squashing before it is pushed to PR #93. That happens in a later pipeline stage than this test run.
- <code>`pnpm install --frozen-lockfile` — already up to date</code>
- <code>`pnpm run build` — tsc clean</code>
- <code>`pnpm test` — 916 passed, 5 skipped, 0 failed</code>
- <code>`npx vitest run test/commands/stack.test.ts test/cli.test.ts test/skill.test.ts` — 60 passed</code>
- <code>`pnpm run build:skill` then `git status --porcelain` — regenerated skills/gh-axi/SKILL.md is byte-identical, worktree clean</code>
- <code>`git merge-base --is-ancestor 75bc3e9 HEAD` — rebased onto the current main tip</code>
- <code>`grep -n &#39;^## &#39; AGENTS.md` — upstream &#39;gh stderr classification&#39; and &#39;--version fast path&#39; sections both retained alongside the new &#39;Stacked PR support&#39; section</code>
- <code>`git diff --name-only 75bc3e9 HEAD | grep -E &#39;CHANGELOG|release-please-manifest|^package.json&#39;` — release-please-owned files correctly untouched</code>
- <code>Manual e2e against the REAL github/gh-stack v0.1.0 extension in a scratch git repo, using the built `dist/bin/gh-axi.js`: `stack view` (no stack → exit 2 + guidance), `stack init feature-model feature-api` (branches and .git/gh-stack really created), `stack view` (live stack rendered as TOON), `stack add feature-ui -m &#39;...&#39;` (real upstream ⚠ line → status: warning), `stack down`, `stack top`, `stack trunk`</code>
- <code>Manual e2e guardrails via the built CLI: `stack modify`, `stack switch`, `stack alias`, `stack feedback`, `stack view -R owner/name`, `stack view --repo=owner/name`, `GH_REPO=owner/name stack view`, `stack merge`, `stack checkout`, `stack up 0`, `stack add`, `stack add --all`, `stack view --interactive` — all rejected with VALIDATION_ERROR before gh is invoked</code>
- <code>Manual e2e with a `gh` shim on PATH that echoes its received argv: proved `stack view` → `stack view --json`, `stack submit --open` → `stack submit --open --auto`, `stack merge 42 --squash` → `stack merge 42 --squash --yes`; plus status mapping (ok/partial/aborted), preserved upstream exit codes 3 and 8 with rebase-specific and lock-specific recovery hints, and the `gh extension install github/gh-stack` suggestion on a missing extension</code>
- <code>`gh-axi --help` and `gh-axi stack --help` — stack listed in commands[16], help documents the extension prerequisite and cwd binding</code>
- <code>`gh-axi pr list`, `gh-axi pr view 93`, `gh-axi pr checks 93`, `gh-axi api repos/kunchenguid/gh-axi/pulls/93` (read-only) — #93 is still the only PR authored by bpe-incom, head bpe-incom:feat/stack-support-core, base main; no duplicate PR exists</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `VISION.md:11` - VISION.md owns the project&#39;s scope policy and states &#34;We aim for full functional parity with `gh`&#34; and &#34;We do not add GitHub functionality that cannot be provided through `gh`&#34;. This change is the first command family that wraps a `gh` *extension* (`github/gh-stack`) rather than core `gh`, adding an install prerequisite beyond `gh auth login`. That is arguably inside the letter of the policy (the extension runs through `gh`) but the doc does not say whether official extensions count, so a future contributor cannot tell whether wrapping other extensions is in scope. I deliberately did not edit it: this is the maintainer&#39;s scope statement in an upstream repo we contribute to from outside, and resolving the ambiguity either way is their call, not a staleness fix.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `CHANGELOG.md` - `pnpm exec prettier --check .` reports 21 pre-existing unformatted files (CHANGELOG.md, eslint.config.mjs, src/toon.ts, src/fields.ts, several src/commands/*.ts and test/*.ts, plus .no-mistakes/evidence fixtures). None overlap the ten files this change touches, all of which are prettier-clean, and .github/workflows/ci.yml runs no prettier step. Left unfixed deliberately: reformatting them would be unrelated churn in an upstream repo, and CHANGELOG.md is explicitly off-limits per CONTRIBUTING.md and the guard workflow.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

