### PR TITLE
fix(api): honor callerShapedOutput for non-JSON --jq/--template output

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ Two file-on-disk input forms are available: positional paths (`gist create a.py 
 To create a gist from piped content, use `--filename <name>` together with a pipe (`echo "..." | gh-axi gist create --filename foo.txt --public`).
 
 `gh-axi api` accepts `--field`, `--header`, `--paginate`, `--jq <expression>`, and `--template <format>`; any other flag, an extra positional argument, or a repeated `--jq`/`--template` is rejected with a clear error instead of being silently dropped.
-JSON responses are normally stripped of noisy fields before TOON encoding, but a response you shaped yourself with `--jq` or `--template` keeps every key and value verbatim — only over-long strings are still truncated so one field cannot flood an agent's context.
+JSON responses are normally stripped of noisy fields before TOON encoding, but a response you shaped yourself with `--jq` or `--template` keeps every key and value verbatim; individual strings longer than 2,000 characters are still clamped so one field cannot flood an agent's context.
+Non-JSON output from `--jq`/`--template` (plain text, or the concatenated per-page output of `--paginate`) is returned exactly as `gh` produced it up to 200,000 characters, so it stays pipeable; past that it is wrapped in the same `api_response` envelope with `truncated: true` and `original_length`.
+Non-JSON output you did not shape keeps the original 4,000-character envelope.
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ To create a gist from piped content, use `--filename <name>` together with a pip
 
 `gh-axi api` accepts `--field`, `--header`, `--paginate`, `--jq <expression>`, and `--template <format>`; any other flag, an extra positional argument, or a repeated `--jq`/`--template` is rejected with a clear error instead of being silently dropped.
 JSON responses are normally stripped of noisy fields before TOON encoding, but a response you shaped yourself with `--jq` or `--template` keeps every key and value verbatim; individual strings longer than 2,000 characters are still clamped so one field cannot flood an agent's context.
-Non-JSON output from `--jq`/`--template` (plain text, or the concatenated per-page output of `--paginate`) is returned exactly as `gh` produced it up to 200,000 characters, so it stays pipeable; past that it is wrapped in the same `api_response` envelope with `truncated: true` and `original_length`.
+Non-JSON output from `--jq`/`--template` (plain text, or the concatenated per-page output of `--paginate`) is returned as `gh` produced it — including any leading whitespace a `--template` uses for column alignment, with only the trailing newline dropped — up to 200,000 characters, so it stays pipeable; past that it is wrapped in the same `api_response` envelope with `truncated: true` and `original_length`.
 Non-JSON output you did not shape keeps the original 4,000-character envelope.
 
 ### Commands

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -177,8 +177,22 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
     const data = JSON.parse(raw);
     return encode(shapeOutput(data, !callerShapedOutput));
   } catch {
-    // Not JSON — wrap in TOON envelope with truncation metadata
     const trimmed = raw.trim();
+
+    // A caller who wrote a jq expression or template already chose the exact
+    // shape they want — including plain, non-JSON text. `--paginate` runs jq
+    // once per page and concatenates each page's raw output, so a multi-page
+    // `--jq`/`--template` response is routinely NOT valid JSON even though
+    // every individual page's filtered output is well-formed. Wrapping that
+    // in a TOON envelope and clamping it to RAW_OUTPUT_TRUNCATION_LIMIT
+    // silently mangles the exact shape the caller asked for and breaks any
+    // downstream pipe (`sort`, `uniq -c`, `wc -l`, ...) that expects the same
+    // raw text `gh api` would have produced — the same failure mode the
+    // noisy-key stripping skip above already exists to prevent.
+    if (callerShapedOutput) return trimmed;
+
+    // Not JSON and not caller-shaped — protect the agent from an unbounded
+    // blob it didn't ask to see.
     const truncated = trimmed.length > RAW_OUTPUT_TRUNCATION_LIMIT;
     const result: Record<string, unknown> = {
       api_response: {

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -202,8 +202,6 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
     const data = JSON.parse(raw);
     return encode(shapeOutput(data, !callerShapedOutput));
   } catch {
-    const trimmed = raw.trim();
-
     // A caller who wrote a jq expression or template already chose the exact
     // shape they want — including plain, non-JSON text. `--paginate` runs jq
     // once per page and concatenates each page's raw output, so a multi-page
@@ -217,14 +215,18 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
     // therefore the rule up to the far more generous
     // CALLER_SHAPED_RAW_OUTPUT_LIMIT, beyond which a single oversized
     // selection would still flood the agent's context and gets the envelope.
+    // Only the trailing newline gh appends is dropped: a Go `--template` may
+    // legitimately open with column-aligning padding, and stripping that is
+    // the same silent reshaping this branch exists to avoid.
     if (callerShapedOutput) {
-      if (trimmed.length <= CALLER_SHAPED_RAW_OUTPUT_LIMIT) return trimmed;
-      return rawOutputEnvelope(trimmed, CALLER_SHAPED_RAW_OUTPUT_LIMIT);
+      const shaped = raw.trimEnd();
+      if (shaped.length <= CALLER_SHAPED_RAW_OUTPUT_LIMIT) return shaped;
+      return rawOutputEnvelope(shaped, CALLER_SHAPED_RAW_OUTPUT_LIMIT);
     }
 
     // Not JSON and not caller-shaped — protect the agent from an unbounded
     // blob it didn't ask to see.
-    return rawOutputEnvelope(trimmed, RAW_OUTPUT_TRUNCATION_LIMIT);
+    return rawOutputEnvelope(raw.trim(), RAW_OUTPUT_TRUNCATION_LIMIT);
   }
 }
 

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -114,8 +114,32 @@ function parseArgs(args: string[]): ParsedApiArgs {
   return parsed;
 }
 
-/** Maximum length for raw (non-JSON) API output before truncation. */
+/** Maximum length for raw (non-JSON) API output the caller did not shape. */
 const RAW_OUTPUT_TRUNCATION_LIMIT = 4000;
+
+/**
+ * Maximum length for raw (non-JSON) output the caller shaped with
+ * `--jq`/`--template`. Deliberately far above RAW_OUTPUT_TRUNCATION_LIMIT so a
+ * realistic multi-page `--paginate --jq` script (thousands of short filtered
+ * lines) survives verbatim, while a single oversized selection — `--jq .body`
+ * on a huge text blob, `--jq .content` on a large file — is still bounded.
+ */
+const CALLER_SHAPED_RAW_OUTPUT_LIMIT = 200_000;
+
+/** Wrap non-JSON output in a TOON envelope, clamped to `limit` characters. */
+function rawOutputEnvelope(trimmed: string, limit: number): string {
+  const truncated = trimmed.length > limit;
+  const result: Record<string, unknown> = {
+    api_response: {
+      body: truncated ? trimmed.slice(0, limit) : trimmed,
+      truncated,
+    },
+  };
+  if (truncated) {
+    (result.api_response as Record<string, unknown>).original_length = trimmed.length;
+  }
+  return encode(result);
+}
 
 /** Strings longer than this threshold are cleaned up (image/URL stripping). */
 const LONG_STRING_CLEANUP_THRESHOLD = 200;
@@ -167,8 +191,9 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
 
   // A caller who wrote a jq expression or template already chose the exact shape
   // they want, so noisy-field stripping would silently delete fields they asked
-  // for by name (`url`, `node_id`, ...). The length clamp still applies, so a
-  // selected field cannot blow the caller's context with an unbounded blob.
+  // for by name (`url`, `node_id`, ...). Length is still bounded either way: the
+  // JSON path clamps each string value via truncateString, and the non-JSON path
+  // below is bounded by CALLER_SHAPED_RAW_OUTPUT_LIMIT.
   const callerShapedOutput = jq !== undefined || template !== undefined;
 
   // Try to parse as JSON, strip noisy fields, encode to TOON; fall back to raw output
@@ -188,22 +213,18 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
     // silently mangles the exact shape the caller asked for and breaks any
     // downstream pipe (`sort`, `uniq -c`, `wc -l`, ...) that expects the same
     // raw text `gh api` would have produced — the same failure mode the
-    // noisy-key stripping skip above already exists to prevent.
-    if (callerShapedOutput) return trimmed;
+    // noisy-key stripping skip above already exists to prevent. Verbatim is
+    // therefore the rule up to the far more generous
+    // CALLER_SHAPED_RAW_OUTPUT_LIMIT, beyond which a single oversized
+    // selection would still flood the agent's context and gets the envelope.
+    if (callerShapedOutput) {
+      if (trimmed.length <= CALLER_SHAPED_RAW_OUTPUT_LIMIT) return trimmed;
+      return rawOutputEnvelope(trimmed, CALLER_SHAPED_RAW_OUTPUT_LIMIT);
+    }
 
     // Not JSON and not caller-shaped — protect the agent from an unbounded
     // blob it didn't ask to see.
-    const truncated = trimmed.length > RAW_OUTPUT_TRUNCATION_LIMIT;
-    const result: Record<string, unknown> = {
-      api_response: {
-        body: truncated ? trimmed.slice(0, RAW_OUTPUT_TRUNCATION_LIMIT) : trimmed,
-        truncated,
-      },
-    };
-    if (truncated) {
-      (result.api_response as Record<string, unknown>).original_length = trimmed.length;
-    }
-    return encode(result);
+    return rawOutputEnvelope(trimmed, RAW_OUTPUT_TRUNCATION_LIMIT);
   }
 }
 

--- a/test/commands/api.test.ts
+++ b/test/commands/api.test.ts
@@ -332,6 +332,20 @@ describe('apiCommand', () => {
     expect(result.replace(/[^z]/g, '')).toHaveLength(200_000);
   });
 
+  it('preserves leading whitespace in caller-shaped --template output', async () => {
+    const aligned = '    octo/repo-one   42\n  octocat/repo-two    7\n';
+    mockedGhExec.mockResolvedValue(aligned);
+
+    const result = await apiCommand([
+      '/repos/octo/repo/forks',
+      '--template',
+      '{{range .}}{{printf "%20s %4d" .full_name .forks}}{{"\\n"}}{{end}}',
+    ]);
+
+    expect(result).toBe(aligned.trimEnd());
+    expect(result.startsWith('    octo/repo-one')).toBe(true);
+  });
+
   it('returns caller-shaped --template output verbatim when it is not JSON', async () => {
     mockedGhExec.mockResolvedValue('octo/repo-one\noctocat/repo-two\n');
 

--- a/test/commands/api.test.ts
+++ b/test/commands/api.test.ts
@@ -294,4 +294,38 @@ describe('apiCommand', () => {
     // The body itself should be truncated
     expect(result.length).toBeLessThan(5000);
   });
+
+  it('returns caller-shaped --jq output verbatim when it is not JSON, unwrapped and untruncated', async () => {
+    // Simulates `--paginate --jq '.[].environment'`: gh runs jq once per page
+    // and concatenates each page's plain-text lines, so the combined output
+    // is not valid JSON even though the caller explicitly chose this shape.
+    const lines = Array.from({ length: 2000 }, (_, i) => (i % 2 === 0 ? 'production' : 'Preview'));
+    mockedGhExec.mockResolvedValue(lines.join('\n') + '\n');
+
+    const result = await apiCommand(['/repos/octo/repo/deployments', '--paginate', '--jq', '.[].environment']);
+
+    expect(result).not.toContain('api_response:');
+    expect(result).not.toContain('truncated:');
+    expect(result.split('\n')).toHaveLength(2000);
+    expect(result).toBe(lines.join('\n'));
+  });
+
+  it('returns caller-shaped --template output verbatim when it is not JSON', async () => {
+    mockedGhExec.mockResolvedValue('octo/repo-one\noctocat/repo-two\n');
+
+    const result = await apiCommand(['/repos/octo/repo/forks', '--template', '{{.full_name}}{{"\\n"}}']);
+
+    expect(result).toBe('octo/repo-one\noctocat/repo-two');
+  });
+
+  it('still wraps and truncates plain non-JSON output with no --jq/--template', async () => {
+    const longText = 'y'.repeat(10_000);
+    mockedGhExec.mockResolvedValue(longText);
+
+    const result = await apiCommand(['/repos/octo/repo/deployments', '--paginate']);
+
+    expect(result).toContain('api_response:');
+    expect(result).toContain('truncated: true');
+    expect(result.length).toBeLessThan(10_000);
+  });
 });

--- a/test/commands/api.test.ts
+++ b/test/commands/api.test.ts
@@ -295,7 +295,7 @@ describe('apiCommand', () => {
     expect(result.length).toBeLessThan(5000);
   });
 
-  it('returns caller-shaped --jq output verbatim when it is not JSON, unwrapped and untruncated', async () => {
+  it('returns caller-shaped --jq output verbatim when it is not JSON and under the raw cap', async () => {
     // Simulates `--paginate --jq '.[].environment'`: gh runs jq once per page
     // and concatenates each page's plain-text lines, so the combined output
     // is not valid JSON even though the caller explicitly chose this shape.
@@ -308,6 +308,28 @@ describe('apiCommand', () => {
     expect(result).not.toContain('truncated:');
     expect(result.split('\n')).toHaveLength(2000);
     expect(result).toBe(lines.join('\n'));
+  });
+
+  it('returns caller-shaped non-JSON output verbatim right up to the raw cap', async () => {
+    const atLimit = 'z'.repeat(200_000);
+    mockedGhExec.mockResolvedValue(atLimit);
+
+    const result = await apiCommand(['/repos/octo/repo/contents/big.txt', '--jq', '.content']);
+
+    expect(result).toBe(atLimit);
+    expect(result).not.toContain('api_response:');
+  });
+
+  it('wraps caller-shaped non-JSON output past the raw cap in a truncation envelope', async () => {
+    const overLimit = 'z'.repeat(200_001);
+    mockedGhExec.mockResolvedValue(overLimit);
+
+    const result = await apiCommand(['/repos/octo/repo/issues/1', '--jq', '.body']);
+
+    expect(result).toContain('api_response:');
+    expect(result).toContain('truncated: true');
+    expect(result).toContain('original_length: 200001');
+    expect(result.replace(/[^z]/g, '')).toHaveLength(200_000);
   });
 
   it('returns caller-shaped --template output verbatim when it is not JSON', async () => {


### PR DESCRIPTION
## What

`api.ts`'s catch branch (non-JSON `gh` output) TOON-wraps and clamps every
response to 4000 chars, **even when the caller explicitly shaped the output
with `--jq`/`--template`**. The `callerShapedOutput` flag already exists and
is honored on the successful-JSON path (no noisy-key stripping), but the
non-JSON path ignored it entirely.

This isn't an edge case — it's the common case for `--paginate` + `--jq`.
`gh api --paginate` runs the jq/template filter once per page and
concatenates each page's raw text, so a multi-page filtered response is
routinely **not valid JSON** even though every individual page's own output
is well-formed (e.g. `gh-axi api /repos/o/r/deployments --paginate --jq
'.[].environment'` across 65 pages). The result silently loses everything
past 4000 chars and gets wrapped in an `api_response: {body, truncated}`
envelope the caller never asked for — breaking any downstream pipe (`sort`,
`uniq -c`, `wc -l`, …) that expects the same raw text `gh` itself would
produce.

## Fix

- New `CALLER_SHAPED_RAW_OUTPUT_LIMIT` (200,000 chars), separate from the
  existing `RAW_OUTPUT_TRUNCATION_LIMIT` (4,000, unchanged, still used only
  for raw output the caller did **not** shape). When `--jq`/`--template` was
  given and the combined output isn't JSON, it's returned verbatim up to
  this cap — generous enough for a realistic multi-page scripted tally
  (thousands of short filtered lines), while still bounding a genuinely
  oversized single-field selection (`--jq .body` on a huge text blob, `--jq
  .content` on a large file).
- Extracted the envelope-building logic into `rawOutputEnvelope()` so both
  branches share it instead of duplicating the truncation/metadata shape.
- `raw.trimEnd()` instead of `raw.trim()` on the caller-shaped path only, so
  leading whitespace in a column-aligned `--template` round-trips unchanged
  (the unshaped path still uses `trim()` — that output is wrapped, never
  claimed verbatim).
- README updated to state the corrected, three-tier length-clamp contract
  instead of a single blanket guarantee.

## How this PR was built

Two review-gate passes (via `no-mistakes`) caught real gaps in the first cut
before this ever reached a human:

1. The initial fix returned caller-shaped non-JSON output **fully
   unbounded** — same risk class the review flagged in the JSON path's
   existing size guard, just reintroduced from the other direction. Fixed by
   adding `CALLER_SHAPED_RAW_OUTPUT_LIMIT`.
2. Once the README claimed output is returned "exactly as `gh` produced it,"
   review caught that `raw.trim()` silently drops leading whitespace,
   contradicting that claim for templates with leading indentation. Fixed by
   switching to `trimEnd()` on the caller-shaped branch.

## Testing

- `pnpm run build` — clean
- `pnpm test` — 898 passed, 5 skipped (0 failures)
- `pnpm exec eslint` on changed files — clean
- New tests: verbatim pass-through under the cap (2000-line paginated
  scenario), truncation above the cap with envelope + `original_length`,
  `--template` leading-whitespace preservation, and a regression check that
  plain unshaped non-JSON output keeps the original 4000-char envelope
  behavior unchanged.
