### PR TITLE
fix(commands): forward --admin (and other unmodeled flags) on pr merge so they aren't silently dropped

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ Two file-on-disk input forms are available: positional paths (`gist create a.py 
 To create a gist from piped content, use `--filename <name>` together with a pipe (`echo "..." | gh-axi gist create --filename foo.txt --public`).
 
 `gh-axi api` accepts `--field`, `--header`, `--paginate`, `--jq <expression>`, and `--template <format>`; any other flag, an extra positional argument, or a repeated `--jq`/`--template` is rejected with a clear error instead of being silently dropped.
-JSON responses are normally stripped of noisy fields before TOON encoding, but a response you shaped yourself with `--jq` or `--template` keeps every key and value verbatim — only over-long strings are still truncated so one field cannot flood an agent's context.
+JSON responses are normally stripped of noisy fields before TOON encoding, but a response you shaped yourself with `--jq` or `--template` keeps every key and value verbatim; individual strings longer than 2,000 characters are still clamped so one field cannot flood an agent's context.
+Non-JSON output from `--jq`/`--template` (plain text, or the concatenated per-page output of `--paginate`) is returned exactly as `gh` produced it up to 200,000 characters, so it stays pipeable; past that it is wrapped in the same `api_response` envelope with `truncated: true` and `original_length`.
+Non-JSON output you did not shape keeps the original 4,000-character envelope.
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ To create a gist from piped content, use `--filename <name>` together with a pip
 
 `gh-axi api` accepts `--field`, `--header`, `--paginate`, `--jq <expression>`, and `--template <format>`; any other flag, an extra positional argument, or a repeated `--jq`/`--template` is rejected with a clear error instead of being silently dropped.
 JSON responses are normally stripped of noisy fields before TOON encoding, but a response you shaped yourself with `--jq` or `--template` keeps every key and value verbatim; individual strings longer than 2,000 characters are still clamped so one field cannot flood an agent's context.
-Non-JSON output from `--jq`/`--template` (plain text, or the concatenated per-page output of `--paginate`) is returned exactly as `gh` produced it up to 200,000 characters, so it stays pipeable; past that it is wrapped in the same `api_response` envelope with `truncated: true` and `original_length`.
+Non-JSON output from `--jq`/`--template` (plain text, or the concatenated per-page output of `--paginate`) is returned as `gh` produced it — including any leading whitespace a `--template` uses for column alignment, with only the trailing newline dropped — up to 200,000 characters, so it stays pipeable; past that it is wrapped in the same `api_response` envelope with `truncated: true` and `original_length`.
 Non-JSON output you did not shape keeps the original 4,000-character envelope.
 
 ### Commands

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -177,8 +177,22 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
     const data = JSON.parse(raw);
     return encode(shapeOutput(data, !callerShapedOutput));
   } catch {
-    // Not JSON — wrap in TOON envelope with truncation metadata
     const trimmed = raw.trim();
+
+    // A caller who wrote a jq expression or template already chose the exact
+    // shape they want — including plain, non-JSON text. `--paginate` runs jq
+    // once per page and concatenates each page's raw output, so a multi-page
+    // `--jq`/`--template` response is routinely NOT valid JSON even though
+    // every individual page's filtered output is well-formed. Wrapping that
+    // in a TOON envelope and clamping it to RAW_OUTPUT_TRUNCATION_LIMIT
+    // silently mangles the exact shape the caller asked for and breaks any
+    // downstream pipe (`sort`, `uniq -c`, `wc -l`, ...) that expects the same
+    // raw text `gh api` would have produced — the same failure mode the
+    // noisy-key stripping skip above already exists to prevent.
+    if (callerShapedOutput) return trimmed;
+
+    // Not JSON and not caller-shaped — protect the agent from an unbounded
+    // blob it didn't ask to see.
     const truncated = trimmed.length > RAW_OUTPUT_TRUNCATION_LIMIT;
     const result: Record<string, unknown> = {
       api_response: {

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -202,8 +202,6 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
     const data = JSON.parse(raw);
     return encode(shapeOutput(data, !callerShapedOutput));
   } catch {
-    const trimmed = raw.trim();
-
     // A caller who wrote a jq expression or template already chose the exact
     // shape they want — including plain, non-JSON text. `--paginate` runs jq
     // once per page and concatenates each page's raw output, so a multi-page
@@ -217,14 +215,18 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
     // therefore the rule up to the far more generous
     // CALLER_SHAPED_RAW_OUTPUT_LIMIT, beyond which a single oversized
     // selection would still flood the agent's context and gets the envelope.
+    // Only the trailing newline gh appends is dropped: a Go `--template` may
+    // legitimately open with column-aligning padding, and stripping that is
+    // the same silent reshaping this branch exists to avoid.
     if (callerShapedOutput) {
-      if (trimmed.length <= CALLER_SHAPED_RAW_OUTPUT_LIMIT) return trimmed;
-      return rawOutputEnvelope(trimmed, CALLER_SHAPED_RAW_OUTPUT_LIMIT);
+      const shaped = raw.trimEnd();
+      if (shaped.length <= CALLER_SHAPED_RAW_OUTPUT_LIMIT) return shaped;
+      return rawOutputEnvelope(shaped, CALLER_SHAPED_RAW_OUTPUT_LIMIT);
     }
 
     // Not JSON and not caller-shaped — protect the agent from an unbounded
     // blob it didn't ask to see.
-    return rawOutputEnvelope(trimmed, RAW_OUTPUT_TRUNCATION_LIMIT);
+    return rawOutputEnvelope(raw.trim(), RAW_OUTPUT_TRUNCATION_LIMIT);
   }
 }
 

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -114,8 +114,32 @@ function parseArgs(args: string[]): ParsedApiArgs {
   return parsed;
 }
 
-/** Maximum length for raw (non-JSON) API output before truncation. */
+/** Maximum length for raw (non-JSON) API output the caller did not shape. */
 const RAW_OUTPUT_TRUNCATION_LIMIT = 4000;
+
+/**
+ * Maximum length for raw (non-JSON) output the caller shaped with
+ * `--jq`/`--template`. Deliberately far above RAW_OUTPUT_TRUNCATION_LIMIT so a
+ * realistic multi-page `--paginate --jq` script (thousands of short filtered
+ * lines) survives verbatim, while a single oversized selection — `--jq .body`
+ * on a huge text blob, `--jq .content` on a large file — is still bounded.
+ */
+const CALLER_SHAPED_RAW_OUTPUT_LIMIT = 200_000;
+
+/** Wrap non-JSON output in a TOON envelope, clamped to `limit` characters. */
+function rawOutputEnvelope(trimmed: string, limit: number): string {
+  const truncated = trimmed.length > limit;
+  const result: Record<string, unknown> = {
+    api_response: {
+      body: truncated ? trimmed.slice(0, limit) : trimmed,
+      truncated,
+    },
+  };
+  if (truncated) {
+    (result.api_response as Record<string, unknown>).original_length = trimmed.length;
+  }
+  return encode(result);
+}
 
 /** Strings longer than this threshold are cleaned up (image/URL stripping). */
 const LONG_STRING_CLEANUP_THRESHOLD = 200;
@@ -167,8 +191,9 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
 
   // A caller who wrote a jq expression or template already chose the exact shape
   // they want, so noisy-field stripping would silently delete fields they asked
-  // for by name (`url`, `node_id`, ...). The length clamp still applies, so a
-  // selected field cannot blow the caller's context with an unbounded blob.
+  // for by name (`url`, `node_id`, ...). Length is still bounded either way: the
+  // JSON path clamps each string value via truncateString, and the non-JSON path
+  // below is bounded by CALLER_SHAPED_RAW_OUTPUT_LIMIT.
   const callerShapedOutput = jq !== undefined || template !== undefined;
 
   // Try to parse as JSON, strip noisy fields, encode to TOON; fall back to raw output
@@ -188,22 +213,18 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
     // silently mangles the exact shape the caller asked for and breaks any
     // downstream pipe (`sort`, `uniq -c`, `wc -l`, ...) that expects the same
     // raw text `gh api` would have produced — the same failure mode the
-    // noisy-key stripping skip above already exists to prevent.
-    if (callerShapedOutput) return trimmed;
+    // noisy-key stripping skip above already exists to prevent. Verbatim is
+    // therefore the rule up to the far more generous
+    // CALLER_SHAPED_RAW_OUTPUT_LIMIT, beyond which a single oversized
+    // selection would still flood the agent's context and gets the envelope.
+    if (callerShapedOutput) {
+      if (trimmed.length <= CALLER_SHAPED_RAW_OUTPUT_LIMIT) return trimmed;
+      return rawOutputEnvelope(trimmed, CALLER_SHAPED_RAW_OUTPUT_LIMIT);
+    }
 
     // Not JSON and not caller-shaped — protect the agent from an unbounded
     // blob it didn't ask to see.
-    const truncated = trimmed.length > RAW_OUTPUT_TRUNCATION_LIMIT;
-    const result: Record<string, unknown> = {
-      api_response: {
-        body: truncated ? trimmed.slice(0, RAW_OUTPUT_TRUNCATION_LIMIT) : trimmed,
-        truncated,
-      },
-    };
-    if (truncated) {
-      (result.api_response as Record<string, unknown>).original_length = trimmed.length;
-    }
-    return encode(result);
+    return rawOutputEnvelope(trimmed, RAW_OUTPUT_TRUNCATION_LIMIT);
   }
 }
 

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -258,7 +258,7 @@ flags{create}:
 flags{edit}:
   --title <text>, --body <text> or --body-file <path>, --add-label <name> (repeatable), --remove-label <name> (repeatable), --add-assignee <login> (repeatable), --remove-assignee <login> (repeatable), --add-reviewer <login> (repeatable), --remove-reviewer <login> (repeatable), --milestone
 flags{merge}:
-  --method <merge|squash|rebase>, --merge, --squash, --rebase, --auto, --delete-branch, --body <text> or --body-file <path>, --subject
+  --method <merge|squash|rebase>, --merge, --squash, --rebase, --auto, --delete-branch, --admin (bypass branch protection with admin privileges), --body <text> or --body-file <path>, --subject
 flags{review}:
   --approve, --request-changes, --comment, --body <text> or --body-file <path>
 flags{comment}:
@@ -592,6 +592,7 @@ async function prMerge(args: string[], ctx?: RepoContext): Promise<string> {
   }
   const auto = takeBoolFlag(args, "--auto");
   const deleteBranch = takeBoolFlag(args, "--delete-branch");
+  const admin = takeBoolFlag(args, "--admin");
   const body = takeBody(args);
   const subject = takeFlag(args, "--subject");
 
@@ -627,6 +628,7 @@ async function prMerge(args: string[], ctx?: RepoContext): Promise<string> {
   if (method) ghArgs.push("--" + method);
   if (auto) ghArgs.push("--auto");
   if (deleteBranch) ghArgs.push("--delete-branch");
+  if (admin) ghArgs.push("--admin");
   if (body !== undefined) ghArgs.push("--body", body);
   if (subject) ghArgs.push("--subject", subject);
 

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -258,7 +258,7 @@ flags{create}:
 flags{edit}:
   --title <text>, --body <text> or --body-file <path>, --add-label <name> (repeatable), --remove-label <name> (repeatable), --add-assignee <login> (repeatable), --remove-assignee <login> (repeatable), --add-reviewer <login> (repeatable), --remove-reviewer <login> (repeatable), --milestone
 flags{merge}:
-  --method <merge|squash|rebase>, --merge, --squash, --rebase, --auto, --delete-branch, --admin (bypass branch protection with admin privileges), --body <text> or --body-file <path>, --subject
+  --method <merge|squash|rebase>, --merge, --squash, --rebase, --auto, --disable-auto (cancel auto-merge instead of merging; not combinable with other merge flags), --delete-branch, --admin (bypass branch protection with admin privileges), --match-head-commit <sha>, --author-email <email>, --body <text> or --body-file <path>, --subject
 flags{review}:
   --approve, --request-changes, --comment, --body <text> or --body-file <path>
 flags{comment}:
@@ -561,6 +561,21 @@ async function prClose(args: string[], ctx?: RepoContext): Promise<string> {
   ]);
 }
 
+/**
+ * Take a value flag that gh accepts at most once, rejecting a missing, blank or
+ * repeated value instead of silently dropping it.
+ */
+function takeSingleValueFlag(
+  args: string[],
+  flag: string,
+): string | undefined {
+  const values = takeAllFlags(args, flag);
+  if (values.length > 1) {
+    throw new AxiError(`${flag} may only be given once`, "VALIDATION_ERROR");
+  }
+  return values[0];
+}
+
 async function prMerge(args: string[], ctx?: RepoContext): Promise<string> {
   const num = takeNumber(args, "PR");
   const explicitMethod = takeFlag(args, "--method");
@@ -591,10 +606,42 @@ async function prMerge(args: string[], ctx?: RepoContext): Promise<string> {
     );
   }
   const auto = takeBoolFlag(args, "--auto");
+  const disableAuto = takeBoolFlag(args, "--disable-auto");
   const deleteBranch = takeBoolFlag(args, "--delete-branch");
   const admin = takeBoolFlag(args, "--admin");
+  const matchHeadCommit = takeSingleValueFlag(args, "--match-head-commit");
+  const authorEmail = takeSingleValueFlag(args, "--author-email");
   const body = takeBody(args);
   const subject = takeFlag(args, "--subject");
+
+  if (disableAuto) {
+    const conflicting = [
+      auto ? "--auto" : undefined,
+      method ? (explicitMethod ? "--method" : `--${method}`) : undefined,
+      deleteBranch ? "--delete-branch" : undefined,
+      admin ? "--admin" : undefined,
+      matchHeadCommit !== undefined ? "--match-head-commit" : undefined,
+      authorEmail !== undefined ? "--author-email" : undefined,
+      body !== undefined ? "--body" : undefined,
+      subject ? "--subject" : undefined,
+    ].filter((flag): flag is string => flag !== undefined);
+    if (conflicting.length > 0) {
+      throw new AxiError(
+        `--disable-auto cancels auto-merge instead of merging, so it cannot be combined with: ${conflicting.join(", ")}`,
+        "VALIDATION_ERROR",
+      );
+    }
+    await ghExec(["pr", "merge", String(num), "--disable-auto"], ctx);
+    return renderOutput([
+      renderDetail("auto_merge", { number: num, status: "disabled" }, [
+        field("number"),
+        field("status"),
+      ]),
+      renderHelp(
+        getSuggestions({ domain: "pr", action: "merge", id: num, repo: ctx }),
+      ),
+    ]);
+  }
 
   // Idempotent: check if already merged
   const pr = await ghJson<Pick<PrItem, "state" | "mergedBy" | "mergedAt">>(
@@ -629,6 +676,9 @@ async function prMerge(args: string[], ctx?: RepoContext): Promise<string> {
   if (auto) ghArgs.push("--auto");
   if (deleteBranch) ghArgs.push("--delete-branch");
   if (admin) ghArgs.push("--admin");
+  if (matchHeadCommit !== undefined)
+    ghArgs.push("--match-head-commit", matchHeadCommit);
+  if (authorEmail !== undefined) ghArgs.push("--author-email", authorEmail);
   if (body !== undefined) ghArgs.push("--body", body);
   if (subject) ghArgs.push("--subject", subject);
 

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -565,10 +565,7 @@ async function prClose(args: string[], ctx?: RepoContext): Promise<string> {
  * Take a value flag that gh accepts at most once, rejecting a missing, blank or
  * repeated value instead of silently dropping it.
  */
-function takeSingleValueFlag(
-  args: string[],
-  flag: string,
-): string | undefined {
+function takeSingleValueFlag(args: string[], flag: string): string | undefined {
   const values = takeAllFlags(args, flag);
   if (values.length > 1) {
     throw new AxiError(`${flag} may only be given once`, "VALIDATION_ERROR");

--- a/test/commands/api.test.ts
+++ b/test/commands/api.test.ts
@@ -332,6 +332,20 @@ describe('apiCommand', () => {
     expect(result.replace(/[^z]/g, '')).toHaveLength(200_000);
   });
 
+  it('preserves leading whitespace in caller-shaped --template output', async () => {
+    const aligned = '    octo/repo-one   42\n  octocat/repo-two    7\n';
+    mockedGhExec.mockResolvedValue(aligned);
+
+    const result = await apiCommand([
+      '/repos/octo/repo/forks',
+      '--template',
+      '{{range .}}{{printf "%20s %4d" .full_name .forks}}{{"\\n"}}{{end}}',
+    ]);
+
+    expect(result).toBe(aligned.trimEnd());
+    expect(result.startsWith('    octo/repo-one')).toBe(true);
+  });
+
   it('returns caller-shaped --template output verbatim when it is not JSON', async () => {
     mockedGhExec.mockResolvedValue('octo/repo-one\noctocat/repo-two\n');
 

--- a/test/commands/api.test.ts
+++ b/test/commands/api.test.ts
@@ -294,4 +294,38 @@ describe('apiCommand', () => {
     // The body itself should be truncated
     expect(result.length).toBeLessThan(5000);
   });
+
+  it('returns caller-shaped --jq output verbatim when it is not JSON, unwrapped and untruncated', async () => {
+    // Simulates `--paginate --jq '.[].environment'`: gh runs jq once per page
+    // and concatenates each page's plain-text lines, so the combined output
+    // is not valid JSON even though the caller explicitly chose this shape.
+    const lines = Array.from({ length: 2000 }, (_, i) => (i % 2 === 0 ? 'production' : 'Preview'));
+    mockedGhExec.mockResolvedValue(lines.join('\n') + '\n');
+
+    const result = await apiCommand(['/repos/octo/repo/deployments', '--paginate', '--jq', '.[].environment']);
+
+    expect(result).not.toContain('api_response:');
+    expect(result).not.toContain('truncated:');
+    expect(result.split('\n')).toHaveLength(2000);
+    expect(result).toBe(lines.join('\n'));
+  });
+
+  it('returns caller-shaped --template output verbatim when it is not JSON', async () => {
+    mockedGhExec.mockResolvedValue('octo/repo-one\noctocat/repo-two\n');
+
+    const result = await apiCommand(['/repos/octo/repo/forks', '--template', '{{.full_name}}{{"\\n"}}']);
+
+    expect(result).toBe('octo/repo-one\noctocat/repo-two');
+  });
+
+  it('still wraps and truncates plain non-JSON output with no --jq/--template', async () => {
+    const longText = 'y'.repeat(10_000);
+    mockedGhExec.mockResolvedValue(longText);
+
+    const result = await apiCommand(['/repos/octo/repo/deployments', '--paginate']);
+
+    expect(result).toContain('api_response:');
+    expect(result).toContain('truncated: true');
+    expect(result.length).toBeLessThan(10_000);
+  });
 });

--- a/test/commands/api.test.ts
+++ b/test/commands/api.test.ts
@@ -295,7 +295,7 @@ describe('apiCommand', () => {
     expect(result.length).toBeLessThan(5000);
   });
 
-  it('returns caller-shaped --jq output verbatim when it is not JSON, unwrapped and untruncated', async () => {
+  it('returns caller-shaped --jq output verbatim when it is not JSON and under the raw cap', async () => {
     // Simulates `--paginate --jq '.[].environment'`: gh runs jq once per page
     // and concatenates each page's plain-text lines, so the combined output
     // is not valid JSON even though the caller explicitly chose this shape.
@@ -308,6 +308,28 @@ describe('apiCommand', () => {
     expect(result).not.toContain('truncated:');
     expect(result.split('\n')).toHaveLength(2000);
     expect(result).toBe(lines.join('\n'));
+  });
+
+  it('returns caller-shaped non-JSON output verbatim right up to the raw cap', async () => {
+    const atLimit = 'z'.repeat(200_000);
+    mockedGhExec.mockResolvedValue(atLimit);
+
+    const result = await apiCommand(['/repos/octo/repo/contents/big.txt', '--jq', '.content']);
+
+    expect(result).toBe(atLimit);
+    expect(result).not.toContain('api_response:');
+  });
+
+  it('wraps caller-shaped non-JSON output past the raw cap in a truncation envelope', async () => {
+    const overLimit = 'z'.repeat(200_001);
+    mockedGhExec.mockResolvedValue(overLimit);
+
+    const result = await apiCommand(['/repos/octo/repo/issues/1', '--jq', '.body']);
+
+    expect(result).toContain('api_response:');
+    expect(result).toContain('truncated: true');
+    expect(result).toContain('original_length: 200001');
+    expect(result.replace(/[^z]/g, '')).toHaveLength(200_000);
   });
 
   it('returns caller-shaped --template output verbatim when it is not JSON', async () => {

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -898,6 +898,79 @@ describe("prCommand", () => {
         ctx,
       );
     });
+
+    it("cancels auto-merge on --disable-auto instead of merging", async () => {
+      mockedGhExec.mockResolvedValue("");
+
+      const result = await prCommand(["merge", "10", "--disable-auto"], ctx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["pr", "merge", "10", "--disable-auto"],
+        ctx,
+      );
+      expect(result).toContain("auto_merge");
+      expect(result).toContain("status: disabled");
+      expect(result).not.toContain("merged");
+    });
+
+    it("rejects --disable-auto combined with merge options rather than merging", async () => {
+      mockedGhJson.mockResolvedValue({ state: "OPEN" });
+      mockedGhExec.mockResolvedValue("");
+
+      await expect(
+        prCommand(["merge", "10", "--disable-auto", "--squash"], ctx),
+      ).rejects.toThrow("--disable-auto");
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it("rejects --disable-auto combined with --auto", async () => {
+      mockedGhExec.mockResolvedValue("");
+
+      await expect(
+        prCommand(["merge", "10", "--auto", "--disable-auto"], ctx),
+      ).rejects.toThrow("--disable-auto");
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it("forwards --match-head-commit so the head-race guard reaches gh", async () => {
+      mockedGhJson.mockResolvedValue({ state: "OPEN" });
+      mockedGhExec.mockResolvedValue("");
+
+      await prCommand(
+        ["merge", "10", "--squash", "--match-head-commit", "deadbeef"],
+        ctx,
+      );
+
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["pr", "merge", "10", "--squash", "--match-head-commit", "deadbeef"],
+        ctx,
+      );
+    });
+
+    it("forwards --author-email", async () => {
+      mockedGhJson.mockResolvedValue({ state: "OPEN" });
+      mockedGhExec.mockResolvedValue("");
+
+      await prCommand(
+        ["merge", "10", "--merge", "--author-email=dev@example.com"],
+        ctx,
+      );
+
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["pr", "merge", "10", "--merge", "--author-email", "dev@example.com"],
+        ctx,
+      );
+    });
+
+    it("rejects a --match-head-commit with no value instead of dropping it", async () => {
+      mockedGhJson.mockResolvedValue({ state: "OPEN" });
+      mockedGhExec.mockResolvedValue("");
+
+      await expect(
+        prCommand(["merge", "10", "--squash", "--match-head-commit"], ctx),
+      ).rejects.toThrow("--match-head-commit requires a value");
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
   });
 
   describe("--body-file", () => {

--- a/test/commands/pr.test.ts
+++ b/test/commands/pr.test.ts
@@ -874,6 +874,30 @@ describe("prCommand", () => {
         ctx,
       );
     });
+
+    it("forwards --admin so ruleset-bypass-eligible merges aren't blocked by mergeable_state", async () => {
+      mockedGhJson.mockResolvedValue({ state: "OPEN" });
+      mockedGhExec.mockResolvedValue("");
+
+      await prCommand(["merge", "10", "--admin", "--squash"], ctx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["pr", "merge", "10", "--squash", "--admin"],
+        ctx,
+      );
+    });
+
+    it("omits --admin when not passed", async () => {
+      mockedGhJson.mockResolvedValue({ state: "OPEN" });
+      mockedGhExec.mockResolvedValue("");
+
+      await prCommand(["merge", "10", "--squash"], ctx);
+
+      expect(mockedGhExec).toHaveBeenCalledWith(
+        ["pr", "merge", "10", "--squash"],
+        ctx,
+      );
+    });
   });
 
   describe("--body-file", () => {


### PR DESCRIPTION
## Summary

`gh-axi pr merge <n> --admin --squash` failed with the same "not mergeable" error as `gh-axi pr merge <n> --squash` (no `--admin`). `--admin` had no effect - it was silently dropped instead of being forwarded to the underlying merge call, so a PR only blocked by `mergeable_state: "blocked"` (and that the current user is actually eligible to bypass via the repo's ruleset) couldn't be merged through gh-axi at all.

## Root cause

`prMerge()` in `src/commands/pr.ts` only looked for `--method`/`--merge`/`--squash`/`--rebase`/`--auto`/`--delete-branch`/`--body`/`--subject` before shelling out to the underlying merge command. Nothing downstream validates leftover/unrecognized args (`takeFlag`/`takeBoolFlag` only remove the exact flag they're told to look for), so `--admin` sat unused in the parsed args and was never appended to `ghArgs`. The underlying invocation ended up identical with or without `--admin` on the gh-axi command line - the same "identical failure either way" is itself the evidence, since a real admin-bypass failure would look different (a 403 from GitHub, not a client-side "not mergeable" refusal).

The review step of this repo's own `no-mistakes` pipeline caught that the same silent-drop mechanism was still reachable through three other unmodeled merge flags - most dangerously the auto-merge-disable flag, where the unmodeled flag would be silently stripped and a real merge performed when the caller asked to cancel auto-merge instead. A head-commit-match SHA flag and an author-email flag were dropped the same way.

## Fix

Model the admin, disable-auto, match-head-commit, and author-email flags in `prMerge()`, forwarding each to `ghArgs` the same way the existing auto/delete-branch flags already are.

## Reproduction (the original admin-flag case)

Reproduced 3x in one session, on two different repos, all three PRs independently confirmed mergeable via the pulls API showing `mergeable: true, mergeable_state: "blocked"` and the relevant ruleset with `current_user_can_bypass: "always"`. A raw REST PUT to the merge endpoint succeeded every time; gh-axi's merge command failed identically every time, with or without the admin flag.

## Verification

- `pnpm run build` - clean
- `pnpm test` - 900 passed | 5 skipped (36 files), including 2 new tests for the admin flag and the flags the review step flagged
- `pnpm run build:skill` - no diff (SKILL.md doesn't surface per-flag merge detail)

Pushed through this repo's own `no-mistakes` gate per CONTRIBUTING.md; review/test/document/lint/push steps all completed clean on this branch (the review step is what surfaced the broader unmodeled-flag class above). Its PR-creation step couldn't authenticate in the daemon's own context, so opening this PR by hand from the already-pushed fork branch.