### PR TITLE
fix(commands): honor --full for issue comments and add an api --full escape hatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ Gist visibility is fixed at creation; a secret gist is unlisted (anyone with the
 Two file-on-disk input forms are available: positional paths (`gist create a.py b.py`) or repeatable `--file` flags (`gist create --file a.py --file b.py`); mixing the two is an error.
 To create a gist from piped content, use `--filename <name>` together with a pipe (`echo "..." | gh-axi gist create --filename foo.txt --public`).
 
-`gh-axi api` accepts `--field`, `--header`, `--paginate`, `--jq <expression>`, and `--template <format>`; any other flag, an extra positional argument, or a repeated `--jq`/`--template` is rejected with a clear error instead of being silently dropped.
+`gh-axi api` accepts `--field`, `--header`, `--paginate`, `--jq <expression>`, `--template <format>`, and `--full`; any other flag, an extra positional argument, or a repeated `--jq`/`--template` is rejected with a clear error instead of being silently dropped.
 JSON responses are normally stripped of noisy fields before TOON encoding, but a response you shaped yourself with `--jq` or `--template` keeps every key and value verbatim — only over-long strings are still truncated so one field cannot flood an agent's context.
+`--full` is an explicit opt-in escape hatch: it keeps every field and every complete value, and it also returns non-JSON response bodies without the length cap. `--full` is a gh-axi flag only, and gh-axi does not send it to `gh`. Compact output stays the default without `--full`.
 
 ### Commands
 

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -8,8 +8,8 @@ export const API_HELP = `usage: gh-axi api [<method>] <path>
 description: Make an authenticated GitHub API request. Defaults to GET if no method specified.
 methods[6]:
   GET, POST, PUT, PATCH, DELETE, HEAD
-flags[5]:
-  --field <key=value> (repeatable), --header <key:value> (repeatable), --paginate, --jq <expression>, --template <format>
+flags[6]:
+  --field <key=value> (repeatable), --header <key:value> (repeatable), --paginate, --jq <expression>, --template <format>, --full (preserve complete field values and response bodies without truncation)
 examples:
   gh-axi api /repos/{owner}/{repo}
   gh-axi api POST /repos/{owner}/{repo}/issues --field title="Bug report"
@@ -24,10 +24,18 @@ const REPEATABLE_VALUE_FLAGS = new Set(['--field', '--header']);
 /** Value flags that gh accepts only one of, so a repeat is a caller mistake. */
 const SINGLE_VALUE_FLAGS = new Set(['--jq', '--template']);
 
-/** Flags that stand alone and must not consume the following argument. */
+/** Flags that stand alone and must not consume the following argument, and are forwarded to gh. */
 const BOOL_FLAGS = new Set(['--paginate']);
 
-const SUPPORTED_FLAGS = [...REPEATABLE_VALUE_FLAGS, ...SINGLE_VALUE_FLAGS, ...BOOL_FLAGS];
+/** Flags that stand alone, are gh-axi-only, and must not be forwarded to gh. */
+const LOCAL_BOOL_FLAGS = new Set(['--full']);
+
+const SUPPORTED_FLAGS = [
+  ...REPEATABLE_VALUE_FLAGS,
+  ...SINGLE_VALUE_FLAGS,
+  ...BOOL_FLAGS,
+  ...LOCAL_BOOL_FLAGS,
+];
 
 /** The flag's name without any `=value` suffix, so errors never echo a value. */
 function flagName(arg: string): string {
@@ -42,6 +50,7 @@ interface ParsedApiArgs {
   jq?: string;
   template?: string;
   paginate: boolean;
+  full: boolean;
 }
 
 /**
@@ -65,6 +74,7 @@ function parseArgs(args: string[]): ParsedApiArgs {
     fields: [],
     headers: [],
     paginate: false,
+    full: false,
   };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -77,6 +87,12 @@ function parseArgs(args: string[]): ParsedApiArgs {
       if (name !== arg)
         throw new AxiError(`${name} does not take a value`, 'VALIDATION_ERROR');
       parsed.paginate = true;
+      continue;
+    }
+    if (LOCAL_BOOL_FLAGS.has(name)) {
+      if (name !== arg)
+        throw new AxiError(`${name} does not take a value`, 'VALIDATION_ERROR');
+      parsed.full = true;
       continue;
     }
     if (!REPEATABLE_VALUE_FLAGS.has(name) && !SINGLE_VALUE_FLAGS.has(name)) {
@@ -127,7 +143,8 @@ const STRING_VALUE_TRUNCATION_LIMIT = 2000;
 export async function apiCommand(args: string[], ctx?: RepoContext): Promise<string> {
   if (args[0] === '--help' || args.length === 0) return API_HELP;
 
-  const { positionals, fields, headers, jq, template, paginate } = parseArgs(args);
+  const { positionals, fields, headers, jq, template, paginate, full } =
+    parseArgs(args);
 
   const pathRequired = new AxiError(
     'API path is required: gh-axi api [<method>] <path>',
@@ -171,15 +188,21 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
   // selected field cannot blow the caller's context with an unbounded blob.
   const callerShapedOutput = jq !== undefined || template !== undefined;
 
+  // --full is an explicit opt-in escape hatch: it keeps every field (like
+  // caller-shaped output) and additionally lifts the string-length clamp, so
+  // compact output stays the default everywhere --full is not given.
+  const stripNoisyKeys = !callerShapedOutput && !full;
+  const truncateValues = !full;
+
   // Try to parse as JSON, strip noisy fields, encode to TOON; fall back to raw output
   const raw = await ghExec(ghArgs, ctx);
   try {
     const data = JSON.parse(raw);
-    return encode(shapeOutput(data, !callerShapedOutput));
+    return encode(shapeOutput(data, stripNoisyKeys, truncateValues));
   } catch {
     // Not JSON — wrap in TOON envelope with truncation metadata
     const trimmed = raw.trim();
-    const truncated = trimmed.length > RAW_OUTPUT_TRUNCATION_LIMIT;
+    const truncated = !full && trimmed.length > RAW_OUTPUT_TRUNCATION_LIMIT;
     const result: Record<string, unknown> = {
       api_response: {
         body: truncated ? trimmed.slice(0, RAW_OUTPUT_TRUNCATION_LIMIT) : trimmed,
@@ -245,19 +268,27 @@ function clampString(value: string): string {
  * With `stripNoisyKeys` the noisy keys are dropped and long strings are cleaned
  * as well. Output the caller shaped with --jq/--template keeps both its keys and
  * its content verbatim and is only length-bounded, since rewriting a field they
- * selected by name is the same silent mutation as deleting it.
+ * selected by name is the same silent mutation as deleting it. With
+ * `truncateValues` false (--full), string values pass through untouched.
  */
-function shapeOutput(obj: unknown, stripNoisyKeys: boolean, depth = 0): unknown {
+function shapeOutput(
+  obj: unknown,
+  stripNoisyKeys: boolean,
+  truncateValues: boolean,
+  depth = 0,
+): unknown {
   if (depth > 8) return obj;
   if (Array.isArray(obj)) {
-    return obj.map((item) => shapeOutput(item, stripNoisyKeys, depth + 1));
+    return obj.map((item) =>
+      shapeOutput(item, stripNoisyKeys, truncateValues, depth + 1),
+    );
   }
   if (obj !== null && typeof obj === 'object') {
     const record = obj as Record<string, unknown>;
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(record)) {
       if (!stripNoisyKeys) {
-        result[key] = shapeOutput(value, stripNoisyKeys, depth + 1);
+        result[key] = shapeOutput(value, stripNoisyKeys, truncateValues, depth + 1);
         continue;
       }
       if (NOISY_KEYS.has(key)) continue;
@@ -272,10 +303,13 @@ function shapeOutput(obj: unknown, stripNoisyKeys: boolean, depth = 0): unknown 
         result[key] = collapseRepo(value as Record<string, unknown>);
         continue;
       }
-      result[key] = shapeOutput(value, stripNoisyKeys, depth + 1);
+      result[key] = shapeOutput(value, stripNoisyKeys, truncateValues, depth + 1);
     }
     return result;
   }
-  if (typeof obj === 'string') return stripNoisyKeys ? clampString(obj) : truncateString(obj);
+  if (typeof obj === 'string') {
+    if (!truncateValues) return obj;
+    return stripNoisyKeys ? clampString(obj) : truncateString(obj);
+  }
   return obj;
 }

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -136,20 +136,19 @@ const viewSchemaWithoutType: FieldDef[] = viewSchema.filter(
   (f) => f !== issueTypeField,
 );
 
-const viewSchemaFull: FieldDef[] = viewSchema.map((f) =>
-  "as" in f && f.as === "body"
-    ? custom("body", (item: Record<string, unknown>) =>
-        typeof item.body === "string" ? item.body : "",
-      )
-    : f,
-);
+const withFullBody = (schema: FieldDef[]): FieldDef[] =>
+  schema.map((f) =>
+    "as" in f && f.as === "body"
+      ? custom("body", (item: Record<string, unknown>) =>
+          typeof item.body === "string" ? item.body : "",
+        )
+      : f,
+  );
 
-const viewSchemaFullWithoutType: FieldDef[] = viewSchemaWithoutType.map((f) =>
-  "as" in f && f.as === "body"
-    ? custom("body", (item: Record<string, unknown>) =>
-        typeof item.body === "string" ? item.body : "",
-      )
-    : f,
+const viewSchemaFull: FieldDef[] = withFullBody(viewSchema);
+
+const viewSchemaFullWithoutType: FieldDef[] = withFullBody(
+  viewSchemaWithoutType,
 );
 
 const createResultSchema: FieldDef[] = [
@@ -178,13 +177,7 @@ const commentResultSchema: FieldDef[] = [
   ),
 ];
 
-const commentResultSchemaFull: FieldDef[] = commentResultSchema.map((f) =>
-  "as" in f && f.as === "body"
-    ? custom("body", (item: Record<string, unknown>) =>
-        typeof item.body === "string" ? item.body : "",
-      )
-    : f,
-);
+const commentResultSchemaFull: FieldDef[] = withFullBody(commentResultSchema);
 
 const lockResultSchema: FieldDef[] = [
   field("number"),

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -178,6 +178,14 @@ const commentResultSchema: FieldDef[] = [
   ),
 ];
 
+const commentResultSchemaFull: FieldDef[] = commentResultSchema.map((f) =>
+  "as" in f && f.as === "body"
+    ? custom("body", (item: Record<string, unknown>) =>
+        typeof item.body === "string" ? item.body : "",
+      )
+    : f,
+);
+
 const lockResultSchema: FieldDef[] = [
   field("number"),
   lower("state"),
@@ -358,13 +366,12 @@ async function viewIssue(args: string[], ctx?: RepoContext): Promise<string> {
   const blocks: string[] = [renderDetail("issue", augmented, schema)];
 
   if (withComments && Array.isArray(item.comments)) {
+    const commentSchema = full ? commentResultSchemaFull : commentResultSchema;
     blocks.push(
       renderList(
         "comments",
         item.comments as Record<string, unknown>[],
-        commentResultSchema.filter((d) =>
-          "key" in d ? d.key !== "number" : true,
-        ),
+        commentSchema.filter((d) => ("key" in d ? d.key !== "number" : true)),
       ),
     );
   }

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -68,7 +68,7 @@ subcommands[14]:
 flags{list}:
   --state <open|closed|all>, --label <name> (repeatable), --assignee <login>, --author <login>, --milestone <name>, --sort <created|updated|comments>, --limit <n> (default 30), --fields <a,b,c>
 flags{view}:
-  --comments, --full (show complete body without truncation)
+  --comments, --full (show the complete issue body and comment bodies without truncation)
 flags{create}:
   --title <text> (required), --body <text> or --body-file <path>, --assignee <login> (repeatable), --label <name> (repeatable), --milestone <name>, --project <name> (repeatable), --type <name>
 flags{edit}:

--- a/test/commands/api.test.ts
+++ b/test/commands/api.test.ts
@@ -294,4 +294,48 @@ describe('apiCommand', () => {
     // The body itself should be truncated
     expect(result.length).toBeLessThan(5000);
   });
+
+  it('preserves complete string values and noisy fields with --full', async () => {
+    const blob = 'a'.repeat(5000);
+    mockedGhExec.mockResolvedValue(JSON.stringify({
+      content: blob,
+      node_id: 'abc123',
+      avatar_url: 'https://avatars.example.com/u/123',
+    }));
+
+    const result = await apiCommand(['/repos/octo/repo/contents/README.md', '--full']);
+
+    expect(result).toContain(blob);
+    expect(result).not.toContain('... (truncated)');
+    // --full preserves every field, including ones the compact default strips.
+    expect(result).toContain('abc123');
+    expect(result).toContain('avatars.example.com');
+  });
+
+  it('does not forward --full to gh', async () => {
+    mockedGhExec.mockResolvedValue('{}');
+
+    await apiCommand(['/repos/octo/repo', '--full']);
+
+    const ghArgs = mockedGhExec.mock.calls[0][0];
+    expect(ghArgs).not.toContain('--full');
+  });
+
+  it('preserves the complete non-JSON body with --full', async () => {
+    const longText = 'x'.repeat(5000);
+    mockedGhExec.mockResolvedValue(longText);
+
+    const result = await apiCommand(['/some/endpoint', '--full']);
+
+    expect(result).toContain('api_response:');
+    expect(result).toContain('truncated: false');
+    expect(result).not.toContain('original_length:');
+    expect(result.length).toBeGreaterThan(5000);
+  });
+
+  it('rejects --full with a value', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '--full=true'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    });
+  });
 });

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -522,6 +522,57 @@ describe("issueCommand", () => {
       const result = await issueCommand(["view", "42"], ctx);
       expect(result).not.toMatch(/^help\[/m);
     });
+
+    it("truncates comment bodies over 800 chars by default", async () => {
+      const longBody = "a".repeat(1000);
+      mockedGhJson.mockResolvedValue({
+        number: 42,
+        title: "Bug",
+        state: "OPEN",
+        author: { login: "alice" },
+        createdAt: "2024-01-01T00:00:00Z",
+        body: "body",
+        comments: [
+          {
+            author: { login: "bob" },
+            createdAt: "2024-01-02T00:00:00Z",
+            body: longBody,
+          },
+        ],
+      });
+
+      const result = await issueCommand(["view", "42", "--comments"], ctx);
+
+      expect(result).toContain("truncated");
+      expect(result).not.toContain(longBody);
+    });
+
+    it("returns the complete comment body with --full --comments", async () => {
+      const longBody = "a".repeat(1000);
+      mockedGhJson.mockResolvedValue({
+        number: 42,
+        title: "Bug",
+        state: "OPEN",
+        author: { login: "alice" },
+        createdAt: "2024-01-01T00:00:00Z",
+        body: "body",
+        comments: [
+          {
+            author: { login: "bob" },
+            createdAt: "2024-01-02T00:00:00Z",
+            body: longBody,
+          },
+        ],
+      });
+
+      const result = await issueCommand(
+        ["view", "42", "--full", "--comments"],
+        ctx,
+      );
+
+      expect(result).toContain(longBody);
+      expect(result).not.toContain("... (truncated");
+    });
   });
 
   describe("create", () => {


### PR DESCRIPTION
## Intent

Fix GitHub issue #74 (filed by bmurgic): gh-axi truncates data even when the caller explicitly asks for the complete version. Two independent fixes, both scoped as an explicit --full opt-in escape hatch that must not change any compact-output default: (1) issue view --full --comments still truncated comment bodies at 800 chars via commentResultSchema's truncateBody call, even though --full already produced an untruncated issue body via viewSchemaFull -- added a parallel commentResultSchemaFull (full body passthrough) and select it in viewIssue when --full is set, matching the existing full/compact schema-selection pattern. (2) gh-axi api had no complete-output escape hatch: JSON responses always ran through stripNoisyKeys field-stripping and clampString/truncateString (2000-char limit), and non-JSON bodies were always capped at 4000 chars, regardless of --jq/--template. Added a new local-only boolean flag --full to gh-axi api (not forwarded to the underlying gh api child process) that disables both noisy-key stripping and value truncation, and skips the raw-body truncation envelope fields entirely. Verified against the issue's own two repro commands against the live kunchenguid/gh-axi repo. Full pnpm test suite and pnpm run build pass; ESLint clean. Note: this run reuses the already-validated commit history (review/test/document/lint all previously passed on this exact head) -- the only prior failure was the PR step targeting the wrong base repo because this worktree's git 'origin' remote pointed at my fork instead of the parent. I have since fixed that: origin now points at https://github.com/kunchenguid/gh-axi.git (the PR base) and the gate is reinitialized with --fork-url https://github.com/bmurgic/gh-axi.git (the push target), matching CONTRIBUTING.md's documented remote setup. I also closed the incorrectly-targeted bmurgic/gh-axi#1 PR that the earlier misconfigured run opened. This run should push to the fork and open one correct PR against kunchenguid/gh-axi main.

## What Changed

- `issue view --comments --full` now prints complete comment bodies. A new `commentResultSchemaFull` passes the body through, and `viewIssue` selects it when `--full` is set. Before, the comment bodies were truncated at 800 characters.
- `gh-axi api` accepts a new local-only `--full` flag. The flag disables the noisy-key stripping and the value truncation for the JSON output, and removes the 4000-character cap on the raw bodies. The flag is not forwarded to the `gh api` child process, and it rejects a value (`--full=x`).
- A `withFullBody` helper replaces the three copies of the full-body schema mapping in `issue.ts`. The README documents `api --full` and the full comment bodies. New tests cover both flags in `test/commands/api.test.ts` and `test/commands/issue.test.ts`.

## Risk Assessment

✅ Low: The only new commit is a behavior-preserving extraction of a repeated schema map into a helper, on top of an already-reviewed additive opt-in --full escape hatch that leaves all compact-output defaults unchanged.

## Testing

`I ran the full vitest suite (898 passing) and then reproduced issue #74's own two commands against the live kunchenguid/gh-axi repo with the CLI. Without --full the outputs truncate exactly as before (comment cut with a truncated marker, api body clamped at 2000 chars, raw README capped at 4000 chars with truncated:true/original_length); with --full the same commands return the complete 6781-char comment, the complete 3104-char issue body with previously stripped keys, and the full 15 KB README. I also confirmed --full is local-only and rejects a value. The one cosmetic deviation from the intent text is that the raw envelope still emits truncated:false under --full (only original_length is omitted), which is accurate rather than a defect. Note pnpm test fails on the default Node v20 because pnpm 11 requires Node >=22; I ran the tests under Node v22.23.1.`

<details>
<summary>Evidence: issue view --full --comments: compact vs full comment bodies (live repo)</summary>

```text
$ gh-axi issue view 85 --comments -R kunchenguid/gh-axi   (compact default, unchanged)
  type: none
  body: "## Problem\n\n`gh-axi` has no `gist` command. `gh gist` is a CORE command in `gh`, and\n`VISION.md` states the goal as *\"full functional parity with `gh`\"* — every\ncapability reachable through `gh` should eventually be reachable through an\nAXI-native interface.\n\nToday an agent that needs a gist has two bad options:\n\n1. `gh-axi api /gists` — works for reads, but the agent must hand-assemble the\n   `files{}` JSON payload for any mutation, which is exactly the friction #62\n   already documents for nes\n... (truncated, 8967 chars total - use --full to see complete body)"
comments[1]{author,created,body}:
  bauti-defi,18d ago,"## Design resolved — correcting two recommendations above, and closing all three open questions\n\nI did a deeper pass against the AXI principles and the existing command families\nbefore starting implementation. Two things I recommended in the issue body are\nwrong, and all three open questions now have answers. Writing it up here so the\nissue reflects what I'd actually build.\n\n### Correction 1 — the truncation guidance in the body is wrong\n\nI suggested `gist view` reuse the `run view --log` convention: keep the last\n20,000 chars, spill the rest to a temp file, expose it as `full_log`. That is the\nwrong existing convention to copy.\n\nAXI Principle 3 specifies the opposite shape:\n\n[quoted text removed]\n\n`run.ts` keeps the **tail** because CI failures land at the end of a log. Gist\nfiles are doc\n... (truncated, 6526 chars total - use --full to see complete body)"

$ gh-axi issue view 85 --comments --full -R kunchenguid/gh-axi   (NEW: comment bodies complete)
  type: none
  body: "## Problem\n\n`gh-axi` has no `gist` command. `gh gist` is a CORE command in `gh`, and\n`VISION.md` states the goal as *\"full functional parity with `gh`\"* — every\ncapability reachable through `gh` should eventually be reachable through an\nAXI-native interface.\n\nToday an agent that needs a gist has two bad options:\n\n1. `gh-axi api /gists` — works for reads, but the agent must hand-assemble the\n   `files{}` JSON payload for any mutation, which is exactly the friction #62\n   already documents for nested request bodies.\n2. Drop out of `gh-axi` entirely and shell `gh gist` — raw table output, no TOON,\n   no `help:` suggestions, no structured errors. The agent loses every ergonomic\n   property the wrapper exists to provide, mid-task.\n\nGists are a natural agent primitive: dumping a long log, sharing a repro, or\nstashing generated output somewhere linkable without polluting a repo.\n\n## What parity means here\n\nTwo independent axes. Surface parity alone is not enough to call this\nfirst-class — the existing command families all clear a second bar.\n\n### Axis 1 — surface parity with `gh gist` (7 subcommands)\n\nFull flag surface as of `gh` v2.86.0, and the proposed mapping:\n\n| `gh` | flags | proposed `gh-axi` | notes |\n| --- | --- | --- | --- |\n| `gist list` | `--filter <re>`, `--include-content`, `-L/--limit` (default 10), `--public`, `--secret` | `gist list` | `--limit` default should follow house convention (`label list` uses 500), not gh's 10 |\n| `gist view <id\\|url>` | `-f/--filename`, `--files`, `-r/--raw`, `-w/--web` | `gist view <id\\|url>` | `--web` is agent-hostile; reject it rather than accept-and-ignore |\n| `gist create [<file>...\\|-]` | `-d/--desc`, `-f/--filename`, `-p/--public`, `-w/--web` | `gist create` | stdin (`-`) is the primary agent path; see \"secret content\" below |\n| `gist edit <id\\|url> [<file>\\|-]` | `-a/--add`, `-d/--desc`, `-f/--filename`, `-r/--remove` | `gist edit <id\\|url>` | positional `-` is the ONLY non-interactive content path; see below |\n| `gist delete <id\\|url>` | `--yes` | `gist delete <id\\|url>` | must always pass `--yes` |\n| `gist rename <id\\|url> <old> <new>` | — | `gist rename` | no flags |\n| `gist clone <gist> [<dir>] [-- <gitflags>]` | — | `gist clone` | shells out to `git`; scope call needed (see Open questions) |\n\n### Axis 2 — the AXI conventions every existing family already meets\n\nDerived from `label.ts` (the canonical minimal family) plus `project.ts`:\n\n- [ ] `GIST_HELP` constant with `usage:` / `subcommands[N]:` / `flags{sub}:` /\n      `examples:` — `test/help-examples.test.ts` enforces ≥2 examples, each\n      indented exactly 2 spaces and starting with `gh-axi`\n- [ ] Registered in `src/cli.ts`: `COMMANDS`, `COMMAND_HELP`, and the\n      `commands[14]:` line in `TOP_HELP` (bump to 15)\n- [ ] TOON output via `renderOutput` / `renderList` / `field` with a declared\n      `FieldDef[]` schema\n- [ ] `formatCountLine` on list output\n- [ ] Contextual `help:` next steps registered in `src/suggestions.ts`\n      (`domain: 'gist'`)\n- [ ] Structured errors via `AxiError` / `mapGhError` — `VALIDATION_ERROR` for\n      bad input, never a silent drop (cf. #55/#57/#75/#77/#80)\n- [ ] Idempotent mutations that report what changed (`{ delete: 'ok', ... }`)\n- [ ] Unknown subcommand → `renderError` listing valid subcommands\n- [ ] `test/commands/gist.test.ts` matching the depth of the sibling suites\n- [ ] Skill + docs: `SKILL_DESCRIPTION` / \"When to use\" / Tips in `src/skill.ts`,\n      regenerated via `pnpm run build:skill`; README command table + usage block\n\n## Design notes (verified against `gh` v2.86.0 source)\n\n**No `gh gist` subcommand supports `--json`.** `gh gist list --json id` and\n`gh gist view --json id` both fail with `unknown flag: --json`. This breaks the\n`ghJson(['<cmd>', '--json', fields])` pattern every other family relies on.\n`gist list` emits bare TSV (`id \\t description \\t \"N files\" \\t secret \\t updated_at`)\nwith no owner and no URL — parsing it is brittle and gh offers no stability\ncontract for it.\n\nSuggested split, which keeps `gh` as the only backend (VISION-compliant) and\nfollows the existing `api.ts` / `project.ts` precedent:\n\n- **Reads** (`list`, `view`) → `gh api /gists` and `gh api /gists/<id>` via\n  `ghJson`. Full structured payload: `id`, `description`, `public`, `files{}`,\n  `html_url`, `created_at`, `updated_at`, `comments`, `owner`. Note this means\n  gh's `--filter` / `--include-content` regex matching must be reimplemented\n  client-side to keep the flag.\n- **Mutations** (`create`, `edit`, `delete`, `rename`) → `gh gist ...` via\n  `ghExec` / `ghExecWithStdin`, since the API equivalents require hand-built\n  `files{}` payloads.\n\n**Gist is user-scoped, not repo-scoped.** `gh gist` has no `--repo` flag at all.\n`gh.ts#buildArgs` auto-appends `--repo <nwo>` whenever `ctx.source !== 'git'`, so\nthreading `RepoContext` into `ghJson`/`ghExec` makes every `gist` call fail the\nmoment someone passes `-R`. Follow the `project.ts` / `search.ts` rule: never\npass `ctx` as the second argument. (Inside a git repo with no `-R` it would\nappear to work, which makes this a latent bug rather than an obvious one.)\n\n**`gist create` prints only the HTML URL on stdout**; all status messages go to\nstderr. The gist ID must be recovered from the URL's last path segment — same\nshape as the existing `gh pr create` output parsing noted in `AGENTS.md`.\n\n**Interactivity gates that must be pre-empted, not discovered at runtime:**\n\n- `gist edit` opens `$EDITOR` unless the positional source file is given. `-` is\n  the stdin path (`edit <id> - --filename foo.md`). Without it: hangs or errors.\n- `gist edit` with no `--filename` on a multi-file gist → prompts\n  (`\"unsure what file to edit; either specify --filename or run interactively\"`).\n- `gist delete` without `--yes` → `--yes required when not running interactively`.\n- `gist view` / `gist delete` with no ID → prompts to pick from recent gists.\n- `gist create` with no files and a TTY stdin → `no filenames passed and nothing on STDIN`.\n\nAXI commands must never hang on interactive input (the `resolveValue` rule in\n`src/secretValue.ts`), so each of these should be a `VALIDATION_ERROR` with an\nactionable message before `gh` is ever invoked.\n\n**Unbounded content.** A single gist file can be mega

... [1601 bytes truncated] ...

d `view` output is truncated with a recoverable full-content path\n- [ ] `--web` and other agent-hostile flags are rejected with `VALIDATION_ERROR`,\n      not silently ignored\n- [ ] Every subcommand emits contextual `help:` suggestions\n- [ ] `test/commands/gist.test.ts` covers each subcommand plus the interactivity\n      and `-R` guards\n- [ ] `TOP_HELP` count bumped, README table updated, `pnpm run build:skill` run\n\n## Open questions\n\n1. **`gist clone` in scope?** It is the one subcommand that shells to `git` and\n   writes the local filesystem, closer to `repo clone` than to the rest. Happy to\n   split it into a follow-up if it complicates the first pass.\n2. **Keep `--filter` / `--include-content`?** They are pure client-side regex\n   convenience in gh. Reimplementing them on the API path is easy but is net-new\n   code rather than a passthrough; dropping them is also defensible since agents\n   can grep TOON output directly.\n3. **`list` default limit** — match gh's 10, or the house `label list` default of 500?\n\nHappy to implement this through `no-mistakes` if the direction and the open\nquestions above land the way you'd want.\n"
comments[1]{author,created,body}:
  bauti-defi,18d ago,"## Design resolved — correcting two recommendations above, and closing all three open questions\n\nI did a deeper pass against the AXI principles and the existing command families\nbefore starting implementation. Two things I recommended in the issue body are\nwrong, and all three open questions now have answers. Writing it up here so the\nissue reflects what I'd actually build.\n\n### Correction 1 — the truncation guidance in the body is wrong\n\nI suggested `gist view` reuse the `run view --log` convention: keep the last\n20,000 chars, spill the rest to a temp file, expose it as `full_log`. That is the\nwrong existing convention to copy.\n\nAXI Principle 3 specifies the opposite shape:\n\n> Never omit large fields entirely — include a truncated preview\n> Show the total size so the agent knows how much it's missing\n> Suggest the escape hatch (`--full`) only when content is actually truncated\n> Choose a truncation limit that covers most use cases (500-1500 chars)\n\n`run.ts` keeps the **tail** because CI failures land at the end of a log. Gist\nfiles are documents and source — the **head** is what identifies them. And 20,000\nchars is an order of magnitude outside the range P3 gives.\n\nSo: head-slice at ~1500 chars per file (top of P3's range, since content skews\ntoward code), per-file `size` so the agent knows what it's missing, and the\n`--full` hint emitted only when something was actually cut.\n\n### Correction 2 — `truncateBody` must NOT be reused for gist content\n\nRelated, and a live hazard for whoever implements this. `body.ts#truncateBody`\nruns `cleanBody` on the truncation path, which:\n\n- collapses any run of 3+ lines starting with `>` into `[quoted text removed]`\n- strips URLs over 80/100 chars\n- rewrites `![alt](url)` → `[image: alt]`\n\nThat is correct for issue and PR prose. Applied to gist content it **corrupts\ncode**: a diff's context lines start with `>`, as do shell redirects and quoted\nstrings inside source. The agent gets mangled content with no signal it happened.\n\nGist content needs a separate `truncateContent()` — raw head slice, no cleanups,\nsame `... (truncated, N chars total - use --full)` footer for consistency.\n\n(Tangentially relevant to #74, which asks for `--full` to cover more surfaces —\nwhatever shape that takes should probably cover gist content too.)\n\n### Open question 1 — is `clone` in scope? **Yes.**\n\n`repo.ts#cloneRepo` (L139-150) already sets the house precedent, and it is 11\nlines: take the positional, `ghExec(['repo','clone', repo])`, return\n`{clone:'ok', repo}`. It deliberately supports neither the target-directory\npositional nor `-- <gitflags>`, even though `gh repo clone` offers both.\n\n`gist clone` should mirror that exactly — selector only. At that size there is no\nreason to defer it.\n\n### Open question 2 — keep `--filter` / `--include-content`? **No, drop both.**\n\nThey are pure client-side regex convenience in gh. The agent already holds the\noutput and can grep it, so reimplementing filtering on our side of the agent buys\nnothing. `--include-content` is additionally at odds with P2 (\"long-form content\nbelongs in detail views, not lists\") — it exists to stuff file content into a\nlist view.\n\n### Open question 3 — `list` default limit? **100, not gh's 10.**\n\nP2: \"Default limits: high enough to cover common cases in one call (if most repos\nhave <100 labels, default to 100, not 30).\" 100 is also the gists API `per_page`\nmax, so it is one call.\n\n### Decisions not covered in the body\n\n**Backend split — same as the body, but for a better reason.** I framed it as\n\"reads are lossy in gh.\" The stronger reason is the write path: `gh gist create`\nand `gh gist edit` both reject binary content via full MIME detection\n(`shared.IsBinaryContents` / `IsBinaryFile`, walking the MIME parent chain to\n`text/plain`) plus blank-file rejection. Going all-API silently drops that, and\nthe failure mode is bad — the agent pipes a binary blob in, the API accepts it,\nthe gist is corrupt, no error. So: **writes through `gh gist` because that is\nwhere the non-obvious validation lives; reads through `gh api` because there only\nthe output format fails, not the logic.**\n\nThe interactivity gates listed in the body are not an argument against this — we\ncontrol the argv we build, so we always pass `--yes`, always pass the `-`\npositional, always pass `--filename`. They are pre-flight guards, not blockers.\n\n**`create` requires explicit `--public` or `--secret`.** `gh` defaults to secret,\nbut a secret gist is *unlisted, not private* — anyone with the URL reads it. An\nagent that equates the two can leak, and a wrongly-public gist cannot be\nun-leaked. VISION explicitly permits this reshape (\"may reshape, combine, or\nsimplify `gh` operations when doing so improves agent ergonomics without\nexpanding the underlying capability\") — both visibilities stay reachable, so no\ncapability is lost. `create` only; `gh gist edit` has no visibility flag and\nshould not grow one.\n\n**`create` accepts positional paths or repeatable `--file`; mixing them is a\n`VALIDATION_ERROR`.** Positionals pass straight to gh so it does the globbing and\nbinary sniffing on real paths; `--file` matches the repeatable-flag house style.\nFailing loud on mixed forms avoids defining and testing a merge order, per P6.\n\n**`--web` is rejected**, not accepted-and-ignored (P6). Opening a browser from an\nagent context is a silent no-op at best.\n\n**`gistIdFromSelector()` is the one piece of gh logic we reimplement.** Writes get\nselector parsing free (gh parses ID-or-URL itself), but API-backed reads need the\nbare ID. It must resolve through `host.ts#resolveHost()` rather than assuming\n`gist.github.com`, or GHE selectors break.\n\n**Gists stay out of the dashboard.** `home.ts` is repo-scoped; gists are\nuser-scoped, so they would be contextually wrong and would add a network call to\nevery bare `gh-axi` invocation.\n\n**`RepoContext` must never be threaded into `ghJson`/`ghExec` here** — already in\nthe body, restating because it is the one mistake that passes local testing.\nInside a git repo with no `-R`, `buildArgs` appends nothing and everything looks\nfine; the moment anyone passes `-R`, every gist call breaks.\n\n### Implementation plan\n\nFour vertical slices, each shipping useful on its own:\n\n1. **`list` + `view`** — carries the scaffolding: `cli.ts` registration,\n   `TOP_HELP` bump, TOON schemas, `truncateContent()`, `gistIdFromSelector()`,\n   `suggestions.ts` domain, tests, skill + README regen\n2. **`create`** — dual input forms, explicit visibility, stdin\n3. **`edit` + `rename`** — add/remove/replace/desc\n4. **`delete` + `clone`**\n\n@kunchenguid — happy to implement all four through `no-mistakes` per\nCONTRIBUTING, starting with slice 1. Flag anything above you'd want shaped\ndifferently and I'll adjust before opening the first PR.\n"
```
</details>
<details>
<summary>Evidence: gh-axi api --full: JSON clamping, key stripping, and raw-body cap disabled</summary>

<code>--- default: body line length: 2070 ... (truncated)&#10;--- --full: body line length: 3187 ... contribution workflow.\n&#34;&#10;README raw default: truncated: true / original_length: 14780 / total output bytes: 4161&#10;README raw --full: truncated: false / total output bytes: 15113&#10;--full=x -&gt; error: &#34;--full does not take a value&#34; (VALIDATION_ERROR)</code>

```text
=== gh-axi api /repos/kunchenguid/gh-axi/issues/74 (issue #74 repro; real body is 3104 chars) ===

--- default (unchanged): body clamped at 2000 chars, noisy keys stripped ---
body line length: 2070
aw-response limit to non-JSON output.\nI did not find a local `--full` output flag in that pa... (truncated)"

--- --full: complete body, node_id/url no longer stripped ---
body line length: 3187
ntent?\nIf so, I would be happy to submit the tested patch through the repository's contribution workflow.\n"
14:  node_id: MDQ6VXNlcjQ3MjcwMjM5
17:  url: "https://api.github.com/users/bmurgic"

=== non-JSON body: README raw (real size ~15 KB) ===
--- default: 4000-char cap ---
  truncated: true
  original_length: 14780
total output bytes:     4161
--- --full: no cap ---
  truncated: false
total output bytes:    15113

=== --full is gh-axi-local and rejects a value ===
error: "--full does not take a value"
code: VALIDATION_ERROR

=== help ===
  GET, POST, PUT, PATCH, DELETE, HEAD
flags[6]:
  --field <key=value> (repeatable), --header <key:value> (repeatable), --paginate, --jq <expression>, --template <format>, --full (preserve complete field values and response bodies without truncation)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ℹ️ `src/commands/api.ts:207` - The intent states --full &#34;skips the raw-body truncation envelope fields entirely&#34;, but the non-JSON path still emits `truncated: false` inside the api_response envelope (src/commands/api.ts:207-210). Only `original_length` is skipped. The behavior is harmless and matches the pre-existing short-body output, but it does not match the wording of the criterion.
- ℹ️ `src/commands/issue.ts:181` - The same `schema.map(f =&gt; &#34;as&#34; in f &amp;&amp; f.as === &#34;body&#34; ? custom(&#34;body&#34;, ...) : f)` block now appears three times (viewSchemaFull, viewSchemaFullWithoutType, commentResultSchemaFull). A single `withFullBody(schema: FieldDef[])` helper would remove the repetition without changing behavior.

🔧 Fix: extract withFullBody helper for full-body schemas
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx vitest run` (full suite, Node v22.23.1) - 898 passed, 5 skipped, 1 file skipped</code>
- <code>`npx tsx bin/gh-axi.ts issue view 85 --comments -R kunchenguid/gh-axi` (compact baseline: comment truncated at 800 chars)</code>
- <code>`npx tsx bin/gh-axi.ts issue view 85 --comments --full -R kunchenguid/gh-axi` (6781-char comment printed complete)</code>
- <code>`npx tsx bin/gh-axi.ts api /repos/kunchenguid/gh-axi/issues/74` vs `... --full` (2000-char clamp + key stripping vs complete 3104-char body with node_id/url retained)</code>
- <code>`npx tsx bin/gh-axi.ts api /repos/kunchenguid/gh-axi/readme --header &#34;Accept: application/vnd.github.raw&#34;` vs `... --full` (4161 bytes with truncated:true/original_length vs 15113 bytes uncapped)</code>
- <code>`npx tsx bin/gh-axi.ts api /repos/kunchenguid/gh-axi/issues/74 --full=x` (VALIDATION_ERROR: --full does not take a value)</code>
- <code>`npx tsx bin/gh-axi.ts api --help` (flags[6] now documents --full)</code>
- <code>`git status --porcelain` (worktree clean, no transient artifacts)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
