### PR TITLE
fix: correctly classify workflow repository resolution failures

### DIFF
--- a/.no-mistakes/evidence/fm/ghaxi-workflow-run-auth-r1/workflow-run-cli-transcript.txt
+++ b/.no-mistakes/evidence/fm/ghaxi-workflow-run-auth-r1/workflow-run-cli-transcript.txt
@@ -1,0 +1,23 @@
+Focused end-user CLI verification
+================================
+
+Setup:
+- Ran the public gh-axi CLI from a temporary git checkout whose origin was
+  git@github.com-work:octo/repo.git, reproducing the SSH-host-alias condition.
+- Stubbed only the raw `gh` executable boundary. Without `--repo`, it returned
+  gh's real repo-resolution stderr including the misleading `gh auth login`
+  remediation hint. With `--repo octo/repo`, it returned a successful workflow
+  run URL.
+
+$ gh-axi workflow run dispatch-check.yml --ref main
+error: Could not determine the target repository from this checkout's git remotes
+code: VALIDATION_ERROR
+help[2]: "Pass the repo explicitly: `-R <owner>/<name>` (after the command)","For a GitHub Enterprise host, add `--hostname <host>` or set GH_HOST"
+exit_status: 2
+
+$ gh-axi workflow run dispatch-check.yml --ref main -R octo/repo
+triggered: ok
+workflow: dispatch-check.yml
+help[1]:
+  Run `gh-axi run list -R octo/repo` to see triggered run
+exit_status: 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,12 @@ Both collectors reject a dangling (`--label` with nothing after it) or blank (`-
 Pick the collector that matches the surrounding file: `issue.ts` reads args non-destructively (`getAllFlags`), `pr.ts` consumes them (`takeAllFlags`).
 When a flag becomes repeatable, mark it `(repeatable)` in that command's `*_HELP` string.
 
+## gh stderr classification (`src/errors.ts`)
+
+`mapGhError` walks `patterns` in order and returns on the first regex hit, so **order is the contract**: a narrow, specific pattern must sit ahead of any broader one it would otherwise be swallowed by.
+The trap is that gh embeds remediation hints in errors that are not about that remedy - most notably it ends its repo-resolution failure ("none of the git remotes configured ... point to a known GitHub host") with "please use `gh auth login`", which the generic `/gh auth login/` pattern would report as a bogus `AUTH_REQUIRED` under a perfectly valid token.
+When adding a pattern, check it against real gh stderr (`strings "$(command -v gh)" | grep …` finds the literal message templates) rather than the message you expect, and place non-auth carriers of a hint above the generic hint match instead of narrowing the generic one - narrowing risks _missing_ a genuine auth failure.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,8 @@ When a flag becomes repeatable, mark it `(repeatable)` in that command's `*_HELP
 ## gh stderr classification (`src/errors.ts`)
 
 `mapGhError` walks `patterns` in order and returns on the first regex hit, so **order is the contract**: a narrow, specific pattern must sit ahead of any broader one it would otherwise be swallowed by.
-The trap is that gh embeds remediation hints in errors that are not about that remedy - most notably it ends its repo-resolution failure ("none of the git remotes configured ... point to a known GitHub host") with "please use `gh auth login`", which the generic `/gh auth login/` pattern would report as a bogus `AUTH_REQUIRED` under a perfectly valid token.
-When adding a pattern, check it against real gh stderr (`strings "$(command -v gh)" | grep …` finds the literal message templates) rather than the message you expect, and place non-auth carriers of a hint above the generic hint match instead of narrowing the generic one - narrowing risks _missing_ a genuine auth failure.
+gh sometimes embeds remediation hints in errors with a different root cause, so check new patterns against real stderr and place specific carriers of a generic hint first rather than narrowing the generic match.
+`test/errors.test.ts` pins the repo-resolution and genuine-auth cases.
 
 ## Maintaining this file
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -59,6 +59,22 @@ const patterns: ErrorPattern[] = [
     suggestions: () => [`Run \`gh-axi run list\` to see recent runs`],
   },
   {
+    // gh tacks a `gh auth login` hint onto its repo-resolution failure, but the
+    // token is fine: gh just could not work out which repository to target from
+    // the git remotes (unknown host, SSH host alias, no GitHub remote). Must sit
+    // ahead of the generic `gh auth login` pattern below, which would otherwise
+    // report a bogus AUTH_REQUIRED.
+    pattern:
+      /none of the git remotes configured for this repository point to a known GitHub host/i,
+    code: "VALIDATION_ERROR",
+    message: () =>
+      "Could not determine the target repository from this checkout's git remotes",
+    suggestions: () => [
+      "Pass the repo explicitly: `-R <owner>/<name>` (after the command)",
+      "For a GitHub Enterprise host, add `--hostname <host>` or set GH_HOST",
+    ],
+  },
+  {
     pattern: /gh auth login/,
     code: "AUTH_REQUIRED",
     message: () => "GitHub auth required — run `gh auth login` first",

--- a/test/commands/workflow-run-dispatch.test.ts
+++ b/test/commands/workflow-run-dispatch.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { execFile } from "node:child_process";
+import { workflowCommand } from "../../src/commands/workflow.js";
+import { AxiError } from "../../src/errors.js";
+import type { RepoContext } from "../../src/context.js";
+
+// Deliberately does NOT mock src/gh.js: this exercises the real `workflow run`
+// path through gh.ts and the error classifier, stubbing only the gh boundary.
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+const mockedExecFile = vi.mocked(execFile);
+type ExecFileCallback = (
+  error: Error | null,
+  stdout: string,
+  stderr: string,
+) => void;
+
+/** Capture the argv handed to gh, and reply with a canned exit/stdout/stderr. */
+function stubGh(
+  error: (Error & { code?: string | number }) | null,
+  stdout: string,
+  stderr: string,
+): { argv: () => string[] } {
+  let seen: string[] = [];
+  mockedExecFile.mockImplementation((_cmd, args, _opts, callback) => {
+    seen = args as string[];
+    (callback as ExecFileCallback)(error, stdout, stderr);
+    return {} as ReturnType<typeof execFile>;
+  });
+  return { argv: () => seen };
+}
+
+function ghFailure(): Error & { code: number } {
+  return Object.assign(new Error("gh exited 1"), { code: 1 });
+}
+
+const ctx: RepoContext = {
+  owner: "octo",
+  name: "repo",
+  nwo: "octo/repo",
+  source: "flag",
+};
+
+describe("workflow run dispatch", () => {
+  beforeEach(() => {
+    mockedExecFile.mockReset();
+  });
+
+  it("dispatches successfully and reports the trigger", async () => {
+    const gh = stubGh(
+      null,
+      "https://github.com/octo/repo/actions/runs/1\n",
+      "",
+    );
+
+    const result = await workflowCommand(
+      ["run", "dispatch-check.yml", "--ref", "main", "--field", "note=hi"],
+      ctx,
+    );
+
+    expect(result).toContain("triggered: ok");
+    expect(gh.argv()).toEqual([
+      "workflow",
+      "run",
+      "dispatch-check.yml",
+      "--ref",
+      "main",
+      "--field",
+      "note=hi",
+      "--repo",
+      "octo/repo",
+    ]);
+  });
+
+  // Regression: gh appends a `gh auth login` hint to its repo-resolution
+  // failure. gh-axi used to substring-match that hint and report AUTH_REQUIRED,
+  // so a dispatch under a perfectly valid workflow-scoped token looked like an
+  // auth gap even though `gh workflow run -R owner/repo` succeeded.
+  it("does not report AUTH_REQUIRED when gh only failed to resolve the repo", async () => {
+    stubGh(
+      ghFailure(),
+      "",
+      "none of the git remotes configured for this repository point to a known GitHub host. To tell gh about a new GitHub host, please use `gh auth login`\n",
+    );
+
+    const err = await workflowCommand(["run", "dispatch-check.yml"]).catch(
+      (e: unknown) => e as AxiError,
+    );
+
+    expect(err).toBeInstanceOf(AxiError);
+    expect(err.code).toBe("VALIDATION_ERROR");
+    expect(err.suggestions.join(" ")).toContain("-R <owner>/<name>");
+  });
+
+  it("still reports AUTH_REQUIRED when gh is genuinely not authenticated", async () => {
+    stubGh(
+      ghFailure(),
+      "",
+      "To get started with GitHub CLI, please run:  gh auth login\n",
+    );
+
+    const err = await workflowCommand(["run", "dispatch-check.yml"], ctx).catch(
+      (e: unknown) => e as AxiError,
+    );
+
+    expect(err).toBeInstanceOf(AxiError);
+    expect(err.code).toBe("AUTH_REQUIRED");
+  });
+
+  it("still reports AUTH_REQUIRED for gh's 401 hint", async () => {
+    stubGh(
+      ghFailure(),
+      "",
+      "HTTP 401: Bad credentials (https://api.github.com/repos/octo/repo)\nTry authenticating with:  gh auth login\n",
+    );
+
+    const err = await workflowCommand(["run", "dispatch-check.yml"], ctx).catch(
+      (e: unknown) => e as AxiError,
+    );
+
+    expect(err).toBeInstanceOf(AxiError);
+    expect(err.code).toBe("AUTH_REQUIRED");
+  });
+
+  it("surfaces a missing workflow_dispatch trigger as a validation error, not auth", async () => {
+    stubGh(
+      ghFailure(),
+      "",
+      "could not create workflow dispatch event: HTTP 422: Workflow does not have 'workflow_dispatch' trigger (https://api.github.com/repos/octo/repo/actions/workflows/1/dispatches)\n",
+    );
+
+    const err = await workflowCommand(["run", "dispatch-check.yml"], ctx).catch(
+      (e: unknown) => e as AxiError,
+    );
+
+    expect(err).toBeInstanceOf(AxiError);
+    expect(err.code).toBe("VALIDATION_ERROR");
+  });
+});

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -77,6 +77,15 @@ describe("mapGhError", () => {
     expect(err.code).toBe("AUTH_REQUIRED");
   });
 
+  it("classifies gh's repo-resolution failure as a validation error, not auth", () => {
+    const err = mapGhError(
+      "none of the git remotes configured for this repository point to a known GitHub host. To tell gh about a new GitHub host, please use `gh auth login`",
+      1,
+    );
+    expect(err.code).toBe("VALIDATION_ERROR");
+    expect(err.suggestions.join(" ")).toContain("-R <owner>/<name>");
+  });
+
   it("matches missing OAuth scope pattern (e.g. gh project without project scope)", () => {
     const err = mapGhError(
       "error: your authentication token is missing required scopes [read:project]\n" +


### PR DESCRIPTION
## Intent

Investigate and fix a gh-axi bug: `gh-axi workflow run` fails with AUTH_REQUIRED even when the caller has a valid, workflow-scoped GitHub token, while the equivalent plain `gh workflow run -R <owner/repo> ...` succeeds with that same authentication.

Reported evidence, verbatim from a fleet worker dispatching a real GitHub Actions workflow (an App Store Connect build-status check): "'gh-axi workflow run' returned AUTH_REQUIRED to dispatch the check despite a valid workflow-scoped gh token; plain 'gh workflow run -R ...' worked - a gh-axi wrapper quirk, not a real auth gap." So the underlying gh auth was genuinely fine; gh-axi's own workflow run path is what rejected it.

Required approach: (1) reproduce the divergence end to end as a real user would, before starting on any fix; (2) find the TRUE root cause in gh-axi's workflow run implementation and its auth/preflight layer, establishing with evidence which candidate it actually is rather than assuming - candidates considered were a gh-axi-side auth preflight or capability check stricter than gh needs, a token-source or scope check misclassifying a valid workflow-scoped token, an env/arg passthrough gap, or a command-surface mismatch; (3) fix the most fundamental cause so gh-axi workflow run succeeds exactly where plain gh workflow run succeeds, WITHOUT weakening any genuine auth check - explicitly NOT papering over it by disabling a preflight wholesale if a narrower correct fix exists, and NOT relaxing a real security check to make the symptom disappear; (4) add an executable regression exercising the real workflow run code path, mocking/stubbing the gh boundary as the existing tests do, asserting observable behavior rather than source text.

Constraints: gh-axi is a public axi-family CLI wrapper around the GitHub CLI, so auth must stay on raw gh - do not invent a parallel credential path. Keep the change minimal and targeted to the real cause; do not refactor unrelated surface. AXI ergonomics apply if the CLI surface is touched.

What the investigation actually found (this is the reasoning behind the diff, so a reviewer reading only the diff will not have it): there is NO auth preflight anywhere in gh-axi's workflow run path - runWorkflow shells straight through to `gh workflow run`. The bug is in ERROR CLASSIFICATION. gh ends its repo-RESOLUTION failure with an auth remediation hint: "none of the git remotes configured for this repository point to a known GitHub host. To tell gh about a new GitHub host, please use \`gh auth login\`". src/errors.ts classified gh stderr with a bare /gh auth login/ substring match, so this entirely non-auth failure was reported as AUTH_REQUIRED. Reproduced end to end against a real workflow_dispatch workflow with a real valid token: in a checkout whose origin remote uses an SSH host alias (git@github.com-work:owner/repo.git), `gh workflow run <wf> -R owner/repo --ref main` dispatched successfully (proving auth is fine) while `gh-axi workflow run <wf> --ref main` returned AUTH_REQUIRED. The chain is: gh-axi's host-strict parseRemoteUrl cannot resolve the alias, so it withholds --repo, gh then redoes resolution itself and fails, and gh-axi mislabels that hint as auth.

Deliberate decisions made, so these should not be flagged as oversights:
- The fix adds ONE narrower regex for the repo-resolution message placed AHEAD of the generic /gh auth login/ pattern in src/errors.ts's ordered pattern list, mapping it to VALIDATION_ERROR with an actionable `-R <owner>/<name>` suggestion. The generic auth pattern is deliberately left INTACT rather than narrowed: narrowing it would risk MISSING a genuine auth failure, which is the worse error. Every genuine auth failure (not logged in, gh's 401 "Try authenticating with: gh auth login" hint) still maps to AUTH_REQUIRED, and regression tests pin that.
- VALIDATION_ERROR (exit 2, AXI usage-error code) was chosen deliberately over REPO_NOT_FOUND or a new error code: the repo exists, the invocation simply did not say which repo to target, which is a usage error the caller fixes with -R.
- Deliberately did NOT change gh.ts#buildArgs to always append --repo. That would eliminate the double-resolution divergence but would break `gh pr create` from a fork, which relies on gh's own base/head remote resolution. Verified this is a real constraint, so it is out of scope on purpose.
- Deliberately did NOT loosen src/context.ts#parseRemoteUrl to resolve SSH host aliases. That changes repo-resolution semantics broadly and risks mis-resolving; the corrected error message now tells the caller to pass -R instead.
- The regression test test/commands/workflow-run-dispatch.test.ts deliberately does NOT mock src/gh.js (unlike the sibling test/commands/workflow.test.ts) - it stubs only node:child_process so gh.ts and errors.ts execute for real, exercising the actual workflow run path end to end through the public workflowCommand interface. It asserts observable behavior: successful dispatch plus the exact argv handed to gh, the regression case, both genuine-auth cases still classifying as AUTH_REQUIRED, and the 422 case. Verified it FAILS before the fix and PASSES after it.
- AGENTS.md gained a short 'gh stderr classification' section recording the durable sharp edge: mapGhError returns on first match so pattern ORDER is the contract, and gh embeds remediation hints in errors that are not about that remedy.

Explicitly OUT of scope, by user decision, and must not be expanded into: (a) deleting the private scratch repo kunchenguid/ghaxi-dispatch-scratch created for the end-to-end reproduction (the token lacks the delete_repo scope); (b) a separate pre-existing wart where a gh HTTP 422 with no JSON body collapses to a bare "Validation error" and drops gh's detail. Both were reported to the user and deliberately left alone.

## What Changed

- Classify GitHub CLI repository-resolution failures as `VALIDATION_ERROR` with actionable repository and hostname guidance instead of incorrectly reporting `AUTH_REQUIRED`.
- Preserve genuine authentication error handling while adding executable workflow dispatch coverage for success, repository resolution, authentication, and HTTP 422 cases.
- Document stderr pattern-ordering requirements and capture focused CLI verification for SSH host-alias checkouts.

## Risk Assessment

✅ Low: The targeted ordered-classifier fix corrects the false AUTH_REQUIRED result without weakening genuine authentication handling, and executable regression coverage exercises the real workflow-to-gh error path.

## Testing

Targeted tests exercised workflow dispatch, repository-resolution classification, genuine authentication failures, and HTTP 422 behavior; an end-user CLI check reproduced the SSH-alias condition and confirmed the corrected error plus successful explicit-repository dispatch.

- Evidence: [End-user workflow run CLI transcript](https://github.com/kunchenguid/gh-axi/blob/33c9f8dff324ad671d20ea23f7cec834e9e35e52/.no-mistakes/evidence/fm/ghaxi-workflow-run-auth-r1/workflow-run-cli-transcript.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm exec vitest run test/commands/workflow-run-dispatch.test.ts test/errors.test.ts`
- <code>From a temporary checkout with origin `git@github.com-work:octo/repo.git`, ran `gh-axi workflow run dispatch-check.yml --ref main` against a stubbed raw `gh` boundary and verified `VALIDATION_ERROR`, an actionable `-R` suggestion, and exit 2 instead of `AUTH_REQUIRED`.</code>
- <code>From the same checkout, ran `gh-axi workflow run dispatch-check.yml --ref main -R octo/repo` and verified `triggered: ok` with exit 0.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
