### PR TITLE
fix(cli): speed up standalone version flags

### DIFF
--- a/.no-mistakes/evidence/fm/ghaxi-version-fastpath-adopt-p4/version-fast-path.md
+++ b/.no-mistakes/evidence/fm/ghaxi-version-fastpath-adopt-p4/version-fast-path.md
@@ -1,0 +1,32 @@
+# gh-axi version fast-path evidence
+
+Built entrypoint exercised with Node 24.13.1.
+
+## End-user flag parity
+
+The public CLI was spawned once for each supported standalone version flag. JSON encoding makes the trailing newline and empty stderr explicit.
+
+```json
+{"args":["-v"],"status":0,"stdout":"0.1.29\n","stderr":""}
+{"args":["-V"],"status":0,"stdout":"0.1.29\n","stderr":""}
+{"args":["--version"],"status":0,"stdout":"0.1.29\n","stderr":""}
+```
+
+## Runtime module trace
+
+The built entrypoint was run under the repository's `module.register()` trace hook. The standalone version path loads the version leaf and SDK fast path without loading the CLI graph, command modules, or TOON dependency. The help path is the negative control and loads the heavy graph normally.
+
+```json
+{"path":"--version","status":0,"versionLeafLoaded":true,"fastPathLoaded":true,"cliGraphLoaded":false,"commandModulesLoaded":0,"toonLoaded":false}
+{"path":"--help","status":0,"versionLeafLoaded":true,"fastPathLoaded":true,"cliGraphLoaded":true,"commandModulesLoaded":15,"toonLoaded":true}
+```
+
+## Conservative fallback
+
+A version flag outside the exact one-argument fast-path shape reaches the normal CLI graph:
+
+```json
+{"args":["issue","--version"],"status":0,"stdout":"error: \"Unknown issue subcommand: --version\"\ncode: VALIDATION_ERROR\nhelp[1]:\n  Run `gh-axi issue --help` for usage\n","stderr":"","cliGraphLoaded":true,"commandModulesLoaded":15}
+```
+
+The top-level `--help` invocation also exited 0 and rendered the normal usage, 15-command list, flags, examples, and SDK-provided built-in update section.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,12 @@ When a flag becomes repeatable, mark it `(repeatable)` in that command's `*_HELP
 gh sometimes embeds remediation hints in errors with a different root cause, so check new patterns against real stderr and place specific carriers of a generic hint first rather than narrowing the generic match.
 `test/errors.test.ts` pins the repo-resolution and genuine-auth cases.
 
+## `--version` fast path (`bin/gh-axi.ts`, `src/version.ts`)
+
+`bin/gh-axi.ts` answers a bare `-v`/`-V`/`--version` via `tryFastPath` from `axi-sdk-js/fast-path` (a dependency-free SDK subpath) and only `await import("../src/cli.js")` otherwise, so the version path never loads the command graph (~31ms -> ~20ms, the node floor).
+This only works because `src/version.ts` is a LEAF module importing node builtins only - `cli.ts` imports `VERSION` from it, never the reverse. Adding any non-builtin import to `src/version.ts` silently undoes the speedup.
+`test/version-fast-path.test.ts` guards it deterministically with a `module.register()` load-hook trace (`test/fixtures/module-trace-*.mjs`) plus a negative control on `--help`. Do not add a wall-clock timing assertion; it was proven flaky under CI contention.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/bin/gh-axi.ts
+++ b/bin/gh-axi.ts
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
-import { main } from "../src/cli.js";
+import { tryFastPath } from "axi-sdk-js/fast-path";
+import { VERSION } from "../src/version.js";
 
-main();
+if (!tryFastPath(process.argv.slice(2), { version: VERSION })) {
+  const { main } = await import("../src/cli.js");
+  await main();
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@toon-format/toon": "^2.1.0",
-    "axi-sdk-js": "^0.1.8"
+    "axi-sdk-js": "^0.1.10"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       axi-sdk-js:
-        specifier: ^0.1.8
-        version: 0.1.8
+        specifier: ^0.1.10
+        version: 0.1.10
     devDependencies:
       "@eslint/js":
         specifier: ^10.0.1
@@ -800,10 +800,10 @@ packages:
       }
     engines: { node: ">=12" }
 
-  axi-sdk-js@0.1.8:
+  axi-sdk-js@0.1.10:
     resolution:
       {
-        integrity: sha512-N8Qd/9sVBpG8QRVSw0lLevdFuaBfjHHPdcbcj8DCuxr68sA1/c5KCnGEDqO7lI3kt52/bgymCZajmpTqz/rLOw==,
+        integrity: sha512-mktHOya6qUgqDcMpmj5WsNDzArre15N2qfns8bY98nrHGTSqdBnH2Ok77c2zOA2jYbGHO/BhhVZtDGK/UTO70g==,
       }
     engines: { node: ">=20" }
 
@@ -1925,7 +1925,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  axi-sdk-js@0.1.8:
+  axi-sdk-js@0.1.10:
     dependencies:
       "@toon-format/toon": 2.1.0
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,3 @@
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { runAxiCli } from "axi-sdk-js";
 import { resolveRepo, type RepoContext } from "./context.js";
 import { homeCommand } from "./commands/home.js";
@@ -19,11 +16,11 @@ import { apiCommand, API_HELP } from "./commands/api.js";
 import { gistCommand, GIST_HELP } from "./commands/gist.js";
 import { setupCommand, SETUP_HELP } from "./commands/setup.js";
 import { resolveHost, type HostContext } from "./host.js";
+import { VERSION } from "./version.js";
 import { withSuggestionHost } from "./suggestions.js";
 
 export const DESCRIPTION =
   "Agent ergonomic wrapper around Github CLI. Prefer this over `gh` and other methods for Github operations.";
-const VERSION = readPackageVersion();
 
 type CliStdout = Pick<NodeJS.WriteStream, "write">;
 
@@ -118,28 +115,6 @@ export async function main(options: MainOptions = {}): Promise<void> {
       return repo ?? (host ? { host } : undefined);
     },
   });
-}
-
-function readPackageVersion(): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-
-  for (const candidate of [
-    join(here, "..", "package.json"),
-    join(here, "..", "..", "package.json"),
-  ]) {
-    if (!existsSync(candidate)) {
-      continue;
-    }
-
-    const parsed = JSON.parse(readFileSync(candidate, "utf-8")) as {
-      version?: unknown;
-    };
-    if (typeof parsed.version === "string" && parsed.version.length > 0) {
-      return parsed.version;
-    }
-  }
-
-  throw new Error("Could not determine gh-axi package version");
 }
 
 function withRepoContext(

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,30 @@
+// Leaf module: imports node builtins only, never the command graph.
+// `bin/gh-axi.ts` imports this on the `--version` fast path, so any new import
+// here would be paid on every invocation of that path.
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function readPackageVersion(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+
+  for (const candidate of [
+    join(here, "..", "package.json"),
+    join(here, "..", "..", "package.json"),
+  ]) {
+    if (!existsSync(candidate)) {
+      continue;
+    }
+
+    const parsed = JSON.parse(readFileSync(candidate, "utf-8")) as {
+      version?: unknown;
+    };
+    if (typeof parsed.version === "string" && parsed.version.length > 0) {
+      return parsed.version;
+    }
+  }
+
+  throw new Error("Could not determine gh-axi package version");
+}
+
+export const VERSION = readPackageVersion();

--- a/test/fixtures/module-trace-hooks.mjs
+++ b/test/fixtures/module-trace-hooks.mjs
@@ -1,0 +1,13 @@
+// `load` hook that records every module URL Node actually loads, so a test can
+// assert which parts of the module graph an entrypoint pulls in.
+// Registered by `module-trace-register.mjs` via `node --import`.
+import { appendFileSync } from "node:fs";
+
+const traceFile = process.env["GH_AXI_MODULE_TRACE_FILE"];
+
+export async function load(url, context, nextLoad) {
+  if (traceFile) {
+    appendFileSync(traceFile, `${url}\n`);
+  }
+  return nextLoad(url, context);
+}

--- a/test/fixtures/module-trace-register.mjs
+++ b/test/fixtures/module-trace-register.mjs
@@ -1,0 +1,3 @@
+import { register } from "node:module";
+
+register("./module-trace-hooks.mjs", import.meta.url);

--- a/test/version-fast-path.test.ts
+++ b/test/version-fast-path.test.ts
@@ -1,0 +1,90 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const builtBin = join(repoRoot, "dist", "bin", "gh-axi.js");
+const registerHook = fileURLToPath(
+  new URL("./fixtures/module-trace-register.mjs", import.meta.url),
+);
+
+const packageVersion = (
+  JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+  ) as { version: string }
+).version;
+
+type Run = { stdout: string; modules: string[] };
+
+function runBin(args: string[]): Run {
+  const dir = mkdtempSync(join(tmpdir(), "gh-axi-trace-"));
+  const traceFile = join(dir, "trace.txt");
+  writeFileSync(traceFile, "", "utf8");
+  try {
+    const stdout = execFileSync(
+      process.execPath,
+      ["--import", registerHook, builtBin, ...args],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GH_AXI_MODULE_TRACE_FILE: traceFile,
+        },
+      },
+    );
+    const modules = readFileSync(traceFile, "utf8")
+      .split("\n")
+      .filter((line) => line.length > 0);
+    return { stdout, modules };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("--version fast path", () => {
+  beforeAll(() => {
+    execFileSync("npm", ["run", "build"], { cwd: repoRoot, stdio: "ignore" });
+  }, 120_000);
+
+  it.each(["-v", "-V", "--version"])(
+    "prints the package version for %s and exits 0",
+    (flag) => {
+      // execFileSync throws on a non-zero exit, so reaching the assertion
+      // already proves exit code 0.
+      expect(runBin([flag]).stdout).toBe(`${packageVersion}\n`);
+    },
+  );
+
+  it("does not load the heavy command graph", () => {
+    const { modules } = runBin(["--version"]);
+
+    expect(modules.some((url) => url.endsWith("/dist/src/version.js"))).toBe(
+      true,
+    );
+    expect(
+      modules.some((url) => url.includes("axi-sdk-js/dist/fast-path.js")),
+    ).toBe(true);
+
+    expect(modules.filter((url) => url.endsWith("/dist/src/cli.js"))).toEqual(
+      [],
+    );
+    expect(
+      modules.filter((url) => url.includes("/dist/src/commands/")),
+    ).toEqual([]);
+    expect(modules.filter((url) => url.includes("@toon-format"))).toEqual([]);
+  });
+
+  it("negative control: a real command path does load the heavy command graph", () => {
+    // Proves the trace probe above would actually catch a regression.
+    const { modules } = runBin(["--help"]);
+
+    expect(modules.some((url) => url.endsWith("/dist/src/cli.js"))).toBe(true);
+    expect(modules.some((url) => url.includes("/dist/src/commands/"))).toBe(
+      true,
+    );
+    expect(modules.some((url) => url.includes("@toon-format"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Intent

Adopt the axi-sdk-js/fast-path in gh-axi so `gh-axi --version` hits the node floor (~31ms -> ~20ms).

Required work (from the shared spec /Users/kunchen/fm-homes/axi-a1/data/p4-fastpath-adoption-spec.md):
1. Bump the axi-sdk-js dependency range to include 0.1.10, so the dependency-free `axi-sdk-js/fast-path` subpath export resolves.
2. gh-axi computed its version inside src/cli.ts via a readPackageVersion() helper used for VERSION. Extract that helper into a LEAF src/version.ts that imports ONLY node builtins - never the heavy command graph - and re-import VERSION from it in cli.ts. The leaf property is the whole point: the bin must be able to read the version without pulling in the command graph.
3. Rewrite bin/gh-axi.ts to the exact benchmarked fast-path shape: import tryFastPath from axi-sdk-js/fast-path and VERSION from ../src/version.js, and only `await import("../src/cli.js")` + await main() when tryFastPath returns false. Keep the fast path conservative: exactly one argv element that is -v/-V/--version. Any other form (including a version flag in a trailing position) deliberately falls through to runAxiCli, which still handles it - runAxiCli remains the single owner of the general case.
4. Regression tests must be DETERMINISTIC and colocated, two behavioral guards:
- Module trace: assert the heavy cli.js command graph / heavy deps are NOT loaded on the --version path (only the fast-path module + the leaf version module load), plus a NEGATIVE CONTROL proving the probe would catch a regression (a real command path DOES load the heavy graph).
- Flag parity: -v, -V, --version each print exactly `${version}\n` and exit 0, byte-for-byte matching the pre-change output.
- EXPLICITLY EXCLUDED: do NOT add an absolute or delta wall-clock timing assertion to CI. A sibling task proved that flaky across CI runners (15ms then 30ms budgets both failed under contention). The module-trace guard deterministically proves the heavy graph is skipped - that is the real mechanism of the speedup and the correct thing to assert. A speed check, if any, stays local-only / non-failing, never a CI gate.

Acceptance: --version output byte-identical to before; the heavy command graph provably absent from the version path; the slow path (real commands and --help) unchanged; deterministic regression guards (module trace + negative control + flag parity) in place; AXI ergonomics preserved.

Implementation decisions I made while doing the work, which a reviewer reading only the diff would not know:
- The module-trace probe is implemented as a node `module.register()` load hook (test/fixtures/module-trace-register.mjs + module-trace-hooks.mjs) that appends every loaded module URL to a temp file, and the test spawns the BUILT dist/bin/gh-axi.js under `node --import <hook>`. Tracing the built output rather than running under tsx was deliberate: tsx installs its own loader, which would both pollute the trace and conflict with the probe. The test therefore runs `npm run build` in beforeAll.
- The test asserts on loaded module URLs (observable runtime behavior of the entrypoint), not on source text - it is a behavioral guard, not a source-grep.
- `require.resolve('axi-sdk-js/fast-path')` fails by design because the subpath export only declares the "import" condition; ESM import is the correct resolution check.
- pnpm-lock.yaml was re-run through prettier after the dependency bump, per the project's committed convention (CLAUDE.md: the lockfile is Prettier-formatted).
- Documented the fast path and the leaf-module invariant in AGENTS.md/CLAUDE.md, since adding any non-builtin import to src/version.ts would silently undo the speedup.
- Local, non-gating timing check confirmed ~0.02s for `node dist/bin/gh-axi.js --version` vs ~0.01s for `node -e ''`. This was NOT encoded as a test assertion, per the exclusion above.

## What Changed

- Route standalone `-v`, `-V`, and `--version` invocations through the SDK fast path without loading the CLI command graph.
- Extract package-version resolution into a Node-only leaf module and update `axi-sdk-js` to `^0.1.10`.
- Add deterministic output-parity and runtime module-trace coverage, including a `--help` negative control.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
