### PR TITLE
feat(stack): add agent-safe stacked PR commands

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # GitHub concurrency groups retain at most one pending run, replacing older
 # pending runs even when cancel-in-progress is false. Give body-bearing events
@@ -40,13 +41,17 @@ jobs:
     steps:
       - name: Verify no-mistakes signature in PR body
         env:
-          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_REPOSITORY: ${{ github.repository }}
         run: |
           set -eu
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
-          if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
+          # no-mistakes can update the PR body and push its final commit together.
+          # Read the current PR instead of the potentially stale event snapshot.
+          pr_body="$(gh api "repos/${PR_REPOSITORY}/pulls/${PR_NUMBER}" --jq .body)"
+          if printf '%s' "$pr_body" | grep -qF -- "$marker"; then
             echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
             exit 0
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,13 @@ gh sometimes embeds remediation hints in errors with a different root cause, so 
 This only works because `src/version.ts` is a LEAF module importing node builtins only - `cli.ts` imports `VERSION` from it, never the reverse. Adding any non-builtin import to `src/version.ts` silently undoes the speedup.
 `test/version-fast-path.test.ts` guards it deterministically with a `module.register()` load-hook trace (`test/fixtures/module-trace-*.mjs`) plus a negative control on `--help`. Do not add a wall-clock timing assertion; it was proven flaky under CI contention.
 
+## Stacked PR support (`src/commands/stack.ts`)
+
+`gh-axi stack` is a strict adapter over GitHub's official `github/gh-stack` extension, not a second stack engine. Keep stack metadata, Git mutation, rebasing, and Stacks API behavior in the extension.
+Stack commands are bound to the current working directory. `cli.ts#withLocalRepoContext` rejects `-R`, `--repo`, and `GH_REPO`, strips the host flag, and does not pass `RepoContext` to the extension because `gh stack` operates on the local checkout.
+The adapter rejects interactive-only forms, forces `view --json`, `submit --auto`, and `merge --yes`, and requires explicit targets for commands that otherwise prompt. Preserve gh-stack's exit codes 2-10 through `StackError` and the CLI `formatError` hook.
+The extension may be absent. Detect its `unknown command "stack" for "gh"` error and suggest `gh extension install github/gh-stack`; do not silently fall back to core `gh` behavior.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ npx skills add kunchenguid/gh-axi --skill gh-axi -g
 That is the entire setup - no npm install needed.
 The skill teaches your agent to run gh-axi through `npx -y gh-axi`, so the CLI comes along on demand.
 You still need [`gh`](https://cli.github.com/) installed and authenticated via `gh auth login` (Node 20+ required).
+Stack commands additionally require GitHub's official extension: `gh extension install github/gh-stack`.
 For GitHub Enterprise or another custom host, authenticate `gh` for that host and either pass `--hostname <host>` after the command or set `GH_HOST`.
 
 The skill is not a user-facing slash command (`user-invocable: false`).
@@ -85,6 +86,9 @@ gh-axi                          # dashboard - live state, no args needed
 gh-axi issue list               # list issues in current repo
 gh-axi issue subissue list 16   # list sub-issues for issue #16
 gh-axi pr view 42               # view pull request #42
+gh-axi stack init model api      # create or adopt stacked branches
+gh-axi stack submit --open       # create ready-for-review stacked PRs
+gh-axi stack view                 # inspect the current stack as TOON
 gh-axi issue edit 42 --add-label bug --add-label chore  # repeat a flag per value
 gh-axi run list -R owner/repo   # list workflow runs for a specific repo
 gh-axi issue list --hostname git.example.com  # target a GitHub Enterprise host
@@ -143,28 +147,32 @@ Gist visibility is fixed at creation; a secret gist is unlisted (anyone with the
 Two file-on-disk input forms are available: positional paths (`gist create a.py b.py`) or repeatable `--file` flags (`gist create --file a.py --file b.py`); mixing the two is an error.
 To create a gist from piped content, use `--filename <name>` together with a pipe (`echo "..." | gh-axi gist create --filename foo.txt --public`).
 
+`gh-axi stack` is a strict, non-interactive adapter over GitHub's official `github/gh-stack` extension. It supports stack creation, inspection, branch navigation, submission, synchronization, rebasing, linking, unstacking, and merging without duplicating the extension's local metadata or Git logic.
+Stack commands operate on the current working directory's checkout and reject `-R`, `--repo`, and `GH_REPO` rather than risking an operation against a different local stack. `stack view` requests JSON and returns TOON, `stack submit` always adds `--auto`, and `stack merge <stack-or-pr>` requires a target and adds `--yes`. Interactive `modify`, `switch`, `alias`, and `feedback` commands are deliberately not wrapped.
+
 `gh-axi api` accepts `--field`, `--header`, `--paginate`, `--jq <expression>`, and `--template <format>`; any other flag, an extra positional argument, or a repeated `--jq`/`--template` is rejected with a clear error instead of being silently dropped.
 JSON responses are normally stripped of noisy fields before TOON encoding, but a response you shaped yourself with `--jq` or `--template` keeps every key and value verbatim — only over-long strings are still truncated so one field cannot flood an agent's context.
 
 ### Commands
 
-| Command    | Description                                                                 |
-| ---------- | --------------------------------------------------------------------------- |
-| `issue`    | Issues — list, view, create, edit, close, reopen, comment, subissue         |
-| `pr`       | Pull requests — list, view, create, merge, review, checks                   |
-| `run`      | Existing workflow runs - list, view, watch, rerun, cancel, delete, download |
-| `workflow` | Workflows - list, view, run (trigger), enable, disable                      |
-| `release`  | Releases — list, view, create, edit, delete                                 |
-| `repo`     | Repositories — list, view, create, edit, clone, fork                        |
-| `label`    | Labels — list, create, edit, delete                                         |
-| `gist`     | Gists — list, view, edit, rename, create, delete, clone                     |
-| `project`  | Projects (v2) - list, view, create, edit, close, copy, items, fields        |
-| `secret`   | Actions secrets — list, set, delete                                         |
-| `variable` | Actions variables — list, set, delete                                       |
-| `search`   | Search issues, PRs, repos, commits, code                                    |
-| `api`      | Raw GitHub API access                                                       |
-| `setup`    | Install optional agent session hooks                                        |
-| `update`   | Built-in self-update command inherited from `axi-sdk-js`                    |
+| Command    | Description                                                                  |
+| ---------- | ---------------------------------------------------------------------------- |
+| `issue`    | Issues — list, view, create, edit, close, reopen, comment, subissue          |
+| `pr`       | Pull requests — list, view, create, merge, review, checks                    |
+| `stack`    | Stacked branches and PRs - init, view, submit, sync, rebase, merge, navigate |
+| `run`      | Existing workflow runs - list, view, watch, rerun, cancel, delete, download  |
+| `workflow` | Workflows - list, view, run (trigger), enable, disable                       |
+| `release`  | Releases — list, view, create, edit, delete                                  |
+| `repo`     | Repositories — list, view, create, edit, clone, fork                         |
+| `label`    | Labels — list, create, edit, delete                                          |
+| `gist`     | Gists — list, view, edit, rename, create, delete, clone                      |
+| `project`  | Projects (v2) - list, view, create, edit, close, copy, items, fields         |
+| `secret`   | Actions secrets — list, set, delete                                          |
+| `variable` | Actions variables — list, set, delete                                        |
+| `search`   | Search issues, PRs, repos, commits, code                                     |
+| `api`      | Raw GitHub API access                                                        |
+| `setup`    | Install optional agent session hooks                                         |
+| `update`   | Built-in self-update command inherited from `axi-sdk-js`                     |
 
 ### Global flags
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For GitHub Enterprise or another custom host, authenticate `gh` for that host an
 
 The skill is not a user-facing slash command (`user-invocable: false`).
 Its frontmatter also includes Hermes Agent metadata (`metadata.hermes`) so Hermes can categorize it as a `devops` skill for GitHub, git, CI, pull requests, releases, and projects.
-Just ask for anything that touches GitHub - filing issues, reviewing PRs, checking CI runs, cutting releases, managing Projects boards, or managing GitHub Actions secrets and variables - and the agent loads the skill on its own when it recognizes the task.
+Just ask for anything that touches GitHub - filing issues, reviewing PRs, managing stacked branches and PRs, checking CI runs, cutting releases, managing Projects boards, or managing GitHub Actions secrets and variables - and the agent loads the skill on its own when it recognizes the task.
 
 `-g` installs the skill for all projects (`~/.claude/skills/`, for example); drop it to install for the current project only (`.claude/skills/`).
 

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-axi
-description: "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist view`, `gist edit`, `gist rename`, `gist create`, `gist delete`, or `gist clone`."
+description: "Operate GitHub through the gh-axi CLI - issues, pull requests, stacked PRs, workflow runs, workflows, releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, managing stacked branches and PRs, checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist view`, `gist edit`, `gist rename`, `gist create`, `gist delete`, or `gist clone`."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -33,12 +33,13 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 6. Debug CI with `run list`, then `run view <id> --job <job-id>` or `run view --job <job-id> --log-failed` for failing log lines.
    Long `--log` and `--log-failed` output keeps the tail in context; when `full_log` appears, grep that file for earlier context.
 7. Every response ends with contextual next-step hints under `help:` - follow them.
+8. Manage stacked PRs from the target repository's working directory. Use `stack init <branch>`, `stack add <branch>`, `stack submit --open`, and `stack view`; the wrapper keeps these operations non-interactive.
 
 ## Commands
 
 ```
-commands[15]:
-  (none)=dashboard, issue, pr, run, workflow, release, repo, label, gist, project, secret, variable, search, api, setup
+commands[16]:
+  (none)=dashboard, issue, pr, stack, run, workflow, release, repo, label, gist, project, secret, variable, search, api, setup
 ```
 
 Installed copies also inherit the SDK built-in `update` command.
@@ -52,6 +53,8 @@ Run `npx -y gh-axi --help` for global flags, or `npx -y gh-axi <command> --help`
 - Output is TOON-encoded and token-efficient; pipe through grep/head only when a list is very long.
 - Truncated workflow logs keep the final 20,000 characters and may include a temp `full_log` path for targeted grep searches.
 - Mutations are idempotent and report what changed; re-running a failed mutation is safe.
+- `stack` wraps GitHub's official `gh-stack` extension. Install it with `gh extension install github/gh-stack`; stack commands are bound to the current checkout and reject `-R`, `--repo`, and `GH_REPO`.
+- Stack output is TOON-encoded. `stack view` uses `--json`, `stack submit` uses `--auto`, and `stack merge <stack-or-pr>` uses `--yes` automatically. Interactive `modify`, `switch`, `alias`, and `feedback` are intentionally not wrapped.
 - For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass `--body-file <path>` or the release `--notes-file <path>` alias on commands that support file-backed text.
 - Label, assignee, reviewer, and project flags repeat: pass the flag once per value, e.g. `issue edit 42 --add-label bug --add-label chore`, and every value is applied. A repeated flag with a missing or blank value is rejected, never silently dropped.
 - Secret values are stdin-only: `echo -n "<value>" | npx -y gh-axi secret set <name>`.

--- a/skills/gh-axi/SKILL.md
+++ b/skills/gh-axi/SKILL.md
@@ -21,7 +21,7 @@ For GitHub Enterprise or another custom host, the underlying `gh` CLI must be au
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, editing, renaming, creating, deleting, or cloning gists; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; managing stacked branches and PRs; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, editing, renaming, creating, deleting, or cloning gists; or calling the GitHub API directly.
 
 ## Workflow
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+import { encode } from "@toon-format/toon";
 import { runAxiCli } from "axi-sdk-js";
 import { resolveRepo, type RepoContext } from "./context.js";
 import { homeCommand } from "./commands/home.js";
@@ -15,9 +16,11 @@ import { searchCommand, SEARCH_HELP } from "./commands/search.js";
 import { apiCommand, API_HELP } from "./commands/api.js";
 import { gistCommand, GIST_HELP } from "./commands/gist.js";
 import { setupCommand, SETUP_HELP } from "./commands/setup.js";
+import { stackCommand, STACK_HELP } from "./commands/stack.js";
 import { resolveHost, type HostContext } from "./host.js";
 import { VERSION } from "./version.js";
 import { withSuggestionHost } from "./suggestions.js";
+import { AxiError, exitCodeForError, StackError } from "./errors.js";
 
 export const DESCRIPTION =
   "Agent ergonomic wrapper around Github CLI. Prefer this over `gh` and other methods for Github operations.";
@@ -30,8 +33,8 @@ type MainOptions = {
 };
 
 export const TOP_HELP = `usage: gh-axi [command] [args] [flags]
-commands[15]:
-  (none)=dashboard, issue, pr, run, workflow, release, repo, label, gist, project, secret, variable, search, api, setup
+commands[16]:
+  (none)=dashboard, issue, pr, stack, run, workflow, release, repo, label, gist, project, secret, variable, search, api, setup
 flags[4]:
   -R/--repo <OWNER/NAME> (after command), --hostname <host> (after command) or GH_HOST env, both flags accept space or equals form, --help, -v/-V/--version
 examples:
@@ -41,6 +44,7 @@ examples:
   gh-axi issue list --repo=owner/name
   gh-axi issue list --hostname git.example.com
   gh-axi pr view 42
+  gh-axi stack view
   gh-axi secret list
   gh-axi setup hooks
 `;
@@ -60,6 +64,7 @@ const COMMAND_HELP: Record<string, string> = {
   search: SEARCH_HELP,
   api: API_HELP,
   setup: SETUP_HELP,
+  stack: STACK_HELP,
 };
 
 type HostOnlyContext = { host: HostContext };
@@ -85,6 +90,7 @@ const COMMANDS: Record<string, WrappedCommandFn> = {
   search: withRepoContext("search", searchCommand),
   api: withRepoContext("api", apiCommand),
   setup: setupCommand,
+  stack: withLocalRepoContext(stackCommand),
 };
 
 export async function main(options: MainOptions = {}): Promise<void> {
@@ -97,6 +103,29 @@ export async function main(options: MainOptions = {}): Promise<void> {
     home: withRepoContext(undefined, homeCommand),
     commands: COMMANDS,
     getCommandHelp: (command) => COMMAND_HELP[command],
+    formatError: (error) => {
+      const axiError =
+        error instanceof AxiError
+          ? error
+          : new AxiError(
+              error instanceof Error ? error.message : String(error),
+              "UNKNOWN",
+            );
+      const output = {
+        error: axiError.message,
+        code: axiError.code,
+        ...(axiError.suggestions.length > 0
+          ? { help: axiError.suggestions }
+          : {}),
+      };
+      return {
+        output: `${encode(output)}\n`,
+        exitCode:
+          error instanceof StackError
+            ? error.exitCode
+            : exitCodeForError(axiError),
+      };
+    },
     resolveContext: ({ command, args }) => {
       const { repoFlag, hostFlag } = parseRepoContextArgs(command, args);
       // Explicit --hostname wins over the GH_HOST env var. Setting GH_HOST here
@@ -128,6 +157,20 @@ function withRepoContext(
         repoContext(ctx),
       ),
     );
+}
+
+function withLocalRepoContext(handler: CommandFn): WrappedCommandFn {
+  return (args, ctx) => {
+    const parsed = parseRepoContextArgs("stack", args);
+    if (parsed.repoFlag !== undefined || process.env["GH_REPO"]) {
+      throw new AxiError(
+        "stack commands operate on the repository in the current working directory and do not support -R, --repo, or GH_REPO",
+        "VALIDATION_ERROR",
+        ["Run `gh-axi stack` from a checkout of the target repository"],
+      );
+    }
+    return withSuggestionHost(ctx?.host, () => handler(parsed.strippedArgs));
+  };
 }
 
 function repoContext(ctx?: CliContext): RepoContext | undefined {

--- a/src/commands/stack.ts
+++ b/src/commands/stack.ts
@@ -1,0 +1,451 @@
+import { encode } from "@toon-format/toon";
+import { ghRaw, type ExecResult } from "../gh.js";
+import { AxiError, StackError } from "../errors.js";
+import { getSuggestions } from "../suggestions.js";
+import { renderHelp, renderOutput } from "../toon.js";
+
+interface StackBranch {
+  name?: string;
+  head?: string;
+  base?: string;
+  isCurrent?: boolean;
+  isMerged?: boolean;
+  isQueued?: boolean;
+  needsRebase?: boolean;
+  pr?: {
+    number?: number;
+    url?: string;
+    state?: string;
+  };
+}
+
+interface StackView {
+  trunk?: string;
+  currentBranch?: string;
+  branches: StackBranch[];
+}
+
+type FlagKind = "boolean" | "value";
+type FlagSpec = Record<string, FlagKind>;
+
+interface ParsedArgs {
+  positionals: string[];
+  seen: Set<string>;
+}
+
+export const STACK_HELP = `usage: gh-axi stack <subcommand> [args] [flags]
+subcommands[16]:
+  view, init <branches...>, add [branch], checkout <stack|pr|url|branch>, push, submit, sync, rebase [branch], link <refs...>, unstack [stack], merge <stack|pr>, up [n], down [n], top, bottom, trunk
+flags{view}:
+  --json is automatic; structured TOON output is always returned
+flags{init}:
+  -b/--base <branch>
+flags{add}:
+  -m/--message <text>, -A/--all, -u/--update (staging flags require a message)
+flags{push}:
+  --remote <name>
+flags{submit}:
+  --open, --remote <name> (--auto is automatic)
+flags{sync}:
+  --prune, --remote <name>
+flags{rebase}:
+  --downstack, --upstack, --no-trunk, --continue, --abort, --remote <name>, --committer-date-is-author-date, --preserve-dates
+flags{link}:
+  --base <branch>, --open, --remote <name>
+flags{unstack}:
+  --local
+flags{merge}:
+  --merge-method <merge|squash|rebase>, --merge, --squash, --rebase (--yes is automatic)
+notes:
+  Requires the official extension: gh extension install github/gh-stack
+  Operates on the git repository in the current working directory; -R, --repo, and GH_REPO are not supported
+  Not wrapped: modify, switch, alias, feedback (use gh stack directly)
+examples:
+  gh-axi stack init feature-model feature-api
+  gh-axi stack submit --open
+  gh-axi stack view
+  gh-axi stack rebase --continue
+  gh-axi stack merge 42 --squash`;
+
+const REMOTE_FLAGS: FlagSpec = { "--remote": "value" };
+const ADD_FLAGS: FlagSpec = {
+  "-m": "value",
+  "--message": "value",
+  "-A": "boolean",
+  "--all": "boolean",
+  "-u": "boolean",
+  "--update": "boolean",
+};
+
+export async function stackCommand(args: string[]): Promise<string> {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    return STACK_HELP;
+  }
+
+  const [subcommand, ...rest] = args;
+  switch (subcommand) {
+    case "view":
+      parseArgs(rest, { "--json": "boolean" }, 0, 0);
+      return viewStack();
+    case "init":
+      parseArgs(rest, { "-b": "value", "--base": "value" }, 1);
+      return runStack(subcommand, rest);
+    case "add":
+      return addStack(rest);
+    case "checkout":
+      parseArgs(rest, {}, 1, 1);
+      return runStack(subcommand, rest);
+    case "push":
+      parseArgs(rest, REMOTE_FLAGS, 0, 0);
+      return runStack(subcommand, rest);
+    case "submit":
+      parseArgs(
+        rest,
+        { ...REMOTE_FLAGS, "--open": "boolean", "--auto": "boolean" },
+        0,
+        0,
+      );
+      return runStack(
+        subcommand,
+        hasFlag(rest, "--auto") ? rest : [...rest, "--auto"],
+      );
+    case "sync":
+      parseArgs(rest, { ...REMOTE_FLAGS, "--prune": "boolean" }, 0, 0);
+      return runStack(subcommand, rest);
+    case "rebase":
+      parseArgs(
+        rest,
+        {
+          ...REMOTE_FLAGS,
+          "--downstack": "boolean",
+          "--upstack": "boolean",
+          "--no-trunk": "boolean",
+          "--continue": "boolean",
+          "--abort": "boolean",
+          "--committer-date-is-author-date": "boolean",
+          "--preserve-dates": "boolean",
+        },
+        0,
+        1,
+      );
+      return runStack(subcommand, rest);
+    case "link":
+      parseArgs(
+        rest,
+        { ...REMOTE_FLAGS, "--base": "value", "--open": "boolean" },
+        2,
+      );
+      return runStack(subcommand, rest);
+    case "unstack":
+      parseArgs(rest, { "--local": "boolean" }, 0, 1);
+      return runStack(subcommand, rest);
+    case "merge":
+      return mergeStack(rest);
+    case "up":
+    case "down":
+      return navigateStack(subcommand, rest);
+    case "top":
+    case "bottom":
+    case "trunk":
+      parseArgs(rest, {}, 0, 0);
+      return runStack(subcommand, rest);
+    case "modify":
+    case "switch":
+    case "alias":
+    case "feedback":
+      throw validation(
+        `${subcommand} is not wrapped because it is interactive or human-only; run gh stack ${subcommand} directly`,
+      );
+    default:
+      throw validation(`Unknown stack subcommand: ${subcommand}`);
+  }
+}
+
+async function viewStack(): Promise<string> {
+  const result = await execute(["stack", "view", "--json"]);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    throw unexpectedOutput(result.stdout);
+  }
+  if (!isStackView(parsed)) throw unexpectedOutput(result.stdout);
+
+  const view = parsed;
+  const stack: Record<string, unknown> = {
+    trunk: view.trunk ?? null,
+    current_branch: view.currentBranch ?? null,
+    branch_count: view.branches.length,
+    branches: view.branches.map((branch) => ({
+      name: branch.name ?? null,
+      head: branch.head ?? null,
+      base: branch.base ?? null,
+      current: branch.isCurrent ?? false,
+      merged: branch.isMerged ?? false,
+      queued: branch.isQueued ?? false,
+      needs_rebase: branch.needsRebase ?? false,
+      pr: branch.pr
+        ? {
+            number: branch.pr.number ?? null,
+            url: branch.pr.url ?? null,
+            state: branch.pr.state?.toLowerCase() ?? null,
+          }
+        : null,
+    })),
+  };
+  if (result.stderr.trim()) stack.diagnostics = result.stderr.trim();
+
+  return renderOutput([
+    encode({ stack }),
+    renderHelp(getSuggestions({ domain: "stack", action: "view" })),
+  ]);
+}
+
+function isStackView(value: unknown): value is StackView {
+  if (typeof value !== "object" || value === null) return false;
+  const branches = (value as { branches?: unknown }).branches;
+  return (
+    Array.isArray(branches) &&
+    branches.every((branch) => typeof branch === "object" && branch !== null)
+  );
+}
+
+function unexpectedOutput(stdout: string): AxiError {
+  return new AxiError(
+    `Unexpected gh stack output: ${stdout.slice(0, 200)}`,
+    "UNKNOWN",
+  );
+}
+
+async function addStack(args: string[]): Promise<string> {
+  const normalized = expandAddShortFlags(args);
+  const parsed = parseArgs(normalized, ADD_FLAGS, 0, 1);
+  const hasMessage = parsed.seen.has("-m") || parsed.seen.has("--message");
+  const stagesAll = parsed.seen.has("-A") || parsed.seen.has("--all");
+  const stagesTracked = parsed.seen.has("-u") || parsed.seen.has("--update");
+
+  if (stagesAll && stagesTracked) {
+    throw validation("Choose only one of --all or --update");
+  }
+  if ((stagesAll || stagesTracked) && !hasMessage) {
+    throw validation("--all and --update require --message");
+  }
+  // gh-stack can generate a branch name when -m is supplied, so a message is
+  // a safe non-interactive alternative to an explicit branch name.
+  if (parsed.positionals.length === 0 && !hasMessage) {
+    throw validation("stack add requires a branch or --message");
+  }
+
+  return runStack("add", args);
+}
+
+async function mergeStack(args: string[]): Promise<string> {
+  const parsed = parseArgs(
+    args,
+    {
+      "--merge-method": "value",
+      "--merge": "boolean",
+      "--squash": "boolean",
+      "--rebase": "boolean",
+      "--yes": "boolean",
+      "-y": "boolean",
+    },
+    1,
+    1,
+  );
+  const methods = ["--merge-method", "--merge", "--squash", "--rebase"].filter(
+    (flag) => parsed.seen.has(flag),
+  );
+  if (methods.length > 1) throw validation("Choose only one merge method");
+
+  const confirmed = parsed.seen.has("--yes") || parsed.seen.has("-y");
+  return runStack("merge", confirmed ? args : [...args, "--yes"]);
+}
+
+async function navigateStack(
+  subcommand: "up" | "down",
+  args: string[],
+): Promise<string> {
+  const parsed = parseArgs(args, {}, 0, 1);
+  const distance = parsed.positionals[0];
+  if (distance !== undefined && !/^[1-9]\d*$/.test(distance)) {
+    throw validation(`${subcommand} distance must be a positive integer`);
+  }
+  return runStack(subcommand, args);
+}
+
+async function runStack(action: string, args: string[]): Promise<string> {
+  const result = await execute(["stack", action, ...args]);
+  return renderOutput([
+    encode({
+      stack: {
+        action,
+        status: "ok",
+        stdout: result.stdout,
+        stderr: result.stderr,
+      },
+    }),
+    renderHelp(getSuggestions({ domain: "stack", action })),
+  ]);
+}
+
+async function execute(args: string[]): Promise<ExecResult> {
+  const result = await ghRaw(args);
+  if (result.exitCode === 0) return result;
+
+  const details = [result.stderr.trim(), result.stdout.trim()].filter(Boolean);
+  const message =
+    details.join("\n") || `gh stack exited with code ${result.exitCode}`;
+  if (/unknown command ["']stack["'] for ["']gh["']/i.test(result.stderr)) {
+    throw new StackError(
+      "The official gh-stack extension is not installed",
+      result.exitCode,
+      ["Run `gh extension install github/gh-stack` to install it"],
+      "EXTENSION_NOT_INSTALLED",
+    );
+  }
+
+  throw new StackError(
+    message,
+    result.exitCode,
+    stackRecovery(args[1] ?? "", result.exitCode),
+  );
+}
+
+function stackRecovery(action: string, exitCode: number): string[] {
+  switch (exitCode) {
+    case 2:
+      return [
+        "Run `gh-axi stack init <branch>` to create or adopt a stack",
+        "Run `gh-axi stack checkout <stack|pr|branch>` to use an existing stack",
+      ];
+    case 3:
+      if (action === "rebase") {
+        return [
+          "Resolve conflicts, stage files with `git add`, then run `gh-axi stack rebase --continue`",
+          "Run `gh-axi stack rebase --abort` to restore the stack",
+        ];
+      }
+      if (action === "sync") {
+        return [
+          "The stack was restored; run `gh-axi stack rebase` to resolve conflicts explicitly",
+        ];
+      }
+      return ["Resolve the reported conflict, then retry the stack operation"];
+    case 4:
+      return ["Run `gh auth status` and retry the command"];
+    case 6:
+      return ["Check out a branch that belongs to only one stack, then retry"];
+    case 7:
+      return [
+        "Run `gh-axi stack rebase --continue` after resolving conflicts, or `gh-axi stack rebase --abort`",
+      ];
+    case 8:
+      return ["Wait for the other stack operation to finish, then retry"];
+    case 9:
+      return ["Enable stacked PRs for this repository before retrying"];
+    case 10:
+      return [
+        "Use `gh stack modify --continue` or `gh stack modify --abort` to recover the interrupted session",
+      ];
+    default:
+      return [];
+  }
+}
+
+function validation(message: string): AxiError {
+  return new AxiError(message, "VALIDATION_ERROR", [
+    "Run `gh-axi stack --help` to see agent-safe forms",
+  ]);
+}
+
+function hasFlag(args: string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+function parseArgs(
+  args: string[],
+  flags: FlagSpec,
+  minPositionals: number,
+  maxPositionals = Number.POSITIVE_INFINITY,
+): ParsedArgs {
+  const positionals: string[] = [];
+  const seen = new Set<string>();
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (!arg.startsWith("-")) {
+      positionals.push(arg);
+      continue;
+    }
+
+    const equalsIndex = arg.indexOf("=");
+    const name = equalsIndex === -1 ? arg : arg.slice(0, equalsIndex);
+    const inlineValue =
+      equalsIndex === -1 ? undefined : arg.slice(equalsIndex + 1);
+    const kind = flags[name];
+    if (!kind) throw validation(`Unsupported stack flag: ${name}`);
+
+    seen.add(name);
+    if (kind === "boolean") {
+      if (inlineValue !== undefined) {
+        throw validation(`${name} does not take a value`);
+      }
+      continue;
+    }
+
+    if (inlineValue !== undefined) {
+      if (inlineValue === "") throw validation(`${name} requires a value`);
+      continue;
+    }
+
+    const value = args[++index];
+    if (!value || value.startsWith("-")) {
+      throw validation(`${name} requires a value`);
+    }
+  }
+
+  if (positionals.length < minPositionals) {
+    throw validation(
+      `Expected at least ${minPositionals} stack argument${minPositionals === 1 ? "" : "s"}`,
+    );
+  }
+  if (positionals.length > maxPositionals) {
+    throw validation(
+      `Expected at most ${maxPositionals} stack argument${maxPositionals === 1 ? "" : "s"}`,
+    );
+  }
+
+  return { positionals, seen };
+}
+
+function expandAddShortFlags(args: string[]): string[] {
+  const expanded: string[] = [];
+  for (const arg of args) {
+    if (!arg.startsWith("-") || arg.startsWith("--") || arg.length <= 2) {
+      expanded.push(arg);
+      continue;
+    }
+
+    const flags = arg.slice(1);
+    let consumedValue = false;
+    for (let index = 0; index < flags.length; index++) {
+      const flag = flags[index];
+      if (flag === "m") {
+        const attached = flags.slice(index + 1);
+        expanded.push(attached ? `-m=${attached}` : "-m");
+        consumedValue = true;
+        break;
+      }
+      if (flag === "A" || flag === "u") {
+        expanded.push(`-${flag}`);
+        continue;
+      }
+      expanded.push(arg);
+      consumedValue = true;
+      break;
+    }
+    if (consumedValue) continue;
+  }
+  return expanded;
+}

--- a/src/commands/stack.ts
+++ b/src/commands/stack.ts
@@ -2,6 +2,7 @@ import { encode } from "@toon-format/toon";
 import { ghRaw, type ExecResult } from "../gh.js";
 import { AxiError, StackError } from "../errors.js";
 import { getSuggestions } from "../suggestions.js";
+import { resolveStackRemote } from "../stack-remote.js";
 import { renderHelp, renderOutput } from "../toon.js";
 
 interface StackBranch {
@@ -97,7 +98,7 @@ export async function stackCommand(args: string[]): Promise<string> {
       return runStack(subcommand, rest);
     case "push":
       parseArgs(rest, REMOTE_FLAGS, 0, 0);
-      return runStack(subcommand, rest);
+      return runRemoteStack(subcommand, rest);
     case "submit":
       parseArgs(
         rest,
@@ -105,13 +106,13 @@ export async function stackCommand(args: string[]): Promise<string> {
         0,
         0,
       );
-      return runStack(
+      return runRemoteStack(
         subcommand,
         hasFlag(rest, "--auto") ? rest : [...rest, "--auto"],
       );
     case "sync":
       parseArgs(rest, { ...REMOTE_FLAGS, "--prune": "boolean" }, 0, 0);
-      return runStack(subcommand, rest);
+      return runRemoteStack(subcommand, rest);
     case "rebase":
       parseArgs(
         rest,
@@ -128,14 +129,16 @@ export async function stackCommand(args: string[]): Promise<string> {
         0,
         1,
       );
-      return runStack(subcommand, rest);
+      return requiresRemoteForRebase(rest)
+        ? runRemoteStack(subcommand, rest)
+        : runStack(subcommand, rest);
     case "link":
       parseArgs(
         rest,
         { ...REMOTE_FLAGS, "--base": "value", "--open": "boolean" },
         2,
       );
-      return runStack(subcommand, rest);
+      return runRemoteStack(subcommand, rest);
     case "unstack":
       parseArgs(rest, { "--local": "boolean" }, 0, 1);
       return runStack(subcommand, rest);
@@ -274,13 +277,33 @@ async function navigateStack(
   return runStack(subcommand, args);
 }
 
+async function runRemoteStack(
+  action: string,
+  args: string[],
+): Promise<string> {
+  return runStack(action, await resolveStackRemote(args));
+}
+
+function requiresRemoteForRebase(args: string[]): boolean {
+  return !(
+    hasFlag(args, "--continue") ||
+    hasFlag(args, "--abort") ||
+    hasFlag(args, "--no-trunk")
+  );
+}
+
 async function runStack(action: string, args: string[]): Promise<string> {
   const result = await execute(["stack", action, ...args]);
+  const status =
+    action === "sync" &&
+    /\bsync aborted\b/i.test(result.stdout + result.stderr)
+      ? "aborted"
+      : "ok";
   return renderOutput([
     encode({
       stack: {
         action,
-        status: "ok",
+        status,
         stdout: result.stdout,
         stderr: result.stderr,
       },

--- a/src/commands/stack.ts
+++ b/src/commands/stack.ts
@@ -278,10 +278,7 @@ async function navigateStack(
   return runStack(subcommand, args);
 }
 
-async function runRemoteStack(
-  action: string,
-  args: string[],
-): Promise<string> {
+async function runRemoteStack(action: string, args: string[]): Promise<string> {
   return runStack(action, await resolveStackRemote(args));
 }
 
@@ -300,8 +297,7 @@ function requiresRemoteForRebase(args: string[]): boolean {
 async function runStack(action: string, args: string[]): Promise<string> {
   const result = await execute(["stack", action, ...args]);
   const status =
-    action === "sync" &&
-    /\bsync aborted\b/i.test(result.stdout + result.stderr)
+    action === "sync" && /\bsync aborted\b/i.test(result.stdout + result.stderr)
       ? "aborted"
       : "ok";
   return renderOutput([

--- a/src/commands/stack.ts
+++ b/src/commands/stack.ts
@@ -2,7 +2,7 @@ import { encode } from "@toon-format/toon";
 import { ghRaw, type ExecResult } from "../gh.js";
 import { AxiError, StackError } from "../errors.js";
 import { getSuggestions } from "../suggestions.js";
-import { resolveStackRemote } from "../stack-remote.js";
+import { resolveStackLinkRemote, resolveStackRemote } from "../stack-remote.js";
 import { renderHelp, renderOutput } from "../toon.js";
 
 interface StackBranch {
@@ -132,13 +132,14 @@ export async function stackCommand(args: string[]): Promise<string> {
       return requiresRemoteForRebase(rest)
         ? runRemoteStack(subcommand, rest)
         : runStack(subcommand, rest);
-    case "link":
-      parseArgs(
+    case "link": {
+      const parsed = parseArgs(
         rest,
         { ...REMOTE_FLAGS, "--base": "value", "--open": "boolean" },
         2,
       );
-      return runRemoteStack(subcommand, rest);
+      return runLinkStack(rest, parsed.positionals);
+    }
     case "unstack":
       parseArgs(rest, { "--local": "boolean" }, 0, 1);
       return runStack(subcommand, rest);
@@ -282,6 +283,10 @@ async function runRemoteStack(
   args: string[],
 ): Promise<string> {
   return runStack(action, await resolveStackRemote(args));
+}
+
+async function runLinkStack(args: string[], refs: string[]): Promise<string> {
+  return runStack("link", await resolveStackLinkRemote(args, refs));
 }
 
 function requiresRemoteForRebase(args: string[]): boolean {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -12,6 +12,19 @@ export type ErrorCode =
 
 export { AxiError, exitCodeForError };
 
+/** Error from gh-stack whose exit code carries actionable recovery state. */
+export class StackError extends AxiError {
+  constructor(
+    message: string,
+    readonly exitCode: number,
+    suggestions: string[] = [],
+    code = "STACK_ERROR",
+  ) {
+    super(message, code, suggestions);
+    this.name = "StackError";
+  }
+}
+
 interface ErrorPattern {
   pattern: RegExp;
   code: ErrorCode;

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -71,7 +71,7 @@ For GitHub Enterprise or another custom host, the underlying \`gh\` CLI must be 
 
 ## When to use
 
-Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, editing, renaming, creating, deleting, or cloning gists; or calling the GitHub API directly.
+Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; viewing, creating, reviewing, or merging pull requests; managing stacked branches and PRs; inspecting workflow runs and CI failures; triggering, enabling, or disabling workflows; managing releases, repositories, or labels; managing Projects (v2) boards and their items; managing Actions secrets or variables; searching issues, PRs, repos, commits, or code; listing, viewing, editing, renaming, creating, deleting, or cloning gists; or calling the GitHub API directly.
 
 ## Workflow
 

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -3,9 +3,9 @@ import { DESCRIPTION, TOP_HELP } from "./cli.js";
 // Trigger string Claude Code (and other agents) match against to auto-load the skill.
 // Kept terse and outcome-focused so it fires on "needs GitHub" intents.
 export const SKILL_DESCRIPTION =
-  "Operate GitHub through the gh-axi CLI - issues, pull requests, workflow runs, workflows, " +
+  "Operate GitHub through the gh-axi CLI - issues, pull requests, stacked PRs, workflow runs, workflows, " +
   "releases, repositories, labels, gists, Projects (v2), Actions secrets and variables, search, and raw API access. " +
-  "Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, " +
+  "Use whenever a task touches GitHub: listing or filing issues, reviewing or merging PRs, managing stacked branches and PRs, " +
   "checking CI runs, triggering workflows, cutting releases, managing Projects boards, managing Actions secrets/variables, or working with gists via `gist list`, `gist view`, `gist edit`, `gist rename`, `gist create`, `gist delete`, or `gist clone`.";
 
 export const SKILL_AUTHOR = "Kun Chen (kunchenguid)";
@@ -83,6 +83,7 @@ Use gh-axi whenever a task touches GitHub: listing, filing, or editing issues; v
 6. Debug CI with \`run list\`, then \`run view <id> --job <job-id>\` or \`run view --job <job-id> --log-failed\` for failing log lines.
    Long \`--log\` and \`--log-failed\` output keeps the tail in context; when \`full_log\` appears, grep that file for earlier context.
 7. Every response ends with contextual next-step hints under \`help:\` - follow them.
+8. Manage stacked PRs from the target repository's working directory. Use \`stack init <branch>\`, \`stack add <branch>\`, \`stack submit --open\`, and \`stack view\`; the wrapper keeps these operations non-interactive.
 
 ## Commands
 
@@ -101,6 +102,8 @@ Run \`npx -y gh-axi --help\` for global flags, or \`npx -y gh-axi <command> --he
 - Output is TOON-encoded and token-efficient; pipe through grep/head only when a list is very long.
 - Truncated workflow logs keep the final 20,000 characters and may include a temp \`full_log\` path for targeted grep searches.
 - Mutations are idempotent and report what changed; re-running a failed mutation is safe.
+- \`stack\` wraps GitHub's official \`gh-stack\` extension. Install it with \`gh extension install github/gh-stack\`; stack commands are bound to the current checkout and reject \`-R\`, \`--repo\`, and \`GH_REPO\`.
+- Stack output is TOON-encoded. \`stack view\` uses \`--json\`, \`stack submit\` uses \`--auto\`, and \`stack merge <stack-or-pr>\` uses \`--yes\` automatically. Interactive \`modify\`, \`switch\`, \`alias\`, and \`feedback\` are intentionally not wrapped.
 - For multi-line markdown bodies, comments, or release notes, write the text to a UTF-8 file and pass \`--body-file <path>\` or the release \`--notes-file <path>\` alias on commands that support file-backed text.
 - Label, assignee, reviewer, and project flags repeat: pass the flag once per value, e.g. \`issue edit 42 --add-label bug --add-label chore\`, and every value is applied. A repeated flag with a missing or blank value is rejected, never silently dropped.
 - Secret values are stdin-only: \`echo -n "<value>" | npx -y gh-axi secret set <name>\`.

--- a/src/stack-remote.ts
+++ b/src/stack-remote.ts
@@ -1,0 +1,84 @@
+import { execFile } from "node:child_process";
+import { AxiError } from "./errors.js";
+
+interface GitResult {
+  stdout: string;
+  exitCode: number;
+}
+
+export type GitRunner = (args: string[]) => Promise<GitResult>;
+
+export async function resolveStackRemote(
+  args: string[],
+  runGit: GitRunner = runGitCommand,
+): Promise<string[]> {
+  if (hasRemote(args)) return args;
+
+  const branch = await currentBranch(runGit);
+  const configKeys = [
+    ...(branch ? [`branch.${branch}.pushRemote`] : []),
+    "remote.pushDefault",
+    ...(branch ? [`branch.${branch}.remote`] : []),
+    "gh-stack.remote",
+  ];
+
+  for (const key of configKeys) {
+    const value = await configValue(runGit, key);
+    if (value) return [...args, "--remote", value];
+  }
+
+  const remotes = await runGit(["remote"]);
+  if (remotes.exitCode !== 0) throw unknownRemote();
+
+  const names = remotes.stdout.trim().split(/\s+/).filter(Boolean);
+  if (names.length === 1) return [...args, "--remote", names[0]];
+  if (names.length > 1) {
+    throw new AxiError(
+      "Multiple git remotes are configured; pass --remote <name>",
+      "VALIDATION_ERROR",
+      ["Pass `--remote <name>` to select the remote for this stack operation"],
+    );
+  }
+  throw unknownRemote();
+}
+
+function hasRemote(args: string[]): boolean {
+  return args.some((arg) => arg === "--remote" || arg.startsWith("--remote="));
+}
+
+async function currentBranch(runGit: GitRunner): Promise<string | undefined> {
+  const result = await runGit(["symbolic-ref", "--quiet", "--short", "HEAD"]);
+  return result.exitCode === 0 ? result.stdout.trim() || undefined : undefined;
+}
+
+async function configValue(
+  runGit: GitRunner,
+  key: string,
+): Promise<string | undefined> {
+  const result = await runGit(["config", "--get", key]);
+  if (result.exitCode === 0) return result.stdout.trim() || undefined;
+  if (result.exitCode === 1) return undefined;
+  throw unknownRemote();
+}
+
+function unknownRemote(): AxiError {
+  return new AxiError(
+    "Could not determine a git remote; pass --remote <name>",
+    "VALIDATION_ERROR",
+    ["Pass `--remote <name>` to select the remote for this stack operation"],
+  );
+}
+
+function runGitCommand(args: string[]): Promise<GitResult> {
+  return new Promise((resolve) => {
+    execFile("git", args, (error, stdout) => {
+      const exitCode = error
+        ? ((error as Error & { code?: string | number }).code ?? 1)
+        : 0;
+      resolve({
+        stdout: stdout ?? "",
+        exitCode: typeof exitCode === "number" ? exitCode : 1,
+      });
+    });
+  });
+}

--- a/src/stack-remote.ts
+++ b/src/stack-remote.ts
@@ -13,8 +13,25 @@ export async function resolveStackRemote(
   runGit: GitRunner = runGitCommand,
 ): Promise<string[]> {
   if (hasRemote(args)) return args;
+  return resolveRemote(args, await currentBranch(runGit), runGit);
+}
 
-  const branch = await currentBranch(runGit);
+export async function resolveStackLinkRemote(
+  args: string[],
+  refs: string[],
+  runGit: GitRunner = runGitCommand,
+): Promise<string[]> {
+  if (hasRemote(args)) return args;
+
+  const branch = await firstLocalBranch(refs, runGit);
+  return branch ? resolveRemote(args, branch, runGit) : args;
+}
+
+async function resolveRemote(
+  args: string[],
+  branch: string | undefined,
+  runGit: GitRunner,
+): Promise<string[]> {
   const configKeys = [
     ...(branch ? [`branch.${branch}.pushRemote`] : []),
     "remote.pushDefault",
@@ -49,6 +66,23 @@ function hasRemote(args: string[]): boolean {
 async function currentBranch(runGit: GitRunner): Promise<string | undefined> {
   const result = await runGit(["symbolic-ref", "--quiet", "--short", "HEAD"]);
   return result.exitCode === 0 ? result.stdout.trim() || undefined : undefined;
+}
+
+async function firstLocalBranch(
+  refs: string[],
+  runGit: GitRunner,
+): Promise<string | undefined> {
+  const result = await runGit([
+    "for-each-ref",
+    "--format=%(refname:short)",
+    "refs/heads",
+  ]);
+  if (result.exitCode !== 0) throw unknownRemote();
+
+  const localBranches = new Set(
+    result.stdout.split("\n").map((branch) => branch.trim()).filter(Boolean),
+  );
+  return refs.find((ref) => localBranches.has(ref));
 }
 
 async function configValue(

--- a/src/stack-remote.ts
+++ b/src/stack-remote.ts
@@ -80,7 +80,10 @@ async function firstLocalBranch(
   if (result.exitCode !== 0) throw unknownRemote();
 
   const localBranches = new Set(
-    result.stdout.split("\n").map((branch) => branch.trim()).filter(Boolean),
+    result.stdout
+      .split("\n")
+      .map((branch) => branch.trim())
+      .filter(Boolean),
   );
   return refs.find((ref) => localBranches.has(ref));
 }

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -714,6 +714,33 @@ const table: SuggestionEntry[] = [
     lines: () => ["Run `gh-axi gist list` to see your gists"],
   },
 
+  // Stacked PRs
+  {
+    match: (c) => c.domain === "stack" && c.action === "view",
+    lines: () => [
+      "Run `gh-axi stack submit` to push and open/update the stack's PRs",
+      "Run `gh-axi stack sync` to reconcile local and remote stack state",
+    ],
+  },
+  {
+    match: (c) => c.domain === "stack" && c.action === "init",
+    lines: () => [
+      'Run `gh-axi stack add -Am "<message>" <branch>` to add the next layer',
+      "Run `gh-axi stack submit` to create the stack's pull requests",
+    ],
+  },
+  {
+    match: (c) => c.domain === "stack" && c.action === "submit",
+    lines: () => [
+      "Run `gh-axi stack view` to inspect branch and PR status",
+      "Run `gh-axi stack sync` to refresh the stack after review changes",
+    ],
+  },
+  {
+    match: (c) => c.domain === "stack",
+    lines: () => ["Run `gh-axi stack view` to inspect the current stack"],
+  },
+
   // Search
   {
     match: (c) => c.domain === "search",

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -63,6 +63,10 @@ vi.mock("../src/commands/api.js", () => ({
   apiCommand: vi.fn().mockResolvedValue("api output"),
   API_HELP: "api help",
 }));
+vi.mock("../src/commands/stack.js", () => ({
+  stackCommand: vi.fn().mockResolvedValue("stack output"),
+  STACK_HELP: "stack help",
+}));
 
 vi.mock("../src/context.js", () => ({
   resolveRepo: vi.fn().mockReturnValue({
@@ -78,6 +82,8 @@ import { homeCommand } from "../src/commands/home.js";
 import { issueCommand } from "../src/commands/issue.js";
 import { prCommand } from "../src/commands/pr.js";
 import { releaseCommand } from "../src/commands/release.js";
+import { stackCommand } from "../src/commands/stack.js";
+import { AxiError, StackError } from "../src/errors.js";
 import { resolveRepo } from "../src/context.js";
 
 const packageVersion = JSON.parse(
@@ -199,7 +205,43 @@ describe("main CLI", () => {
     expect(options.getCommandHelp("issue")).toBe("issue help");
     expect(options.getCommandHelp("secret")).toBe("secret help");
     expect(options.getCommandHelp("variable")).toBe("variable help");
+    expect(options.getCommandHelp("stack")).toBe("stack help");
     expect(options.getCommandHelp("missing")).toBeUndefined();
+  });
+
+  it("keeps stack commands bound to the current checkout", async () => {
+    await main();
+
+    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+    await options.commands.stack(["view"], {
+      owner: "octo",
+      name: "repo",
+      nwo: "octo/repo",
+      source: "git",
+    });
+    expect(vi.mocked(stackCommand)).toHaveBeenCalledWith(["view"]);
+
+    expect(() =>
+      options.commands.stack(["view", "--repo", "other/repo"], undefined),
+    ).toThrow(/current working directory/);
+    expect(vi.mocked(stackCommand)).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves stack exit codes without changing normal error formatting", async () => {
+    await main();
+
+    const options = vi.mocked(runAxiCli).mock.calls[0]?.[0];
+    const stackError = options.formatError(
+      new StackError("rebase conflict", 3, ["resolve it"]),
+    );
+    expect(stackError.exitCode).toBe(3);
+    expect(stackError.output).toContain("STACK_ERROR");
+
+    const normalError = options.formatError(
+      new AxiError("bad flag", "VALIDATION_ERROR"),
+    );
+    expect(normalError.exitCode).toBe(2);
+    expect(normalError.output).toContain("VALIDATION_ERROR");
   });
 
   it("lists secret and variable in the top-level command index", () => {

--- a/test/commands/stack.test.ts
+++ b/test/commands/stack.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/gh.js", () => ({ ghRaw: vi.fn() }));
+vi.mock("../../src/stack-remote.js", () => ({
+  resolveStackRemote: vi.fn(),
+}));
 
 import { ghRaw } from "../../src/gh.js";
+import { resolveStackRemote } from "../../src/stack-remote.js";
 import { stackCommand, STACK_HELP } from "../../src/commands/stack.js";
 import { AxiError } from "../../src/errors.js";
 
 const mockedGhRaw = vi.mocked(ghRaw);
+const mockedResolveStackRemote = vi.mocked(resolveStackRemote);
 
 function success(stdout = "", stderr = "") {
   return { stdout, stderr, exitCode: 0 };
@@ -16,6 +21,7 @@ describe("stackCommand", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     mockedGhRaw.mockResolvedValue(success());
+    mockedResolveStackRemote.mockImplementation(async (args) => args);
   });
 
   it("returns help without invoking gh", async () => {
@@ -167,6 +173,34 @@ describe("stackCommand", () => {
 
     expect(result).toContain("https://github.com/o/r/pull/42");
     expect(result).toContain("Created PR #42");
+  });
+
+  it("stops remote operations without a deterministic remote", async () => {
+    mockedResolveStackRemote.mockRejectedValueOnce(
+      new AxiError(
+        "Multiple git remotes are configured; pass --remote <name>",
+        "VALIDATION_ERROR",
+      ),
+    );
+
+    await expect(stackCommand(["sync"])).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+    expect(mockedResolveStackRemote).toHaveBeenCalledWith([]);
+    expect(mockedGhRaw).not.toHaveBeenCalled();
+  });
+
+  it("reports a zero-exit sync abort as aborted", async () => {
+    mockedGhRaw.mockResolvedValue(
+      success(
+        "Your local stack diverged\nSync aborted \u2014 no changes were made\n",
+      ),
+    );
+
+    const result = await stackCommand(["sync"]);
+
+    expect(result).toContain("status: aborted");
+    expect(result).not.toContain("status: ok");
   });
 
   it("reports malformed view output as a structured error", async () => {

--- a/test/commands/stack.test.ts
+++ b/test/commands/stack.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/gh.js", () => ({ ghRaw: vi.fn() }));
+
+import { ghRaw } from "../../src/gh.js";
+import { stackCommand, STACK_HELP } from "../../src/commands/stack.js";
+import { AxiError } from "../../src/errors.js";
+
+const mockedGhRaw = vi.mocked(ghRaw);
+
+function success(stdout = "", stderr = "") {
+  return { stdout, stderr, exitCode: 0 };
+}
+
+describe("stackCommand", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedGhRaw.mockResolvedValue(success());
+  });
+
+  it("returns help without invoking gh", async () => {
+    expect(await stackCommand([])).toBe(STACK_HELP);
+    expect(mockedGhRaw).not.toHaveBeenCalled();
+  });
+
+  it("renders gh-stack JSON view as TOON and forces JSON mode", async () => {
+    mockedGhRaw.mockResolvedValue(
+      success(
+        JSON.stringify({
+          trunk: "main",
+          currentBranch: "api",
+          branches: [
+            {
+              name: "model",
+              head: "abc",
+              base: "def",
+              isCurrent: false,
+              isMerged: false,
+              isQueued: false,
+              needsRebase: false,
+              pr: {
+                number: 42,
+                url: "https://github.com/o/r/pull/42",
+                state: "OPEN",
+              },
+            },
+            {
+              name: "api",
+              isCurrent: true,
+              isMerged: false,
+              isQueued: false,
+              needsRebase: true,
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await stackCommand(["view"]);
+
+    expect(mockedGhRaw).toHaveBeenCalledWith(["stack", "view", "--json"]);
+    expect(result).toContain("current_branch: api");
+    expect(result).toContain("branch_count: 2");
+    expect(result).toContain("https://github.com/o/r/pull/42");
+    expect(result).toContain("needs_rebase");
+    expect(result).toContain("stack submit");
+  });
+
+  it("rejects unsupported view flags before invoking gh", async () => {
+    await expect(stackCommand(["view", "--short"])).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+    expect(mockedGhRaw).not.toHaveBeenCalled();
+  });
+
+  it("forces submit into auto mode", async () => {
+    const result = await stackCommand(["submit", "--open"]);
+
+    expect(mockedGhRaw).toHaveBeenCalledWith([
+      "stack",
+      "submit",
+      "--open",
+      "--auto",
+    ]);
+    expect(result).toContain("status: ok");
+  });
+
+  it("requires a merge target and forces confirmation", async () => {
+    await expect(stackCommand(["merge"])).rejects.toBeInstanceOf(AxiError);
+    await stackCommand(["merge", "42", "--squash"]);
+
+    expect(mockedGhRaw).toHaveBeenCalledWith([
+      "stack",
+      "merge",
+      "42",
+      "--squash",
+      "--yes",
+    ]);
+
+    await stackCommand(["merge", "43", "--yes"]);
+    expect(mockedGhRaw).toHaveBeenLastCalledWith([
+      "stack",
+      "merge",
+      "43",
+      "--yes",
+    ]);
+  });
+
+  it("requires explicit branches for init and checkout", async () => {
+    await expect(stackCommand(["init"])).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+    await expect(stackCommand(["checkout"])).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+    expect(mockedGhRaw).not.toHaveBeenCalled();
+  });
+
+  it("validates add staging flags and supports bundled -Am", async () => {
+    await expect(stackCommand(["add", "-A"])).rejects.toThrow(
+      /require --message/,
+    );
+    await stackCommand(["add", "-Am", "Add API", "api"]);
+
+    expect(mockedGhRaw).toHaveBeenCalledWith([
+      "stack",
+      "add",
+      "-Am",
+      "Add API",
+      "api",
+    ]);
+  });
+
+  it("allows a message to generate the next branch name", async () => {
+    await stackCommand(["add", "--message=Add API"]);
+
+    expect(mockedGhRaw).toHaveBeenCalledWith([
+      "stack",
+      "add",
+      "--message=Add API",
+    ]);
+  });
+
+  it("rejects zero navigation distance", async () => {
+    await expect(stackCommand(["up", "0"])).rejects.toThrow(/positive integer/);
+    await expect(stackCommand(["down", "0"])).rejects.toThrow(
+      /positive integer/,
+    );
+    expect(mockedGhRaw).not.toHaveBeenCalled();
+  });
+
+  it("rejects deferred interactive and human-only subcommands", async () => {
+    for (const subcommand of ["modify", "switch", "alias", "feedback"]) {
+      await expect(stackCommand([subcommand])).rejects.toThrow(
+        `gh stack ${subcommand} directly`,
+      );
+    }
+    expect(mockedGhRaw).not.toHaveBeenCalled();
+  });
+
+  it("preserves stdout and stderr in non-view results", async () => {
+    mockedGhRaw.mockResolvedValue(
+      success("https://github.com/o/r/pull/42\n", "Created PR #42\n"),
+    );
+
+    const result = await stackCommand(["submit"]);
+
+    expect(result).toContain("https://github.com/o/r/pull/42");
+    expect(result).toContain("Created PR #42");
+  });
+
+  it("reports malformed view output as a structured error", async () => {
+    mockedGhRaw.mockResolvedValue(success(JSON.stringify({ trunk: "main" })));
+
+    await expect(stackCommand(["view"])).rejects.toMatchObject({
+      code: "UNKNOWN",
+      message: expect.stringContaining("Unexpected gh stack output"),
+    });
+  });
+
+  it("preserves stack exit codes and recovery suggestions", async () => {
+    mockedGhRaw.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "conflict while rebasing the stack\n",
+      exitCode: 3,
+    });
+
+    await expect(stackCommand(["rebase"])).rejects.toMatchObject({
+      exitCode: 3,
+      code: "STACK_ERROR",
+      suggestions: expect.arrayContaining([
+        expect.stringContaining("--continue"),
+      ]),
+    });
+  });
+
+  it("suggests installing the extension when gh-stack is missing", async () => {
+    mockedGhRaw.mockResolvedValue({
+      stdout: "",
+      stderr: 'unknown command "stack" for "gh"\n',
+      exitCode: 1,
+    });
+
+    await expect(stackCommand(["view"])).rejects.toMatchObject({
+      code: "EXTENSION_NOT_INSTALLED",
+      suggestions: [
+        expect.stringContaining("gh extension install github/gh-stack"),
+      ],
+    });
+  });
+});

--- a/test/commands/stack.test.ts
+++ b/test/commands/stack.test.ts
@@ -2,15 +2,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/gh.js", () => ({ ghRaw: vi.fn() }));
 vi.mock("../../src/stack-remote.js", () => ({
+  resolveStackLinkRemote: vi.fn(),
   resolveStackRemote: vi.fn(),
 }));
 
 import { ghRaw } from "../../src/gh.js";
-import { resolveStackRemote } from "../../src/stack-remote.js";
+import {
+  resolveStackLinkRemote,
+  resolveStackRemote,
+} from "../../src/stack-remote.js";
 import { stackCommand, STACK_HELP } from "../../src/commands/stack.js";
 import { AxiError } from "../../src/errors.js";
 
 const mockedGhRaw = vi.mocked(ghRaw);
+const mockedResolveStackLinkRemote = vi.mocked(resolveStackLinkRemote);
 const mockedResolveStackRemote = vi.mocked(resolveStackRemote);
 
 function success(stdout = "", stderr = "") {
@@ -21,6 +26,7 @@ describe("stackCommand", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     mockedGhRaw.mockResolvedValue(success());
+    mockedResolveStackLinkRemote.mockImplementation(async (args) => args);
     mockedResolveStackRemote.mockImplementation(async (args) => args);
   });
 
@@ -201,6 +207,40 @@ describe("stackCommand", () => {
 
     expect(result).toContain("status: aborted");
     expect(result).not.toContain("status: ok");
+  });
+
+  it("uses link branch refs to resolve its remote", async () => {
+    mockedResolveStackLinkRemote.mockResolvedValue([
+      "--base",
+      "main",
+      "feature-a",
+      "feature-b",
+      "--remote",
+      "fork",
+    ]);
+
+    await stackCommand([
+      "link",
+      "--base",
+      "main",
+      "feature-a",
+      "feature-b",
+    ]);
+
+    expect(mockedResolveStackLinkRemote).toHaveBeenCalledWith(
+      ["--base", "main", "feature-a", "feature-b"],
+      ["feature-a", "feature-b"],
+    );
+    expect(mockedGhRaw).toHaveBeenCalledWith([
+      "stack",
+      "link",
+      "--base",
+      "main",
+      "feature-a",
+      "feature-b",
+      "--remote",
+      "fork",
+    ]);
   });
 
   it("reports malformed view output as a structured error", async () => {

--- a/test/commands/stack.test.ts
+++ b/test/commands/stack.test.ts
@@ -132,6 +132,9 @@ describe("stackCommand", () => {
     await expect(stackCommand(["add", "-A"])).rejects.toThrow(
       /require --message/,
     );
+    await expect(stackCommand(["add", "-Au", "-m", "Add API"])).rejects.toThrow(
+      "Choose only one of --all or --update",
+    );
     await stackCommand(["add", "-Am", "Add API", "api"]);
 
     expect(mockedGhRaw).toHaveBeenCalledWith([
@@ -219,13 +222,7 @@ describe("stackCommand", () => {
       "fork",
     ]);
 
-    await stackCommand([
-      "link",
-      "--base",
-      "main",
-      "feature-a",
-      "feature-b",
-    ]);
+    await stackCommand(["link", "--base", "main", "feature-a", "feature-b"]);
 
     expect(mockedResolveStackLinkRemote).toHaveBeenCalledWith(
       ["--base", "main", "feature-a", "feature-b"],

--- a/test/help-examples.test.ts
+++ b/test/help-examples.test.ts
@@ -12,6 +12,7 @@ import { VARIABLE_HELP } from "../src/commands/variable.js";
 import { SEARCH_HELP } from "../src/commands/search.js";
 import { API_HELP } from "../src/commands/api.js";
 import { GIST_HELP } from "../src/commands/gist.js";
+import { STACK_HELP } from "../src/commands/stack.js";
 import { TOP_HELP } from "../src/cli.js";
 
 /**
@@ -59,6 +60,15 @@ describe("Help output includes examples for every command family", () => {
   assertHelpHasExamples("SEARCH_HELP", SEARCH_HELP);
   assertHelpHasExamples("API_HELP", API_HELP);
   assertHelpHasExamples("GIST_HELP", GIST_HELP);
+  assertHelpHasExamples("STACK_HELP", STACK_HELP);
+});
+
+describe("STACK_HELP contract", () => {
+  it("documents the extension prerequisite and non-interactive gates", () => {
+    expect(STACK_HELP).toContain("gh extension install github/gh-stack");
+    expect(STACK_HELP).toContain("--auto");
+    expect(STACK_HELP).toContain("--yes is automatic");
+  });
 });
 
 describe("--body-file discoverability", () => {

--- a/test/help-examples.test.ts
+++ b/test/help-examples.test.ts
@@ -12,8 +12,7 @@ import { VARIABLE_HELP } from "../src/commands/variable.js";
 import { SEARCH_HELP } from "../src/commands/search.js";
 import { API_HELP } from "../src/commands/api.js";
 import { GIST_HELP } from "../src/commands/gist.js";
-import { STACK_HELP } from "../src/commands/stack.js";
-import { TOP_HELP } from "../src/cli.js";
+import { main, TOP_HELP } from "../src/cli.js";
 
 /**
  * Every HELP constant must contain an "examples:" section with at least 2
@@ -60,14 +59,33 @@ describe("Help output includes examples for every command family", () => {
   assertHelpHasExamples("SEARCH_HELP", SEARCH_HELP);
   assertHelpHasExamples("API_HELP", API_HELP);
   assertHelpHasExamples("GIST_HELP", GIST_HELP);
-  assertHelpHasExamples("STACK_HELP", STACK_HELP);
 });
 
-describe("STACK_HELP contract", () => {
-  it("documents the extension prerequisite and non-interactive gates", () => {
-    expect(STACK_HELP).toContain("gh extension install github/gh-stack");
-    expect(STACK_HELP).toContain("--auto");
-    expect(STACK_HELP).toContain("--yes is automatic");
+describe("stack help", () => {
+  it("prints the extension prerequisite and non-interactive gates", async () => {
+    let rendered = "";
+    await main({
+      argv: ["stack", "--help"],
+      stdout: {
+        write(chunk: string) {
+          rendered += chunk;
+        },
+      },
+    });
+
+    const examples = rendered
+      .slice(rendered.indexOf("examples:"))
+      .split("\n")
+      .filter((line) => line.trim().startsWith("gh-axi"));
+    expect(examples.length).toBeGreaterThanOrEqual(2);
+    expect(examples).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^ {2}gh-axi/),
+      ]),
+    );
+    expect(rendered).toContain("gh extension install github/gh-stack");
+    expect(rendered).toContain("--auto");
+    expect(rendered).toContain("--yes is automatic");
   });
 });
 

--- a/test/help-examples.test.ts
+++ b/test/help-examples.test.ts
@@ -79,9 +79,7 @@ describe("stack help", () => {
       .filter((line) => line.trim().startsWith("gh-axi"));
     expect(examples.length).toBeGreaterThanOrEqual(2);
     expect(examples).toEqual(
-      expect.arrayContaining([
-        expect.stringMatching(/^ {2}gh-axi/),
-      ]),
+      expect.arrayContaining([expect.stringMatching(/^ {2}gh-axi/)]),
     );
     expect(rendered).toContain("gh extension install github/gh-stack");
     expect(rendered).toContain("--auto");

--- a/test/no-mistakes-required.test.ts
+++ b/test/no-mistakes-required.test.ts
@@ -1,0 +1,162 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const marker =
+  "Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)";
+
+type WorkflowStep = {
+  name?: unknown;
+  env?: unknown;
+  run?: unknown;
+};
+
+type NoMistakesWorkflow = {
+  permissions?: unknown;
+  jobs?: {
+    check?: {
+      steps?: unknown;
+    };
+  };
+};
+
+function signatureCheck(): {
+  permissions: Record<string, unknown>;
+  env: Record<string, string>;
+  run: string;
+} {
+  const workflow = parse(
+    readFileSync(
+      join(root, ".github", "workflows", "no-mistakes-required.yml"),
+      "utf8",
+    ),
+  ) as NoMistakesWorkflow;
+  if (
+    typeof workflow.permissions !== "object" ||
+    workflow.permissions === null ||
+    Array.isArray(workflow.permissions)
+  ) {
+    throw new Error("no-mistakes workflow has no permissions");
+  }
+
+  const step = workflow.jobs?.check?.steps;
+  if (!Array.isArray(step)) {
+    throw new Error("no-mistakes workflow check has no steps");
+  }
+
+  const signatureStep = step.find(
+    (candidate): candidate is WorkflowStep =>
+      typeof candidate === "object" &&
+      candidate !== null &&
+      (candidate as WorkflowStep).name ===
+        "Verify no-mistakes signature in PR body",
+  );
+  if (!signatureStep || typeof signatureStep.run !== "string") {
+    throw new Error("no-mistakes signature check has no executable script");
+  }
+  if (
+    typeof signatureStep.env !== "object" ||
+    signatureStep.env === null ||
+    Array.isArray(signatureStep.env)
+  ) {
+    throw new Error("no-mistakes signature check has no environment");
+  }
+
+  const env = Object.fromEntries(
+    Object.entries(signatureStep.env).map(([key, value]) => [
+      key,
+      String(value),
+    ]),
+  );
+  return {
+    permissions: workflow.permissions as Record<string, unknown>,
+    env,
+    run: signatureStep.run,
+  };
+}
+
+function runSignatureCheck(currentPrBody: string, eventPrBody: string) {
+  const { run } = signatureCheck();
+  const directory = mkdtempSync(join(tmpdir(), "gh-axi-no-mistakes-"));
+  try {
+    const gh = join(directory, "gh");
+    writeFileSync(
+      gh,
+      `#!/bin/sh
+set -eu
+[ "$#" -eq 4 ]
+[ "$1" = "api" ]
+[ "$2" = "repos/\${PR_REPOSITORY}/pulls/\${PR_NUMBER}" ]
+[ "$3" = "--jq" ]
+[ "$4" = ".body" ]
+printf '%s' "$CURRENT_PR_BODY"
+`,
+      "utf8",
+    );
+    chmodSync(gh, 0o755);
+
+    return spawnSync("bash", ["-c", run], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CURRENT_PR_BODY: currentPrBody,
+        GH_TOKEN: "test-token",
+        PATH: `${directory}${delimiter}${process.env.PATH ?? ""}`,
+        PR_AUTHOR: "octocat",
+        PR_BODY: eventPrBody,
+        PR_NUMBER: "108",
+        PR_REPOSITORY: "octo/widgets",
+      },
+    });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+describe("no-mistakes PR body workflow", () => {
+  it("checks the current PR body when the event body is stale", () => {
+    const { permissions, env } = signatureCheck();
+
+    expect(permissions).toMatchObject({
+      contents: "read",
+      "pull-requests": "read",
+    });
+    expect(env).toMatchObject({
+      GH_TOKEN: "${{ github.token }}",
+      PR_NUMBER: "${{ github.event.pull_request.number }}",
+      PR_REPOSITORY: "${{ github.repository }}",
+    });
+    const result = runSignatureCheck(
+      `## Pipeline\n\n${marker}`,
+      "PR body before no-mistakes wrote its signature",
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "Found no-mistakes signature in PR #108 body.",
+    );
+  });
+
+  it("rejects a current PR body without the signature", () => {
+    const result = runSignatureCheck(
+      "An unsigned PR body",
+      `## Pipeline\n\n${marker}`,
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "This PR was not raised through no-mistakes.",
+    );
+  });
+});

--- a/test/skill.test.ts
+++ b/test/skill.test.ts
@@ -72,6 +72,13 @@ describe("createSkillMarkdown", () => {
     const markdown = createSkillMarkdown();
     expect(markdown).toContain("gh auth login");
   });
+
+  it("documents the stacked PR extension and safe workflow", () => {
+    const markdown = createSkillMarkdown();
+    expect(markdown).toContain("gh extension install github/gh-stack");
+    expect(markdown).toContain("stack submit --open");
+    expect(markdown).toContain("stack view` uses `--json`");
+  });
 });
 
 describe("extractCommandsBlock", () => {

--- a/test/stack-remote.test.ts
+++ b/test/stack-remote.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { resolveStackRemote } from "../src/stack-remote.js";
+import {
+  resolveStackLinkRemote,
+  resolveStackRemote,
+} from "../src/stack-remote.js";
 
 type Result = { stdout: string; exitCode: number };
 
@@ -52,5 +55,56 @@ describe("resolveStackRemote", () => {
 
     expect(args).toEqual(["--remote", "upstream"]);
     expect(runGit).not.toHaveBeenCalled();
+  });
+
+  it("uses the first linked local branch's push remote", async () => {
+    const runGit = vi.fn(
+      runner({
+        "for-each-ref --format=%(refname:short) refs/heads": {
+          stdout: "current\nfeature-a\nfeature-b\n",
+          exitCode: 0,
+        },
+        "config --get branch.feature-a.pushRemote": {
+          stdout: "fork\n",
+          exitCode: 0,
+        },
+      }),
+    );
+
+    const args = await resolveStackLinkRemote(
+      ["feature-a", "feature-b"],
+      ["feature-a", "feature-b"],
+      runGit,
+    );
+
+    expect(args).toEqual(["feature-a", "feature-b", "--remote", "fork"]);
+    expect(runGit).toHaveBeenCalledWith([
+      "config",
+      "--get",
+      "branch.feature-a.pushRemote",
+    ]);
+    expect(runGit).not.toHaveBeenCalledWith([
+      "symbolic-ref",
+      "--quiet",
+      "--short",
+      "HEAD",
+    ]);
+  });
+
+  it("does not inject a remote when links contain only pull requests", async () => {
+    const runGit = vi.fn(
+      runner({
+        "for-each-ref --format=%(refname:short) refs/heads": {
+          stdout: "feature-a\n",
+          exitCode: 0,
+        },
+      }),
+    );
+    const refs = ["42", "https://github.com/owner/repo/pull/43"];
+
+    const args = await resolveStackLinkRemote(refs, refs, runGit);
+
+    expect(args).toEqual(refs);
+    expect(runGit).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/stack-remote.test.ts
+++ b/test/stack-remote.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveStackRemote } from "../src/stack-remote.js";
+
+type Result = { stdout: string; exitCode: number };
+
+function runner(responses: Record<string, Result>) {
+  return async (args: string[]): Promise<Result> =>
+    responses[args.join(" ")] ?? { stdout: "", exitCode: 1 };
+}
+
+describe("resolveStackRemote", () => {
+  it("uses git's configured remote priority", async () => {
+    const args = await resolveStackRemote(
+      ["--open", "--auto"],
+      runner({
+        "symbolic-ref --quiet --short HEAD": {
+          stdout: "feature\n",
+          exitCode: 0,
+        },
+        "config --get branch.feature.pushRemote": {
+          stdout: "fork\n",
+          exitCode: 0,
+        },
+      }),
+    );
+
+    expect(args).toEqual(["--open", "--auto", "--remote", "fork"]);
+  });
+
+  it("rejects multiple remotes without a configured default", async () => {
+    await expect(
+      resolveStackRemote(
+        [],
+        runner({
+          "symbolic-ref --quiet --short HEAD": {
+            stdout: "feature\n",
+            exitCode: 0,
+          },
+          remote: { stdout: "fork\norigin\n", exitCode: 0 },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("--remote <name>"),
+    });
+  });
+
+  it("preserves an explicit remote without reading git configuration", async () => {
+    const runGit = vi.fn();
+
+    const args = await resolveStackRemote(["--remote", "upstream"], runGit);
+
+    expect(args).toEqual(["--remote", "upstream"]);
+    expect(runGit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Intent

Add agent-safe support for GitHub stacked PRs through gh-stack.

## What Changed
- Add a non-interactive `gh-axi stack` adapter for the official `gh-stack` extension, including stack lifecycle, navigation, submission, rebasing, linking, and merging commands.
- Render stack views as TOON, resolve safe remotes for remote operations, preserve extension exit codes, and reject repository overrides for checkout-bound commands.
- Document stack prerequisites and agent-safe usage in the README and generated skill.

## Risk Assessment

✅ Low: The adapter is bounded to the current checkout, forces documented non-interactive forms, and preserves gh-stack exit states.

## Testing

Inspected the target change and installed gh-stack interface, ran focused stack tests, and exercised real gh-stack initialization and TOON view output in an isolated local repository. Controlled end-to-end transcripts confirm forced non-interactive flags, local-checkout guards, extension-install guidance, and preserved conflict exit codes. No live GitHub mutations were performed.

<details>
<summary>Evidence: Real gh-stack local stack lifecycle transcript</summary>

```text

$ gh-axi stack init feature-model feature-api
stack:
  action: init
  status: ok
  stdout: ""
  stderr: "✓ Created stack: main ← feature-model ← feature-api\n  You're on feature-api (top of stack).\n\nWhat's next:\n  • commit your work as usual, then add a layer:  gh stack add\n  • see your stack any time:                      gh stack view\n  • when ready to open PRs:                       gh stack submit\n"
help[2]:
  Run `gh-axi stack add -Am "<message>" <branch>` to add the next layer
  Run `gh-axi stack submit` to create the stack's pull requests
[exit 0]

$ gh-axi stack view
stack:
  trunk: main
  current_branch: feature-api
  branch_count: 2
  branches[2]{name,head,base,current,merged,queued,needs_rebase,pr}:
    feature-model,null,2489f0e8919cf26565337415c742530ffbf61a5c,false,false,false,false,null
    feature-api,null,2489f0e8919cf26565337415c742530ffbf61a5c,true,false,false,false,null
help[2]:
  Run `gh-axi stack submit` to push and open/update the stack's PRs
  Run `gh-axi stack sync` to reconcile local and remote stack state
[exit 0]

$ git branch --format="%(refname:short)"
feature-api
feature-model
main
[exit 0]
```
</details>
<details>
<summary>Evidence: Agent-safety and error-handling CLI transcript</summary>

```text

$ PATH=<fake-gh>:$PATH corepack pnpm exec tsx bin/gh-axi.ts stack view
stack:
  trunk: main
  current_branch: feature-api
  branch_count: 2
  branches[2]:
    - name: feature-model
      head: 111aaa
      base: main
      current: false
      merged: false
      queued: false
      needs_rebase: false
      pr:
        number: 41
        url: "https://github.com/acme/widgets/pull/41"
        state: open
    - name: feature-api
      head: 222bbb
      base: feature-model
      current: true
      merged: false
      queued: false
      needs_rebase: true
      pr:
        number: 42
        url: "https://github.com/acme/widgets/pull/42"
        state: open
help[2]:
  Run `gh-axi stack submit` to push and open/update the stack's PRs
  Run `gh-axi stack sync` to reconcile local and remote stack state
[exit 0]

$ PATH=<fake-gh>:$PATH corepack pnpm exec tsx bin/gh-axi.ts stack submit --open --remote origin
stack:
  action: submit
  status: ok
  stdout: "https://github.com/acme/widgets/pull/41\n"
  stderr: "Created stacked pull requests\n"
help[2]:
  Run `gh-axi stack view` to inspect branch and PR status
  Run `gh-axi stack sync` to refresh the stack after review changes
[exit 0]

$ PATH=<fake-gh>:$PATH corepack pnpm exec tsx bin/gh-axi.ts stack submit --repo acme/other
error: "stack commands operate on the repository in the current working directory and do not support -R, --repo, or GH_REPO"
code: VALIDATION_ERROR
help[1]: Run `gh-axi stack` from a checkout of the target repository
[exit 2]

$ GH_REPO=acme/other PATH=<fake-gh>:$PATH corepack pnpm exec tsx bin/gh-axi.ts stack submit
error: "stack commands operate on the repository in the current working directory and do not support -R, --repo, or GH_REPO"
code: VALIDATION_ERROR
help[1]: Run `gh-axi stack` from a checkout of the target repository
[exit 2]

$ FAKE_GH_MODE=missing PATH=<fake-gh>:$PATH corepack pnpm exec tsx bin/gh-axi.ts stack view
error: The official gh-stack extension is not installed
code: EXTENSION_NOT_INSTALLED
help[1]: Run `gh extension install github/gh-stack` to install it
[exit 1]

$ FAKE_GH_MODE=conflict PATH=<fake-gh>:$PATH corepack pnpm exec tsx bin/gh-axi.ts stack rebase
error: conflict while rebasing the stack
code: STACK_ERROR
help[2]: "Resolve conflicts, stage files with `git add`, then run `gh-axi stack rebase --continue`",Run `gh-axi stack rebase --abort` to restore the stack
[exit 3]

--- fake gh calls ---
stack view --json
stack submit --open --remote origin --auto
stack view --json
stack rebase --remote origin
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9e521dfda75ee645146ccaa8e10c9b777da1fe94","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `corepack pnpm exec vitest run test/commands/stack.test.ts test/stack-remote.test.ts test/cli.test.ts test/help-examples.test.ts test/skill.test.ts`
- <code>`gh stack &lt;subcommand&gt; --help` for every wrapped gh-stack command</code>
- <code>Disposable local-repository E2E: `gh-axi stack init feature-model feature-api` then `gh-axi stack view` using the installed official gh-stack extension</code>
- <code>Controlled CLI boundary checks for `stack view`, `stack submit --open --remote origin`, `--repo` and `GH_REPO` rejection, missing-extension recovery, and rebase conflict exit-code preservation</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
