### PR TITLE
fix(pr): make worktree merges repository-safe

### DIFF
--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -183,6 +183,16 @@ const listSchema: FieldDef[] = [
 ];
 
 const LIST_JSON_FIELDS = "number,title,state,author,isDraft,reviewDecision";
+const PR_LIST_INCLUDED_FIELDS = new Set([
+  "number",
+  "title",
+  "state",
+  "author",
+  "isDraft",
+  "reviewDecision",
+  "draft",
+  "review",
+]);
 
 const PR_LIST_EXTRA_FIELDS: Record<string, ExtraFieldSpec> = {
   body: { jsonKey: "body", def: field("body") },
@@ -289,6 +299,7 @@ async function prList(args: string[], ctx?: RepoContext): Promise<string> {
   const { extraDefs, extraJsonKeys } = parseFields(
     fieldsArg,
     PR_LIST_EXTRA_FIELDS,
+    PR_LIST_INCLUDED_FIELDS,
   );
   const state = takeFlag(args, "--state") ?? "open";
   const labels = takeAllFlags(args, "--label");
@@ -626,7 +637,13 @@ async function prMerge(args: string[], ctx?: RepoContext): Promise<string> {
   const ghArgs = ["pr", "merge", String(num)];
   if (method) ghArgs.push("--" + method);
   if (auto) ghArgs.push("--auto");
-  if (deleteBranch) ghArgs.push("--delete-branch");
+  if (deleteBranch) {
+    ghArgs.push("--delete-branch");
+    // Explicit repository mode prevents gh from checking out the base branch
+    // before deleting the remote head. That local checkout is unsafe in a
+    // multi-worktree repository where another worktree already owns main.
+    if (ctx) ghArgs.push("--repo", ctx.nwo);
+  }
   if (body !== undefined) ghArgs.push("--body", body);
   if (subject) ghArgs.push("--subject", subject);
 

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -75,6 +75,7 @@ interface PrItem {
   reviews?: unknown[];
   mergedBy?: { login: string };
   baseRefName: string;
+  url: string;
 }
 
 interface PrReview {
@@ -610,14 +611,14 @@ async function prMerge(args: string[], ctx?: RepoContext): Promise<string> {
 
   // Idempotent: check if already merged
   const pr = await ghJson<
-    Pick<PrItem, "state" | "mergedBy" | "mergedAt" | "baseRefName">
+    Pick<PrItem, "state" | "mergedBy" | "mergedAt" | "baseRefName" | "url">
   >(
     [
       "pr",
       "view",
       String(num),
       "--json",
-      "state,mergedBy,mergedAt,baseRefName",
+      "state,mergedBy,mergedAt,baseRefName,url",
     ],
     ctx,
   );
@@ -657,15 +658,8 @@ async function prMerge(args: string[], ctx?: RepoContext): Promise<string> {
     deleteBranch &&
     (ctx === undefined || ctx.source === "git") &&
     baseBranchNeedsExplicitRepo(pr.baseRefName);
-  if (worktreeConflict && !ctx) {
-    throw new AxiError(
-      "Could not determine repository for a worktree-safe branch deletion — pass --repo <owner/name>",
-      "VALIDATION_ERROR",
-    );
-  }
-
   if (worktreeConflict) {
-    await ghExec(ghArgs, ctx, { explicitRepo: true });
+    await ghExec(ghArgs, pullRequestRepoContext(pr.url, ctx));
   } else {
     await ghExec(ghArgs, ctx);
   }
@@ -680,6 +674,29 @@ async function prMerge(args: string[], ctx?: RepoContext): Promise<string> {
       getSuggestions({ domain: "pr", action: "merge", id: num, repo: ctx }),
     ),
   ]);
+}
+
+function pullRequestRepoContext(
+  pullRequestUrl: string,
+  fallback?: RepoContext,
+): RepoContext {
+  try {
+    const url = new URL(pullRequestUrl);
+    const [owner, name, resource] = url.pathname.split("/").filter(Boolean);
+    if (!owner || !name || resource !== "pull") throw new Error();
+    return {
+      owner,
+      name,
+      nwo: `${owner}/${name}`,
+      source: "flag",
+      host: fallback?.host,
+    };
+  } catch {
+    throw new AxiError(
+      "Could not determine repository from pull request URL for a worktree-safe branch deletion",
+      "VALIDATION_ERROR",
+    );
+  }
 }
 
 async function prReview(args: string[], ctx?: RepoContext): Promise<string> {

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -14,6 +14,7 @@ import {
   pushRepeated,
 } from "../args.js";
 import { parseFields, type ExtraFieldSpec } from "../fields.js";
+import { baseBranchNeedsExplicitRepo } from "../worktree.js";
 import {
   field,
   pluck,
@@ -73,6 +74,7 @@ interface PrItem {
   comments?: PrComment[];
   reviews?: unknown[];
   mergedBy?: { login: string };
+  baseRefName: string;
 }
 
 interface PrReview {
@@ -607,8 +609,16 @@ async function prMerge(args: string[], ctx?: RepoContext): Promise<string> {
   const subject = takeFlag(args, "--subject");
 
   // Idempotent: check if already merged
-  const pr = await ghJson<Pick<PrItem, "state" | "mergedBy" | "mergedAt">>(
-    ["pr", "view", String(num), "--json", "state,mergedBy,mergedAt"],
+  const pr = await ghJson<
+    Pick<PrItem, "state" | "mergedBy" | "mergedAt" | "baseRefName">
+  >(
+    [
+      "pr",
+      "view",
+      String(num),
+      "--json",
+      "state,mergedBy,mergedAt,baseRefName",
+    ],
     ctx,
   );
   if ((pr.state ?? "").toUpperCase() === "MERGED") {
@@ -639,15 +649,26 @@ async function prMerge(args: string[], ctx?: RepoContext): Promise<string> {
   if (auto) ghArgs.push("--auto");
   if (deleteBranch) {
     ghArgs.push("--delete-branch");
-    // Explicit repository mode prevents gh from checking out the base branch
-    // before deleting the remote head. That local checkout is unsafe in a
-    // multi-worktree repository where another worktree already owns main.
-    if (ctx) ghArgs.push("--repo", ctx.nwo);
   }
   if (body !== undefined) ghArgs.push("--body", body);
   if (subject) ghArgs.push("--subject", subject);
 
-  await ghExec(ghArgs, ctx);
+  const worktreeConflict =
+    deleteBranch &&
+    (ctx === undefined || ctx.source === "git") &&
+    baseBranchNeedsExplicitRepo(pr.baseRefName);
+  if (worktreeConflict && !ctx) {
+    throw new AxiError(
+      "Could not determine repository for a worktree-safe branch deletion — pass --repo <owner/name>",
+      "VALIDATION_ERROR",
+    );
+  }
+
+  if (worktreeConflict) {
+    await ghExec(ghArgs, ctx, { explicitRepo: true });
+  } else {
+    await ghExec(ghArgs, ctx);
+  }
 
   return renderOutput([
     renderDetail(

--- a/src/context.ts
+++ b/src/context.ts
@@ -13,7 +13,7 @@ export interface RepoContext {
 
 /**
  * Resolve the target repository.
- * Priority: --repo flag > GH_REPO env > git remotes (origin first).
+ * Priority: --repo flag > GH_REPO env > git remote origin.
  */
 export function resolveRepo(flagValue?: string): RepoContext | undefined {
   if (flagValue) {
@@ -25,42 +25,14 @@ export function resolveRepo(flagValue?: string): RepoContext | undefined {
     return parseNwo(envRepo, "env");
   }
 
-  const origin = getRemoteUrl("origin");
-  const originRepo = origin ? parseRemoteUrl(origin) : undefined;
-  if (originRepo) return originRepo;
-
-  for (const remote of listRemotes()) {
-    if (remote === "origin") continue;
-    const url = getRemoteUrl(remote);
-    const repo = url ? parseRemoteUrl(url) : undefined;
-    if (repo) return repo;
-  }
-
-  return undefined;
-}
-
-function getRemoteUrl(remote: string): string | undefined {
   try {
-    return execFileSync("git", ["remote", "get-url", remote], {
+    const url = execFileSync("git", ["remote", "get-url", "origin"], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
+    return parseRemoteUrl(url);
   } catch {
     return undefined;
-  }
-}
-
-function listRemotes(): string[] {
-  try {
-    return execFileSync("git", ["remote"], {
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "ignore"],
-    })
-      .split(/\r?\n/)
-      .map((remote) => remote.trim())
-      .filter(Boolean);
-  } catch {
-    return [];
   }
 }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -13,7 +13,7 @@ export interface RepoContext {
 
 /**
  * Resolve the target repository.
- * Priority: --repo flag > GH_REPO env > git remote origin.
+ * Priority: --repo flag > GH_REPO env > git remotes (origin first).
  */
 export function resolveRepo(flagValue?: string): RepoContext | undefined {
   if (flagValue) {
@@ -25,14 +25,42 @@ export function resolveRepo(flagValue?: string): RepoContext | undefined {
     return parseNwo(envRepo, "env");
   }
 
+  const origin = getRemoteUrl("origin");
+  const originRepo = origin ? parseRemoteUrl(origin) : undefined;
+  if (originRepo) return originRepo;
+
+  for (const remote of listRemotes()) {
+    if (remote === "origin") continue;
+    const url = getRemoteUrl(remote);
+    const repo = url ? parseRemoteUrl(url) : undefined;
+    if (repo) return repo;
+  }
+
+  return undefined;
+}
+
+function getRemoteUrl(remote: string): string | undefined {
   try {
-    const url = execFileSync("git", ["remote", "get-url", "origin"], {
+    return execFileSync("git", ["remote", "get-url", remote], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
-    return parseRemoteUrl(url);
   } catch {
     return undefined;
+  }
+}
+
+function listRemotes(): string[] {
+  try {
+    return execFileSync("git", ["remote"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .split(/\r?\n/)
+      .map((remote) => remote.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
   }
 }
 

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -1,5 +1,5 @@
-import { AxiError } from './errors.js';
-import type { FieldDef } from './toon.js';
+import { AxiError } from "./errors.js";
+import type { FieldDef } from "./toon.js";
 
 /**
  * Describes an extra field that can be requested via --fields.
@@ -17,8 +17,9 @@ export interface ParseFieldsResult {
 }
 
 /**
- * Parse a --fields value (comma-separated field names), validate against
- * the available map, and return the extra FieldDefs and JSON keys.
+ * Parse a --fields value (comma-separated field names), validate against the
+ * available extras and already-included fields, and return only the extra
+ * FieldDefs and JSON keys.
  *
  * Returns empty arrays when fieldsArg is undefined (no --fields passed).
  * Throws AxiError with VALIDATION_ERROR for any unknown field names.
@@ -32,9 +33,14 @@ export function parseFields(
     return { extraDefs: [], extraJsonKeys: [] };
   }
 
-  const requested = [...new Set(
-    fieldsArg.split(',').map((f) => f.trim()).filter(Boolean),
-  )];
+  const requested = [
+    ...new Set(
+      fieldsArg
+        .split(",")
+        .map((f) => f.trim())
+        .filter(Boolean),
+    ),
+  ];
 
   const unknown = requested.filter(
     (f) => !(f in available) && !included.has(f),
@@ -42,10 +48,12 @@ export function parseFields(
   if (unknown.length > 0) {
     const availableNames = [
       ...new Set([...Object.keys(available), ...included]),
-    ].sort().join(', ');
+    ]
+      .sort()
+      .join(", ");
     throw new AxiError(
-      `Unknown field(s): ${unknown.join(', ')}. Available: ${availableNames}`,
-      'VALIDATION_ERROR',
+      `Unknown field(s): ${unknown.join(", ")}. Available: ${availableNames}`,
+      "VALIDATION_ERROR",
     );
   }
 

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -26,6 +26,7 @@ export interface ParseFieldsResult {
 export function parseFields(
   fieldsArg: string | undefined,
   available: Record<string, ExtraFieldSpec>,
+  included: ReadonlySet<string> = new Set(),
 ): ParseFieldsResult {
   if (fieldsArg === undefined) {
     return { extraDefs: [], extraJsonKeys: [] };
@@ -35,9 +36,13 @@ export function parseFields(
     fieldsArg.split(',').map((f) => f.trim()).filter(Boolean),
   )];
 
-  const unknown = requested.filter((f) => !(f in available));
+  const unknown = requested.filter(
+    (f) => !(f in available) && !included.has(f),
+  );
   if (unknown.length > 0) {
-    const availableNames = Object.keys(available).sort().join(', ');
+    const availableNames = [
+      ...new Set([...Object.keys(available), ...included]),
+    ].sort().join(', ');
     throw new AxiError(
       `Unknown field(s): ${unknown.join(', ')}. Available: ${availableNames}`,
       'VALIDATION_ERROR',
@@ -48,6 +53,7 @@ export function parseFields(
   const extraJsonKeys: string[] = [];
 
   for (const name of requested) {
+    if (included.has(name)) continue;
     const spec = available[name];
     extraDefs.push(spec.def);
     extraJsonKeys.push(spec.jsonKey);

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -11,7 +11,11 @@ export interface ExecResult {
 function buildArgs(args: string[], ctx?: RepoContext): string[] {
   const out = [...args];
   // Append --repo for flag/env sources (git remote is auto-detected by gh)
-  if (ctx && ctx.source !== "git") {
+  if (
+    ctx &&
+    ctx.source !== "git" &&
+    !out.some((arg, index) => arg === "--repo" && index < out.length - 1)
+  ) {
     out.push("--repo", ctx.nwo);
   }
   return out;

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -8,14 +8,17 @@ export interface ExecResult {
   exitCode: number;
 }
 
-function buildArgs(args: string[], ctx?: RepoContext): string[] {
+export interface GhExecOptions {
+  explicitRepo?: boolean;
+}
+
+function buildArgs(
+  args: string[],
+  ctx?: RepoContext,
+  options: GhExecOptions = {},
+): string[] {
   const out = [...args];
-  // Append --repo for flag/env sources (git remote is auto-detected by gh)
-  if (
-    ctx &&
-    ctx.source !== "git" &&
-    !out.some((arg, index) => arg === "--repo" && index < out.length - 1)
-  ) {
+  if (ctx && (ctx.source !== "git" || options.explicitRepo)) {
     out.push("--repo", ctx.nwo);
   }
   return out;
@@ -88,8 +91,9 @@ export async function ghJson<T = unknown>(
 export async function ghExec(
   args: string[],
   ctx?: RepoContext,
+  options?: GhExecOptions,
 ): Promise<string> {
-  const result = await run(buildArgs(args, ctx));
+  const result = await run(buildArgs(args, ctx, options));
   if (result.stderr === "ENOENT") throw ghNotInstalledError();
   if (result.exitCode !== 0) throw mapGhError(result.stderr, result.exitCode);
   return result.stdout;

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,0 +1,38 @@
+import { execFileSync } from "node:child_process";
+
+export function baseBranchNeedsExplicitRepo(baseRefName: string): boolean {
+  try {
+    const currentRoot = runGit(["rev-parse", "--show-toplevel"]);
+    const output = runGit(["worktree", "list", "--porcelain", "-z"]);
+    let worktree = "";
+    let branch = "";
+
+    for (const field of output.split("\0")) {
+      if (field.startsWith("worktree ")) {
+        worktree = field.slice("worktree ".length);
+      } else if (field.startsWith("branch ")) {
+        branch = field.slice("branch ".length);
+      } else if (field === "") {
+        if (
+          worktree !== currentRoot &&
+          branch === `refs/heads/${baseRefName}`
+        ) {
+          return true;
+        }
+        worktree = "";
+        branch = "";
+      }
+    }
+
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+function runGit(args: string[]): string {
+  return execFileSync("git", args, {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+}

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -9,14 +9,22 @@ vi.mock("../../src/gh.js", () => ({
   ghRaw: vi.fn(),
 }));
 
+vi.mock("../../src/worktree.js", () => ({
+  baseBranchNeedsExplicitRepo: vi.fn(),
+}));
+
 import { ghJson, ghExec, ghRaw } from "../../src/gh.js";
 import { prCommand, PR_HELP } from "../../src/commands/pr.js";
 import { AxiError } from "../../src/errors.js";
+import { baseBranchNeedsExplicitRepo } from "../../src/worktree.js";
 import type { RepoContext } from "../../src/context.js";
 
 const mockedGhJson = vi.mocked(ghJson);
 const mockedGhExec = vi.mocked(ghExec);
 const mockedGhRaw = vi.mocked(ghRaw);
+const mockedBaseBranchNeedsExplicitRepo = vi.mocked(
+  baseBranchNeedsExplicitRepo,
+);
 
 const ctx: RepoContext = {
   owner: "octo",
@@ -42,6 +50,7 @@ async function withBodyFile<T>(
 describe("prCommand", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    mockedBaseBranchNeedsExplicitRepo.mockReturnValue(false);
   });
 
   describe("router", () => {
@@ -851,6 +860,7 @@ describe("prCommand", () => {
         state: "MERGED",
         mergedBy: { login: "alice" },
         mergedAt: "2024-01-01T00:00:00Z",
+        baseRefName: "main",
       });
 
       const result = await prCommand(["merge", "10"], ctx);
@@ -867,7 +877,10 @@ describe("prCommand", () => {
     ])(
       "maps %s shorthand to a gh merge method flag",
       async (input, ghFlag, method) => {
-        mockedGhJson.mockResolvedValue({ state: "OPEN" });
+        mockedGhJson.mockResolvedValue({
+          state: "OPEN",
+          baseRefName: "main",
+        });
         mockedGhExec.mockResolvedValue("");
 
         const result = await prCommand(
@@ -876,15 +889,7 @@ describe("prCommand", () => {
         );
 
         expect(mockedGhExec).toHaveBeenCalledWith(
-          [
-            "pr",
-            "merge",
-            "10",
-            ghFlag,
-            "--delete-branch",
-            "--repo",
-            "octo/repo",
-          ],
+          ["pr", "merge", "10", ghFlag, "--delete-branch"],
           ctx,
         );
         expect(result).toContain(`method: ${method}`);
@@ -901,6 +906,42 @@ describe("prCommand", () => {
         ["pr", "merge", "10", "--squash"],
         ctx,
       );
+    });
+
+    it("uses explicit repository mode when another worktree owns the base", async () => {
+      mockedGhJson.mockResolvedValue({ state: "OPEN", baseRefName: "main" });
+      mockedBaseBranchNeedsExplicitRepo.mockReturnValue(true);
+      const gitCtx: RepoContext = { ...ctx, source: "git" };
+
+      await prCommand(["merge", "10", "--delete-branch"], gitCtx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["pr", "merge", "10", "--delete-branch"],
+        gitCtx,
+        { explicitRepo: true },
+      );
+    });
+
+    it("keeps local branch cleanup in a single worktree", async () => {
+      mockedGhJson.mockResolvedValue({ state: "OPEN", baseRefName: "main" });
+      const gitCtx: RepoContext = { ...ctx, source: "git" };
+
+      await prCommand(["merge", "10", "--delete-branch"], gitCtx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["pr", "merge", "10", "--delete-branch"],
+        gitCtx,
+      );
+    });
+
+    it("fails safely when a conflicting worktree has no repo context", async () => {
+      mockedGhJson.mockResolvedValue({ state: "OPEN", baseRefName: "main" });
+      mockedBaseBranchNeedsExplicitRepo.mockReturnValue(true);
+
+      await expect(
+        prCommand(["merge", "10", "--delete-branch"]),
+      ).rejects.toThrow("pass --repo <owner/name>");
+      expect(mockedGhExec).not.toHaveBeenCalled();
     });
   });
 

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -861,6 +861,7 @@ describe("prCommand", () => {
         mergedBy: { login: "alice" },
         mergedAt: "2024-01-01T00:00:00Z",
         baseRefName: "main",
+        url: "https://github.com/octo/repo/pull/10",
       });
 
       const result = await prCommand(["merge", "10"], ctx);
@@ -880,6 +881,7 @@ describe("prCommand", () => {
         mockedGhJson.mockResolvedValue({
           state: "OPEN",
           baseRefName: "main",
+          url: "https://github.com/octo/repo/pull/10",
         });
         mockedGhExec.mockResolvedValue("");
 
@@ -909,7 +911,11 @@ describe("prCommand", () => {
     });
 
     it("uses explicit repository mode when another worktree owns the base", async () => {
-      mockedGhJson.mockResolvedValue({ state: "OPEN", baseRefName: "main" });
+      mockedGhJson.mockResolvedValue({
+        state: "OPEN",
+        baseRefName: "main",
+        url: "https://github.com/upstream/project/pull/10",
+      });
       mockedBaseBranchNeedsExplicitRepo.mockReturnValue(true);
       const gitCtx: RepoContext = { ...ctx, source: "git" };
 
@@ -917,13 +923,21 @@ describe("prCommand", () => {
 
       expect(mockedGhExec).toHaveBeenCalledWith(
         ["pr", "merge", "10", "--delete-branch"],
-        gitCtx,
-        { explicitRepo: true },
+        {
+          owner: "upstream",
+          name: "project",
+          nwo: "upstream/project",
+          source: "flag",
+        },
       );
     });
 
     it("keeps local branch cleanup in a single worktree", async () => {
-      mockedGhJson.mockResolvedValue({ state: "OPEN", baseRefName: "main" });
+      mockedGhJson.mockResolvedValue({
+        state: "OPEN",
+        baseRefName: "main",
+        url: "https://github.com/octo/repo/pull/10",
+      });
       const gitCtx: RepoContext = { ...ctx, source: "git" };
 
       await prCommand(["merge", "10", "--delete-branch"], gitCtx);
@@ -934,13 +948,17 @@ describe("prCommand", () => {
       );
     });
 
-    it("fails safely when a conflicting worktree has no repo context", async () => {
-      mockedGhJson.mockResolvedValue({ state: "OPEN", baseRefName: "main" });
+    it("fails safely when a conflicting worktree has no valid PR URL", async () => {
+      mockedGhJson.mockResolvedValue({
+        state: "OPEN",
+        baseRefName: "main",
+        url: "not-a-pull-request-url",
+      });
       mockedBaseBranchNeedsExplicitRepo.mockReturnValue(true);
 
       await expect(
         prCommand(["merge", "10", "--delete-branch"]),
-      ).rejects.toThrow("pass --repo <owner/name>");
+      ).rejects.toThrow("determine repository from pull request URL");
       expect(mockedGhExec).not.toHaveBeenCalled();
     });
   });

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -662,6 +662,26 @@ describe("prCommand", () => {
       );
       expect(mockedGhJson).not.toHaveBeenCalled();
     });
+
+    it("accepts default identity fields alongside optional list fields", async () => {
+      mockedGhJson.mockResolvedValue([]);
+
+      await prCommand(
+        ["list", "--fields", "number,title,state,author,createdAt,url"],
+        ctx,
+      );
+
+      expect(mockedGhJson.mock.calls[0][0]).toEqual([
+        "pr",
+        "list",
+        "--json",
+        "number,title,state,author,isDraft,reviewDecision,createdAt,url",
+        "--state",
+        "open",
+        "--limit",
+        "30",
+      ]);
+    });
   });
 
   describe("edit with repeatable flags", () => {
@@ -856,7 +876,15 @@ describe("prCommand", () => {
         );
 
         expect(mockedGhExec).toHaveBeenCalledWith(
-          ["pr", "merge", "10", ghFlag, "--delete-branch"],
+          [
+            "pr",
+            "merge",
+            "10",
+            ghFlag,
+            "--delete-branch",
+            "--repo",
+            "octo/repo",
+          ],
           ctx,
         );
         expect(result).toContain(`method: ${method}`);

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -104,6 +104,43 @@ describe("resolveRepo", () => {
     });
   });
 
+  it("falls back to another GitHub remote when origin is unavailable", () => {
+    mockedExecFileSync.mockImplementation((_command, args) => {
+      const gitArgs = args as string[];
+      if (gitArgs.join(" ") === "remote get-url origin") {
+        throw new Error("missing origin");
+      }
+      if (gitArgs.join(" ") === "remote") return "upstream\n";
+      if (gitArgs.join(" ") === "remote get-url upstream") {
+        return "git@github.com:cli/cli.git\n";
+      }
+      throw new Error("unexpected git command");
+    });
+
+    expect(resolveRepo()).toEqual({
+      owner: "cli",
+      name: "cli",
+      nwo: "cli/cli",
+      source: "git",
+    });
+  });
+
+  it("falls back when origin is not hosted on the configured GitHub host", () => {
+    mockedExecFileSync.mockImplementation((_command, args) => {
+      const gitArgs = args as string[];
+      if (gitArgs.join(" ") === "remote get-url origin") {
+        return "git@gitlab.com:owner/repo.git\n";
+      }
+      if (gitArgs.join(" ") === "remote") return "origin\nupstream\n";
+      if (gitArgs.join(" ") === "remote get-url upstream") {
+        return "https://github.com/owner/repo.git\n";
+      }
+      throw new Error("unexpected git command");
+    });
+
+    expect(resolveRepo()?.nwo).toBe("owner/repo");
+  });
+
   it("prioritizes flag over env and git", () => {
     process.env["GH_REPO"] = "env-owner/env-repo";
     mockedExecFileSync.mockReturnValue(

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -104,41 +104,14 @@ describe("resolveRepo", () => {
     });
   });
 
-  it("falls back to another GitHub remote when origin is unavailable", () => {
+  it("does not guess the repository from a non-origin remote", () => {
     mockedExecFileSync.mockImplementation((_command, args) => {
-      const gitArgs = args as string[];
-      if (gitArgs.join(" ") === "remote get-url origin") {
-        throw new Error("missing origin");
-      }
-      if (gitArgs.join(" ") === "remote") return "upstream\n";
-      if (gitArgs.join(" ") === "remote get-url upstream") {
-        return "git@github.com:cli/cli.git\n";
-      }
-      throw new Error("unexpected git command");
+      expect(args).toEqual(["remote", "get-url", "origin"]);
+      throw new Error("missing origin");
     });
 
-    expect(resolveRepo()).toEqual({
-      owner: "cli",
-      name: "cli",
-      nwo: "cli/cli",
-      source: "git",
-    });
-  });
-
-  it("falls back when origin is not hosted on the configured GitHub host", () => {
-    mockedExecFileSync.mockImplementation((_command, args) => {
-      const gitArgs = args as string[];
-      if (gitArgs.join(" ") === "remote get-url origin") {
-        return "git@gitlab.com:owner/repo.git\n";
-      }
-      if (gitArgs.join(" ") === "remote") return "origin\nupstream\n";
-      if (gitArgs.join(" ") === "remote get-url upstream") {
-        return "https://github.com/owner/repo.git\n";
-      }
-      throw new Error("unexpected git command");
-    });
-
-    expect(resolveRepo()?.nwo).toBe("owner/repo");
+    expect(resolveRepo()).toBeUndefined();
+    expect(mockedExecFileSync).toHaveBeenCalledOnce();
   });
 
   it("prioritizes flag over env and git", () => {

--- a/test/fields.test.ts
+++ b/test/fields.test.ts
@@ -79,4 +79,14 @@ describe("parseFields", () => {
     expect(result.extraDefs).toHaveLength(1);
     expect(result.extraJsonKeys).toEqual(["body"]);
   });
+
+  it("accepts already-included fields without duplicating them", () => {
+    const result = parseFields(
+      "number,body,title",
+      available,
+      new Set(["number", "title"]),
+    );
+    expect(result.extraDefs).toEqual([field("body")]);
+    expect(result.extraJsonKeys).toEqual(["body"]);
+  });
 });

--- a/test/gh.test.ts
+++ b/test/gh.test.ts
@@ -187,6 +187,48 @@ describe("ghExec", () => {
       "cli/cli",
     ]);
   });
+
+  it("does not mistake an option value for an explicit repo flag", async () => {
+    mockExecFileResult(null, "output", "");
+    const ctx: RepoContext = {
+      owner: "cli",
+      name: "cli",
+      nwo: "cli/cli",
+      source: "flag",
+    };
+
+    await ghExec(["pr", "merge", "10", "--subject", "--repo"], ctx);
+
+    expect(mockedExecFile.mock.calls[0][1]).toEqual([
+      "pr",
+      "merge",
+      "10",
+      "--subject",
+      "--repo",
+      "--repo",
+      "cli/cli",
+    ]);
+  });
+
+  it("can explicitly target a git-resolved repository", async () => {
+    mockExecFileResult(null, "output", "");
+    const ctx: RepoContext = {
+      owner: "cli",
+      name: "cli",
+      nwo: "cli/cli",
+      source: "git",
+    };
+
+    await ghExec(["pr", "merge", "10"], ctx, { explicitRepo: true });
+
+    expect(mockedExecFile.mock.calls[0][1]).toEqual([
+      "pr",
+      "merge",
+      "10",
+      "--repo",
+      "cli/cli",
+    ]);
+  });
 });
 
 describe("ghRaw", () => {

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -1,0 +1,44 @@
+import { execFileSync } from "node:child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { baseBranchNeedsExplicitRepo } from "../src/worktree.js";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+
+describe("baseBranchNeedsExplicitRepo", () => {
+  beforeEach(() => {
+    mockedExecFileSync.mockReset();
+  });
+
+  it("detects a base branch owned by another worktree", () => {
+    mockedExecFileSync
+      .mockReturnValueOnce("/repo/feature\n")
+      .mockReturnValueOnce(
+        "worktree /repo/main\0HEAD abc\0branch refs/heads/main\0\0" +
+          "worktree /repo/feature\0HEAD def\0branch refs/heads/feature\0\0",
+      );
+
+    expect(baseBranchNeedsExplicitRepo("main")).toBe(true);
+  });
+
+  it("keeps local mode when only the current worktree owns the base", () => {
+    mockedExecFileSync
+      .mockReturnValueOnce("/repo/main\n")
+      .mockReturnValueOnce(
+        "worktree /repo/main\0HEAD abc\0branch refs/heads/main\0\0",
+      );
+
+    expect(baseBranchNeedsExplicitRepo("main")).toBe(false);
+  });
+
+  it("fails safe when worktree state cannot be inspected", () => {
+    mockedExecFileSync.mockImplementation(() => {
+      throw new Error("git unavailable");
+    });
+
+    expect(baseBranchNeedsExplicitRepo("main")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- accept default PR identity fields alongside optional `pr list --fields` values
- keep normal single-worktree `--delete-branch` cleanup
- use explicit repository mode only when another worktree owns the base branch
- bind that explicit merge to the repository in the viewed PR URL
- remove arbitrary non-origin remote fallback from global context resolution

## Verification

- 889 tests passed, 5 skipped
- focused PR/context/gh suite: 98 passed
- TypeScript build passed
- no-mistakes review, test, docs, and lint gates passed
- real CLI evidence covered list fields plus single- and multi-worktree merge routing
