### PR TITLE
fix(commands): reject unknown flags across all commands

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -133,3 +133,37 @@ export function takeNumber(args: string[], label: string): number {
   args.splice(args.indexOf(raw), 1);
   return Number(raw);
 }
+
+/**
+ * Reject flags in `args` that are not listed in `known`, after the subcommand
+ * has parsed the flags it recognizes. Positionals and `--help`/`-h` always
+ * pass; `--` ends flag scanning. Value forms (`--flag=v`) are matched by flag
+ * name only. Throws VALIDATION_ERROR listing every offending flag plus a
+ * one-turn self-correction hint (usage + `--help`), per AXI principle 6:
+ * never silently drop an unknown flag.
+ */
+export function rejectUnknownFlags(
+  args: string[],
+  known: readonly string[],
+  command: string,
+  sub: string,
+): void {
+  const knownSet = new Set(known);
+  const unknown: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const tok = args[i];
+    if (tok === "--") break;
+    if (!tok.startsWith("-")) continue;
+    const name = tok.split("=", 1)[0];
+    if (name === "--help" || name === "-h") continue;
+    if (knownSet.has(name)) continue;
+    if (!unknown.includes(name)) unknown.push(name);
+  }
+  if (unknown.length === 0) return;
+  const list = unknown.join(", ");
+  throw new AxiError(
+    `unknown flag${unknown.length > 1 ? "s" : ""} for gh-axi ${command} ${sub}: ${list}`,
+    "VALIDATION_ERROR",
+    [`gh-axi ${command} ${sub} [flags]`, `gh-axi ${command} ${sub} --help`],
+  );
+}

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -12,6 +12,7 @@ import {
   requireNumber,
   takeFlag,
   takeBoolFlag,
+  rejectUnknownFlags,
 } from "../args.js";
 import { takeBody, truncateBody } from "../body.js";
 import { parseFields, type ExtraFieldSpec } from "../fields.js";
@@ -98,6 +99,60 @@ examples:
   gh-axi issue subissue add 16 20 101 125
   gh-axi issue subissue remove 16 101
   gh-axi issue subissue list 16`;
+
+// ---------------------------------------------------------------------------
+// Per-subcommand known flags (for rejectUnknownFlags)
+// ---------------------------------------------------------------------------
+
+// --search is intentionally listed: listIssues/prList reject it with a
+// dedicated hint pointing at `gh-axi search`, so rejectUnknownFlags lets it
+// through to that handler instead of shadowing the targeted error.
+const ISSUE_FLAGS: Record<string, readonly string[]> = {
+  list: [
+    "--fields",
+    "--state",
+    "--label",
+    "--assignee",
+    "--author",
+    "--milestone",
+    "--sort",
+    "--limit",
+    "--search",
+  ],
+  view: ["--comments", "--full"],
+  create: [
+    "--title",
+    "--body",
+    "--body-file",
+    "--assignee",
+    "--label",
+    "--milestone",
+    "--project",
+    "--type",
+  ],
+  edit: [
+    "--title",
+    "--body",
+    "--body-file",
+    "--add-label",
+    "--remove-label",
+    "--add-assignee",
+    "--remove-assignee",
+    "--milestone",
+    "--no-type",
+    "--type",
+  ],
+  close: ["--reason", "--comment"],
+  reopen: [],
+  comment: ["--body", "--body-file"],
+  delete: [],
+  lock: [],
+  unlock: [],
+  pin: [],
+  unpin: [],
+  transfer: ["--to-repo"],
+  subissue: [],
+};
 
 // ---------------------------------------------------------------------------
 // Field schemas
@@ -1287,6 +1342,12 @@ export async function issueCommand(
   const sub = args[0];
 
   if (sub === "subissue") {
+    rejectUnknownFlags(
+      args.slice(1),
+      ISSUE_FLAGS.subissue,
+      "issue",
+      "subissue",
+    );
     return subissueCommand(args, ctx);
   }
 
@@ -1299,30 +1360,53 @@ export async function issueCommand(
 
   switch (sub) {
     case "list":
+      rejectUnknownFlags(args.slice(1), ISSUE_FLAGS.list, "issue", "list");
       return listIssues(args, ctx);
     case "view":
+      rejectUnknownFlags(args.slice(1), ISSUE_FLAGS.view, "issue", "view");
       return viewIssue(args, ctx);
     case "create":
+      rejectUnknownFlags(args.slice(1), ISSUE_FLAGS.create, "issue", "create");
       return createIssue(args, ctx);
     case "edit":
+      rejectUnknownFlags(args.slice(1), ISSUE_FLAGS.edit, "issue", "edit");
       return editIssue(args, ctx);
     case "close":
+      rejectUnknownFlags(args.slice(1), ISSUE_FLAGS.close, "issue", "close");
       return closeIssue(args, ctx);
     case "reopen":
+      rejectUnknownFlags(args.slice(1), ISSUE_FLAGS.reopen, "issue", "reopen");
       return reopenIssue(args, ctx);
     case "comment":
+      rejectUnknownFlags(
+        args.slice(1),
+        ISSUE_FLAGS.comment,
+        "issue",
+        "comment",
+      );
       return commentOnIssue(args, ctx);
     case "delete":
+      rejectUnknownFlags(args.slice(1), ISSUE_FLAGS.delete, "issue", "delete");
       return deleteIssue(args, ctx);
     case "lock":
+      rejectUnknownFlags(args.slice(1), ISSUE_FLAGS.lock, "issue", "lock");
       return lockIssue(args, ctx);
     case "unlock":
+      rejectUnknownFlags(args.slice(1), ISSUE_FLAGS.unlock, "issue", "unlock");
       return unlockIssue(args, ctx);
     case "pin":
+      rejectUnknownFlags(args.slice(1), ISSUE_FLAGS.pin, "issue", "pin");
       return pinIssue(args, ctx);
     case "unpin":
+      rejectUnknownFlags(args.slice(1), ISSUE_FLAGS.unpin, "issue", "unpin");
       return unpinIssue(args, ctx);
     case "transfer":
+      rejectUnknownFlags(
+        args.slice(1),
+        ISSUE_FLAGS.transfer,
+        "issue",
+        "transfer",
+      );
       return transferIssue(args, ctx);
     default:
       return renderError(

--- a/src/commands/label.ts
+++ b/src/commands/label.ts
@@ -2,7 +2,7 @@ import { encode } from '@toon-format/toon';
 import type { RepoContext } from '../context.js';
 import { ghJson, ghExec } from '../gh.js';
 import { AxiError } from '../errors.js';
-import { getFlag } from '../args.js';
+import { getFlag, rejectUnknownFlags } from '../args.js';
 import {
   field,
   renderList,
@@ -13,6 +13,13 @@ import {
 } from '../toon.js';
 import { formatCountLine } from '../format.js';
 import { getSuggestions } from '../suggestions.js';
+
+const LABEL_FLAGS: Record<string, readonly string[]> = {
+  list: ['--limit'],
+  create: ['--name', '--color', '--description'],
+  edit: ['--name', '--color', '--description'],
+  delete: [],
+};
 
 export const LABEL_HELP = `usage: gh-axi label <subcommand> [flags]
 subcommands[4]:
@@ -129,12 +136,16 @@ export async function labelCommand(args: string[], ctx?: RepoContext): Promise<s
 
   switch (sub) {
     case 'list':
+      rejectUnknownFlags(args.slice(1), LABEL_FLAGS.list, 'label', 'list');
       return listLabels(args, ctx);
     case 'create':
+      rejectUnknownFlags(args.slice(1), LABEL_FLAGS.create, 'label', 'create');
       return createLabel(args, ctx);
     case 'edit':
+      rejectUnknownFlags(args.slice(1), LABEL_FLAGS.edit, 'label', 'edit');
       return editLabel(args, ctx);
     case 'delete':
+      rejectUnknownFlags(args.slice(1), LABEL_FLAGS.delete, 'label', 'delete');
       return deleteLabel(args, ctx);
     default:
       return renderError(`Unknown subcommand: ${sub}`, 'VALIDATION_ERROR', [

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -12,6 +12,7 @@ import {
   takeNumber,
   takeAllFlags,
   pushRepeated,
+  rejectUnknownFlags,
 } from "../args.js";
 import { parseFields, type ExtraFieldSpec } from "../fields.js";
 import {
@@ -245,6 +246,78 @@ const VIEW_JSON_FIELDS =
 // ---------------------------------------------------------------------------
 // Help
 // ---------------------------------------------------------------------------
+
+// --search is intentionally listed: prList rejects it with a dedicated hint
+// pointing at `gh-axi search`, so rejectUnknownFlags lets it through to that
+// handler instead of shadowing the targeted error.
+const PR_FLAGS: Record<string, readonly string[]> = {
+  list: [
+    "--fields",
+    "--state",
+    "--label",
+    "--assignee",
+    "--author",
+    "--base",
+    "--head",
+    "--draft",
+    "--limit",
+    "--search",
+  ],
+  view: ["--comments", "--reviews", "--full"],
+  create: [
+    "--title",
+    "--body",
+    "--body-file",
+    "--base",
+    "--head",
+    "--draft",
+    "--assignee",
+    "--reviewer",
+    "--label",
+    "--milestone",
+    "--project",
+  ],
+  edit: [
+    "--title",
+    "--body",
+    "--body-file",
+    "--add-label",
+    "--remove-label",
+    "--add-assignee",
+    "--remove-assignee",
+    "--add-reviewer",
+    "--remove-reviewer",
+    "--milestone",
+    "--base",
+  ],
+  close: ["--comment"],
+  merge: [
+    "--method",
+    "--merge",
+    "--squash",
+    "--rebase",
+    "--auto",
+    "--delete-branch",
+    "--body",
+    "--body-file",
+    "--subject",
+  ],
+  review: [
+    "--approve",
+    "--request-changes",
+    "--comment",
+    "--body",
+    "--body-file",
+  ],
+  checks: [],
+  diff: ["--full"],
+  checkout: [],
+  ready: [],
+  reopen: [],
+  comment: ["--body", "--body-file"],
+  "update-branch": [],
+  revert: [],
+};
 
 export const PR_HELP = `usage: gh-axi pr <subcommand> [flags]
 subcommands[15]:
@@ -966,34 +1039,54 @@ export async function prCommand(
 
   switch (sub) {
     case "list":
+      rejectUnknownFlags(rest, PR_FLAGS.list, "pr", "list");
       return prList(rest, ctx);
     case "view":
+      rejectUnknownFlags(rest, PR_FLAGS.view, "pr", "view");
       return prView(rest, ctx);
     case "create":
+      rejectUnknownFlags(rest, PR_FLAGS.create, "pr", "create");
       return prCreate(rest, ctx);
     case "edit":
+      rejectUnknownFlags(rest, PR_FLAGS.edit, "pr", "edit");
       return prEdit(rest, ctx);
     case "close":
+      rejectUnknownFlags(rest, PR_FLAGS.close, "pr", "close");
       return prClose(rest, ctx);
     case "merge":
+      rejectUnknownFlags(rest, PR_FLAGS.merge, "pr", "merge");
       return prMerge(rest, ctx);
     case "review":
+      rejectUnknownFlags(rest, PR_FLAGS.review, "pr", "review");
       return prReview(rest, ctx);
     case "checks":
+      rejectUnknownFlags(rest, PR_FLAGS.checks, "pr", "checks");
       return prChecks(rest, ctx);
     case "diff":
+      rejectUnknownFlags(rest, PR_FLAGS.diff, "pr", "diff");
       return prDiff(rest, ctx);
     case "checkout":
+      rejectUnknownFlags(rest, PR_FLAGS.checkout, "pr", "checkout");
       return prCheckout(rest, ctx);
     case "ready":
+      rejectUnknownFlags(rest, PR_FLAGS.ready, "pr", "ready");
       return prReady(rest, ctx);
     case "reopen":
+      rejectUnknownFlags(rest, PR_FLAGS.reopen, "pr", "reopen");
       return prReopen(rest, ctx);
     case "comment":
+      rejectUnknownFlags(rest, PR_FLAGS.comment, "pr", "comment");
       return prComment(rest, ctx);
     case "update-branch":
+      rejectUnknownFlags(
+        rest,
+        PR_FLAGS["update-branch"],
+        "pr",
+        "update-branch",
+      );
       return prUpdateBranch(rest, ctx);
     case "revert":
+      rejectUnknownFlags(rest, PR_FLAGS.revert, "pr", "revert");
       return prRevert(rest, ctx);
     case "--help":
     case "-h":

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -5,7 +5,7 @@ import { AxiError } from "../errors.js";
 import { takeBody, truncateBody } from "../body.js";
 import { formatCountLine } from "../format.js";
 import { getSuggestions } from "../suggestions.js";
-import { takeFlag, takeBoolFlag } from "../args.js";
+import { takeFlag, takeBoolFlag, rejectUnknownFlags } from "../args.js";
 import {
   field,
   pluck,
@@ -55,6 +55,26 @@ interface ProjectFieldListResult {
 // ---------------------------------------------------------------------------
 // Help
 // ---------------------------------------------------------------------------
+
+const PROJECT_FLAGS: Record<string, readonly string[]> = {
+  list: ["--owner", "--closed", "--limit"],
+  view: ["--owner"],
+  "item-list": ["--owner", "--query", "--limit"],
+  "field-list": ["--owner", "--limit"],
+  "item-add": ["--owner", "--url"],
+  "item-create": ["--owner", "--title", "--body", "--body-file"],
+  "item-edit": [
+    "--id", "--project-id", "--field-id", "--text", "--number", "--date",
+    "--single-select-option-id", "--iteration-id", "--title", "--body",
+    "--body-file", "--clear",
+  ],
+  "item-archive": ["--owner", "--id", "--undo"],
+  "item-delete": ["--owner", "--id"],
+  create: ["--owner", "--title"],
+  edit: ["--owner", "--title", "--description", "--readme", "--visibility"],
+  close: ["--owner", "--undo"],
+  copy: ["--source-owner", "--target-owner", "--title", "--drafts"],
+};
 
 export const PROJECT_HELP = `usage: gh-axi project <subcommand> [flags]
 subcommands[13]:
@@ -841,30 +861,43 @@ export async function projectCommand(
 
   switch (sub) {
     case "list":
+      rejectUnknownFlags(rest, PROJECT_FLAGS.list, "project", "list");
       return projectList(rest, ctx);
     case "view":
+      rejectUnknownFlags(rest, PROJECT_FLAGS.view, "project", "view");
       return projectView(rest, ctx);
     case "item-list":
+      rejectUnknownFlags(rest, PROJECT_FLAGS["item-list"], "project", "item-list");
       return projectItemList(rest, ctx);
     case "field-list":
+      rejectUnknownFlags(rest, PROJECT_FLAGS["field-list"], "project", "field-list");
       return projectFieldList(rest, ctx);
     case "item-add":
+      rejectUnknownFlags(rest, PROJECT_FLAGS["item-add"], "project", "item-add");
       return projectItemAdd(rest, ctx);
     case "item-create":
+      rejectUnknownFlags(rest, PROJECT_FLAGS["item-create"], "project", "item-create");
       return projectItemCreate(rest, ctx);
     case "item-edit":
+      rejectUnknownFlags(rest, PROJECT_FLAGS["item-edit"], "project", "item-edit");
       return projectItemEdit(rest);
     case "item-archive":
+      rejectUnknownFlags(rest, PROJECT_FLAGS["item-archive"], "project", "item-archive");
       return projectItemArchive(rest, ctx);
     case "item-delete":
+      rejectUnknownFlags(rest, PROJECT_FLAGS["item-delete"], "project", "item-delete");
       return projectItemDelete(rest, ctx);
     case "create":
+      rejectUnknownFlags(rest, PROJECT_FLAGS.create, "project", "create");
       return projectCreate(rest, ctx);
     case "edit":
+      rejectUnknownFlags(rest, PROJECT_FLAGS.edit, "project", "edit");
       return projectEdit(rest, ctx);
     case "close":
+      rejectUnknownFlags(rest, PROJECT_FLAGS.close, "project", "close");
       return projectClose(rest, ctx);
     case "copy":
+      rejectUnknownFlags(rest, PROJECT_FLAGS.copy, "project", "copy");
       return projectCopy(rest, ctx);
     case "--help":
     case "-h":

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -2,7 +2,7 @@ import { encode } from "@toon-format/toon";
 import type { RepoContext } from "../context.js";
 import { ghJson, ghExec } from "../gh.js";
 import { AxiError } from "../errors.js";
-import { getFlag, hasFlag, takeBoolFlag, takeFlag } from "../args.js";
+import { getFlag, hasFlag, takeBoolFlag, takeFlag, rejectUnknownFlags } from "../args.js";
 import { takeBody, truncateBody } from "../body.js";
 import {
   field,
@@ -18,6 +18,25 @@ import {
   type FieldDef,
 } from "../toon.js";
 import { getSuggestions } from "../suggestions.js";
+
+const RELEASE_FLAGS: Record<string, readonly string[]> = {
+  list: ["--limit", "--exclude-drafts", "--exclude-pre-releases"],
+  view: ["--full"],
+  create: [
+    "--body", "--body-file", "--title", "-t", "--notes", "-n",
+    "--notes-file", "-F", "--target", "--discussion-category",
+    "--notes-start-tag", "--draft", "-d", "--prerelease", "-p",
+    "--generate-notes", "--verify-tag", "--notes-from-tag",
+    "--fail-on-no-commits", "--latest",
+  ],
+  edit: [
+    "--body", "--body-file", "--title", "--notes", "-n", "--notes-file",
+    "-F", "--draft", "--prerelease",
+  ],
+  delete: [],
+  download: ["--pattern", "--dir"],
+  upload: [],
+};
 
 export const RELEASE_HELP = `usage: gh-axi release <subcommand> [flags]
 subcommands[7]:
@@ -407,18 +426,25 @@ export async function releaseCommand(
 
   switch (sub) {
     case "list":
+      rejectUnknownFlags(args.slice(1), RELEASE_FLAGS.list, "release", "list");
       return listReleases(args, ctx);
     case "view":
+      rejectUnknownFlags(args.slice(1), RELEASE_FLAGS.view, "release", "view");
       return viewRelease(args, ctx);
     case "create":
+      rejectUnknownFlags(args.slice(1), RELEASE_FLAGS.create, "release", "create");
       return createRelease(args, ctx);
     case "edit":
+      rejectUnknownFlags(args.slice(1), RELEASE_FLAGS.edit, "release", "edit");
       return editRelease(args, ctx);
     case "delete":
+      rejectUnknownFlags(args.slice(1), RELEASE_FLAGS.delete, "release", "delete");
       return deleteRelease(args, ctx);
     case "download":
+      rejectUnknownFlags(args.slice(1), RELEASE_FLAGS.download, "release", "download");
       return downloadRelease(args, ctx);
     case "upload":
+      rejectUnknownFlags(args.slice(1), RELEASE_FLAGS.upload, "release", "upload");
       return uploadRelease(args, ctx);
     default:
       return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -2,7 +2,7 @@ import { encode } from '@toon-format/toon';
 import type { RepoContext } from '../context.js';
 import { ghJson, ghExec } from '../gh.js';
 import { AxiError } from '../errors.js';
-import { getFlag, hasFlag } from '../args.js';
+import { getFlag, hasFlag, rejectUnknownFlags } from '../args.js';
 import {
   field,
   lower,
@@ -18,6 +18,21 @@ import {
 } from '../toon.js';
 import { formatCountLine } from '../format.js';
 import { getSuggestions } from '../suggestions.js';
+
+const REPO_FLAGS: Record<string, readonly string[]> = {
+  view: [],
+  create: [
+    '--public', '--private', '--internal', '--description', '--clone',
+    '--template',
+  ],
+  edit: [
+    '--description', '--visibility', '--default-branch', '--enable-issues',
+    '--enable-wiki',
+  ],
+  clone: [],
+  fork: ['--clone', '--remote'],
+  list: ['--limit', '--visibility', '--language', '--archived'],
+};
 
 export const REPO_HELP = `usage: gh-axi repo <subcommand> [flags]
 subcommands[6]:
@@ -202,16 +217,22 @@ export async function repoCommand(args: string[], ctx?: RepoContext): Promise<st
 
   switch (sub) {
     case 'view':
+      rejectUnknownFlags(args.slice(1), REPO_FLAGS.view, 'repo', 'view');
       return viewRepo(args, ctx);
     case 'create':
+      rejectUnknownFlags(args.slice(1), REPO_FLAGS.create, 'repo', 'create');
       return createRepo(args, ctx);
     case 'edit':
+      rejectUnknownFlags(args.slice(1), REPO_FLAGS.edit, 'repo', 'edit');
       return editRepo(args, ctx);
     case 'clone':
+      rejectUnknownFlags(args.slice(1), REPO_FLAGS.clone, 'repo', 'clone');
       return cloneRepo(args);
     case 'fork':
+      rejectUnknownFlags(args.slice(1), REPO_FLAGS.fork, 'repo', 'fork');
       return forkRepo(args, ctx);
     case 'list':
+      rejectUnknownFlags(args.slice(1), REPO_FLAGS.list, 'repo', 'list');
       return listRepos(args, ctx);
     default:
       return renderError(`Unknown subcommand: ${sub}`, 'VALIDATION_ERROR', [

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -5,7 +5,7 @@ import { encode } from "@toon-format/toon";
 import type { RepoContext } from "../context.js";
 import { ghJson, ghExec } from "../gh.js";
 import { AxiError } from "../errors.js";
-import { getFlag, hasFlag, takeFlag } from "../args.js";
+import { getFlag, hasFlag, takeFlag, rejectUnknownFlags } from "../args.js";
 import { parseFields, type ExtraFieldSpec } from "../fields.js";
 import {
   field,
@@ -20,6 +20,19 @@ import {
 } from "../toon.js";
 import { formatCountLine } from "../format.js";
 import { getSuggestions } from "../suggestions.js";
+
+const RUN_FLAGS: Record<string, readonly string[]> = {
+  list: [
+    "--fields", "--limit", "--workflow", "--branch", "--status",
+    "--event", "--user", "--commit",
+  ],
+  view: ["--job", "--conclusion", "--log", "--verbose", "--log-failed"],
+  watch: [],
+  rerun: ["--failed", "--debug", "--job"],
+  cancel: [],
+  delete: [],
+  download: ["--name", "--dir"],
+};
 
 export const RUN_HELP = `usage: gh-axi run <subcommand> [flags]
 subcommands[7]:
@@ -487,18 +500,25 @@ export async function runCommand(
 
   switch (sub) {
     case "list":
+      rejectUnknownFlags(args.slice(1), RUN_FLAGS.list, "run", "list");
       return listRuns(args, ctx);
     case "view":
+      rejectUnknownFlags(args.slice(1), RUN_FLAGS.view, "run", "view");
       return viewRun(args, ctx);
     case "watch":
+      rejectUnknownFlags(args.slice(1), RUN_FLAGS.watch, "run", "watch");
       return watchRun(args, ctx);
     case "rerun":
+      rejectUnknownFlags(args.slice(1), RUN_FLAGS.rerun, "run", "rerun");
       return rerunRun(args, ctx);
     case "cancel":
+      rejectUnknownFlags(args.slice(1), RUN_FLAGS.cancel, "run", "cancel");
       return cancelRun(args, ctx);
     case "delete":
+      rejectUnknownFlags(args.slice(1), RUN_FLAGS.delete, "run", "delete");
       return deleteRun(args, ctx);
     case "download":
+      rejectUnknownFlags(args.slice(1), RUN_FLAGS.download, "run", "download");
       return downloadRun(args, ctx);
     default:
       return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,7 +1,7 @@
 import type { RepoContext } from "../context.js";
 import { ghJson } from "../gh.js";
 import { AxiError } from "../errors.js";
-import { getFlag, hasFlag } from "../args.js";
+import { getFlag, hasFlag, rejectUnknownFlags } from "../args.js";
 import {
   field,
   lower,
@@ -33,6 +33,20 @@ const SEARCH_VALUE_FLAGS = new Set([
   "--language",
   "--stars",
 ]);
+
+const SEARCH_FLAGS: Record<string, readonly string[]> = {
+  issues: [
+    "--repo", "--owner", "--state", "--label", "--assignee", "--author",
+    "--sort", "--limit",
+  ],
+  prs: [
+    "--repo", "--owner", "--state", "--label", "--assignee", "--author",
+    "--sort", "--limit", "--draft", "--review",
+  ],
+  repos: ["--repo", "--owner", "--language", "--stars", "--sort", "--limit"],
+  commits: ["--repo", "--owner", "--author", "--sort", "--limit"],
+  code: ["--repo", "--owner", "--language", "--limit"],
+};
 
 export const SEARCH_HELP = `usage: gh-axi search <type> <query> [flags]
 types[5]:
@@ -397,14 +411,19 @@ export async function searchCommand(
 
   switch (sub) {
     case "issues":
+      rejectUnknownFlags(args.slice(1), SEARCH_FLAGS.issues, "search", "issues");
       return searchIssues(args, ctx);
     case "prs":
+      rejectUnknownFlags(args.slice(1), SEARCH_FLAGS.prs, "search", "prs");
       return searchPrs(args, ctx);
     case "repos":
+      rejectUnknownFlags(args.slice(1), SEARCH_FLAGS.repos, "search", "repos");
       return searchRepos(args, ctx);
     case "commits":
+      rejectUnknownFlags(args.slice(1), SEARCH_FLAGS.commits, "search", "commits");
       return searchCommits(args, ctx);
     case "code":
+      rejectUnknownFlags(args.slice(1), SEARCH_FLAGS.code, "search", "code");
       return searchCode(args, ctx);
     default:
       return renderError(`Unknown search type: ${sub}`, "VALIDATION_ERROR", [

--- a/src/commands/variable.ts
+++ b/src/commands/variable.ts
@@ -2,7 +2,7 @@ import { encode } from "@toon-format/toon";
 import type { RepoContext } from "../context.js";
 import { ghJson, ghExec, ghExecWithStdin } from "../gh.js";
 import { AxiError } from "../errors.js";
-import { takeFlag } from "../args.js";
+import { takeFlag, rejectUnknownFlags } from "../args.js";
 import {
   field,
   relativeTime,
@@ -14,6 +14,12 @@ import {
 } from "../toon.js";
 import { getSuggestions } from "../suggestions.js";
 import { resolveValue } from "../secretValue.js";
+
+const VARIABLE_FLAGS: Record<string, readonly string[]> = {
+  list: [],
+  set: ["--body", "-b"],
+  delete: [],
+};
 
 export const VARIABLE_HELP = `usage: gh-axi variable <subcommand> [flags]
 subcommands[3]:
@@ -118,10 +124,13 @@ export async function variableCommand(
 
   switch (sub) {
     case "list":
+      rejectUnknownFlags(args.slice(1), VARIABLE_FLAGS.list, "variable", "list");
       return listVariables(args, ctx);
     case "set":
+      rejectUnknownFlags(args.slice(1), VARIABLE_FLAGS.set, "variable", "set");
       return setVariable(args, ctx);
     case "delete":
+      rejectUnknownFlags(args.slice(1), VARIABLE_FLAGS.delete, "variable", "delete");
       return deleteVariable(args, ctx);
     default:
       return renderError(`Unknown subcommand: ${sub}`, "VALIDATION_ERROR", [

--- a/src/commands/workflow.ts
+++ b/src/commands/workflow.ts
@@ -2,7 +2,7 @@ import { encode } from '@toon-format/toon';
 import type { RepoContext } from '../context.js';
 import { ghJson, ghExec } from '../gh.js';
 import { AxiError } from '../errors.js';
-import { getFlag, hasFlag, getAllFlags } from '../args.js';
+import { getFlag, hasFlag, getAllFlags, rejectUnknownFlags } from '../args.js';
 import {
   field,
   lower,
@@ -15,6 +15,14 @@ import {
 } from '../toon.js';
 import { formatCountLine } from '../format.js';
 import { getSuggestions } from '../suggestions.js';
+
+const WORKFLOW_FLAGS: Record<string, readonly string[]> = {
+  list: ['--limit', '--all'],
+  view: [],
+  run: ['--ref', '--field'],
+  enable: [],
+  disable: [],
+};
 
 export const WORKFLOW_HELP = `usage: gh-axi workflow <subcommand> [flags]
 subcommands[5]:
@@ -162,14 +170,19 @@ export async function workflowCommand(args: string[], ctx?: RepoContext): Promis
 
   switch (sub) {
     case 'list':
+      rejectUnknownFlags(args.slice(1), WORKFLOW_FLAGS.list, 'workflow', 'list');
       return listWorkflows(args, ctx);
     case 'view':
+      rejectUnknownFlags(args.slice(1), WORKFLOW_FLAGS.view, 'workflow', 'view');
       return viewWorkflow(args, ctx);
     case 'run':
+      rejectUnknownFlags(args.slice(1), WORKFLOW_FLAGS.run, 'workflow', 'run');
       return runWorkflow(args, ctx);
     case 'enable':
+      rejectUnknownFlags(args.slice(1), WORKFLOW_FLAGS.enable, 'workflow', 'enable');
       return enableWorkflow(args, ctx);
     case 'disable':
+      rejectUnknownFlags(args.slice(1), WORKFLOW_FLAGS.disable, 'workflow', 'disable');
       return disableWorkflow(args, ctx);
     default:
       return renderError(`Unknown subcommand: ${sub}`, 'VALIDATION_ERROR', [

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -9,6 +9,7 @@ import {
   pushRepeated,
   getPositional,
   requireNumber,
+  rejectUnknownFlags,
 } from "../src/args.js";
 import { AxiError } from "../src/errors.js";
 
@@ -286,5 +287,87 @@ describe("requireNumber", () => {
       expect(e).toBeInstanceOf(AxiError);
       expect((e as AxiError).code).toBe("VALIDATION_ERROR");
     }
+  });
+
+  describe("rejectUnknownFlags", () => {
+    it("passes when no flags are unknown", () => {
+      expect(() =>
+        rejectUnknownFlags(
+          ["--state", "open", "--label", "bug"],
+          ["--state", "--label"],
+          "issue",
+          "list",
+        ),
+      ).not.toThrow();
+    });
+
+    it("passes on positional args", () => {
+      expect(() =>
+        rejectUnknownFlags(
+          ["42", "--comment", "thanks"],
+          ["--comment"],
+          "issue",
+          "comment",
+        ),
+      ).not.toThrow();
+    });
+
+    it("always allows --help and -h", () => {
+      expect(() =>
+        rejectUnknownFlags(["--help"], [], "issue", "list"),
+      ).not.toThrow();
+      expect(() => rejectUnknownFlags(["-h"], [], "pr", "list")).not.toThrow();
+    });
+
+    it("accepts equals-form known flags", () => {
+      expect(() =>
+        rejectUnknownFlags(
+          ["--state=open", "--limit=5"],
+          ["--state", "--limit"],
+          "issue",
+          "list",
+        ),
+      ).not.toThrow();
+    });
+
+    it("throws listing a single unknown flag with a self-correction hint", () => {
+      try {
+        rejectUnknownFlags(["--bogus"], ["--state"], "issue", "list");
+        expect.unreachable();
+      } catch (e) {
+        expect(e).toBeInstanceOf(AxiError);
+        const err = e as AxiError;
+        expect(err.code).toBe("VALIDATION_ERROR");
+        expect(err.message).toContain("--bogus");
+        expect(err.message).toContain("gh-axi issue list");
+        expect(err.suggestions.join("\n")).toContain(
+          "gh-axi issue list --help",
+        );
+      }
+    });
+
+    it("lists every unknown flag and dedupes", () => {
+      try {
+        rejectUnknownFlags(["--one", "--two=2", "--one"], [], "pr", "merge");
+        expect.unreachable();
+      } catch (e) {
+        const err = e as AxiError;
+        expect(err.message).toContain("--one");
+        expect(err.message).toContain("--two");
+        expect(err.message.match(/--one/g)).toHaveLength(1);
+      }
+    });
+
+    it("does not flag unknown short flags", () => {
+      expect(() => rejectUnknownFlags(["-z"], [], "issue", "list")).toThrow(
+        AxiError,
+      );
+    });
+
+    it("stops scanning after a -- separator", () => {
+      expect(() =>
+        rejectUnknownFlags(["--", "--not-a-flag"], [], "repo", "view"),
+      ).not.toThrow();
+    });
   });
 });

--- a/test/commands/issue.test.ts
+++ b/test/commands/issue.test.ts
@@ -92,6 +92,22 @@ describe("issueCommand", () => {
   });
 
   describe("list", () => {
+    it("rejects unknown flags with a structured error", async () => {
+      await expect(issueCommand(["list", "--bogus"], ctx)).rejects.toThrow(
+        /unknown flag for gh-axi issue list: --bogus/,
+      );
+    });
+
+    it("does not reject known list flags (including = form)", async () => {
+      mockedGhJson.mockResolvedValueOnce([]);
+      const result = await issueCommand(
+        ["list", "--state", "closed", "--label", "bug", "--limit=5"],
+        ctx,
+      );
+      expect(result).toContain("issues[0]");
+      expect(mockedGhJson).toHaveBeenCalled();
+    });
+
     it("returns list with count", async () => {
       mockedGhJson.mockResolvedValue([
         {


### PR DESCRIPTION
## Summary

gh-axi claims AXI principle 6 (fail loud on unknown flags), but most commands parsed flags read-only via `getFlag`/`hasFlag` and silently dropped unknown flags — an agent passing a typo'd or stale flag got plausible-looking, unfiltered data. This wires a per-subcommand unknown-flag guard into all ten commands that lacked one.

## What's in this PR

- `src/args.ts`: new `rejectUnknownFlags()` — throws `VALIDATION_ERROR` listing every offending flag, with `usage` + `--help` hints so the agent self-corrects in one turn. Always allows `--help`/`-h`, stops scanning at `--`, matches `=` forms by flag name.
- Per-subcommand known-flag sets wired into the dispatchers of `issue`, `pr`, `run`, `workflow`, `release`, `repo`, `label`, `project`, `variable`, `search` (each subcommand's flag set enumerated per the README/help spec).
- `issue list` / `pr list` `--search` still route to their existing dedicated hint (not shadowed by the generic error).
- Tests: 8 unit tests for `rejectUnknownFlags` + 2 command-level tests in `test/commands/issue.test.ts`.

## Commits in this PR

- `929cab2` fix(commands): reject unknown flags across all commands

## Open questions

None.

## What's NOT in this PR

- `secret` / `api` / `gist` already had unknown-flag validation; untouched.
- Value validation of known flags (e.g. `--limit abc`) is out of scope.
- `home` has no flags and is untouched.

## Verification snapshot

- `pnpm run build` passes (tsc clean)
- `pnpm test`: 902 passed, 5 skipped (35 files)
- eslint clean, prettier-formatted
- Manual: `gh-axi issue list --bogus-flag-xyz` → exit 2, `error: "unknown flag for gh-axi issue list: --bogus-flag-xyz"`, help lists usage + `--help`; legitimate flag combinations (space and `=` forms) are unaffected.

Signed-off-by: onyx-space
