### PR TITLE
chore: update pull request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Never expose an interactive path. Force `view --json`, `submit --auto`, and `mer
 
 ## Raising PRs to upstream
 
-Human-authored PRs targeting `main` must be raised through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes) (`no-mistakes init --fork-url git@github.com:onyx-space/gh-axi.git`, then `git push no-mistakes`): the `Require no-mistakes` workflow fails any PR whose body lacks the pipeline's deterministic signature, and maintainer triage treats hand-raised PRs as blocked. Do not push a PR branch straight to `origin`. See CONTRIBUTING.md.
+Human-authored PRs targeting `main` must be raised through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes) (`no-mistakes init --fork-url git@github.com:<you>/gh-axi.git`, then `git push no-mistakes`): the `Require no-mistakes` workflow fails any PR whose body lacks the pipeline's deterministic signature, and maintainer triage treats hand-raised PRs as blocked. Do not push a PR branch straight to `origin`. See CONTRIBUTING.md.
 
 ## Maintaining this file
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,10 @@ Stack commands are cwd-bound. `cli.ts#withLocalRepoContext` rejects explicit rep
 Successful extension status is commonly written to stderr, and exits 2-10 represent actionable stack state. Preserve both streams and the exact `StackError.exitCode`, which reaches the shell only through `cli.ts`'s `formatError` hook; do not replace `ghRaw` with `ghExec` or generic `mapGhError`.
 Never expose an interactive path. Force `view --json`, `submit --auto`, and `merge --yes`; require arguments for commands that otherwise prompt. Keep `modify`, `switch`, `alias`, and `feedback` out unless upstream gains a useful headless interface.
 
+## Raising PRs to upstream
+
+Human-authored PRs targeting `main` must be raised through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes) (`no-mistakes init --fork-url git@github.com:onyx-space/gh-axi.git`, then `git push no-mistakes`): the `Require no-mistakes` workflow fails any PR whose body lacks the pipeline's deterministic signature, and maintainer triage treats hand-raised PRs as blocked. Do not push a PR branch straight to `origin`. See CONTRIBUTING.md.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.


### PR DESCRIPTION
## What Changed

Final changed paths and statuses:

```text
M	AGENTS.md
```

## Risk Assessment

✅ Low: 范围明确，纯为对代理记忆的文档变更，其每条声明（工作流名称、签名要求、fork 命令、CONTRIBUTING 引用）均已对照实际工作流和贡献文档核实无误。

## Testing

纯文档改动（AGENTS.md 新增 PR 提交流程说明）。验证了文档中每个可机械核对的主张：Require no-mistakes 工作流真实存在并对缺签名的 main 分支 PR 失败（复刻其检查逻辑模拟两种 body 复现失败/通过路径）、no-mistakes CLI 的 --fork-url 标志真实存在、CONTRIBUTING.md 引用有效且内容一致、markdown 经 pandoc 渲染为有效 GFM。唯一无法机械验证的是 'maintainer triage treats hand-raised PRs as blocked' 这一流程性表述（仓库内无其他佐证，但工作流报错文案 'must be submitted via git push no-mistakes' 与其精神一致），属正常文档陈述而非缺陷。无测试失败，无需修复。

<details>
<summary>Evidence: Require no-mistakes 工作流签名检查模拟（无签名 FAIL / 有签名 PASS）</summary>

```text
=== Simulating 'Require no-mistakes' workflow check (logic copied from .github/workflows/no-mistakes-required.yml) ===

--- Case 1: PR body WITHOUT no-mistakes signature (hand-raised PR) ---
RESULT: FAIL -> workflow would error: 'This PR was not raised through no-mistakes.'

--- Case 2: PR body WITH no-mistakes signature (raised via git push no-mistakes) ---
RESULT: PASS (signature found)
```
</details>
<details>
<summary>Evidence: AGENTS.md 经 pandoc (GFM) 渲染的 HTML（验证 markdown 有效性与链接/代码 span 解析）</summary>

```text
<h1 id="project-agent-memory">Project agent memory</h1>
<p>This file is the project's committed home for project-intrinsic agent
knowledge: build, test, release, architecture, and sharp-edge notes that
should travel with the code.</p>
<ul>
<li>Add durable project-specific notes here as they are discovered
through real work.</li>
</ul>
<h2 id="dependency-bumps-and-the-lockfile">Dependency bumps and the
lockfile</h2>
<p>The committed <code>pnpm-lock.yaml</code> is Prettier-formatted
(multi-line <code>resolution:</code> and <code>engines:</code> blocks),
which is not pnpm's native output format. A plain
<code>pnpm install</code> rewrites those blocks inline and produces a
~1000-line cosmetic churn even when only one dependency actually
changed. After bumping a dependency, run
<code>pnpm exec prettier --write pnpm-lock.yaml</code> so the diff
collapses to just the real change. CI uses
<code>pnpm install --frozen-lockfile</code>, which parses the YAML
structurally and accepts the Prettier-formatted lockfile, so the
formatting does not break the frozen-install check.</p>
<h2 id="the-sdk-provided-update-command">The SDK-provided
<code>update</code> command</h2>
<p><code>gh-axi</code> runs its CLI through <code>runAxiCli</code> from
<code>axi-sdk-js</code> (<code>src/cli.ts</code>) and registers no
<code>update</code> command of its own. Since
<code>axi-sdk-js@0.1.8</code> ships <code>update</code> as a
<code>RESERVED_COMMANDS</code> built-in, <code>gh-axi</code> inherits
<code>gh-axi update</code> for free, and the SDK auto-resolves the npm
package name (<code>gh-axi</code>) by walking up to the nearest
<code>package.json</code>. The SDK also appends a
<code>"built-in":</code> section to the top-level <code>--help</code>
output at runtime, so <code>src/cli.ts</code>'s <code>TOP_HELP</code>
constant is a prefix of the rendered help rather than the whole
thing.</p>
<h2 id="release-process">Release process</h2>
<p>Releases are cut by release-please from conventional commit messages
on <code>main</code>; merging the bot's release PR triggers
<code>npm publish</code> via
<code>.github/workflows/release-please.yml</code>. Do not hand-edit
<code>CHANGELOG.md</code> or <code>.release-please-manifest.json</code>
(a guard workflow blocks PRs that touch them), and regenerate
<code>skills/gh-axi/SKILL.md</code> with
<code>pnpm run build:skill</code> instead of editing it directly.</p>
<p>Every <code>pull_request</code> workflow (<code>ci.yml</code>,
<code>guard-generated-files.yml</code>,
<code>no-mistakes-required.yml</code>) uses <code>paths-ignore</code>
for the release-please output set
(<code>.release-please-manifest.json</code>, <code>CHANGELOG.md</code>,
<code>package.json</code>) so release PRs create zero runs. Job-level
bot <code>if</code>s stay as defense in depth.
<code>test/release-ci-exclusions.test.ts</code> derives that set from
<code>release-please-config.json</code> and fails if a workflow drifts;
update the ignore lists when adding <code>extra-files</code> or changing
<code>release-type</code>.</p>
<h2 id="github-enterprise-host-support-srchostts-srcclits">GitHub
Enterprise host support (<code>src/host.ts</code>,
<code>src/cli.ts</code>)</h2>
<p><code>gh-axi</code> targets a custom GitHub host (e.g. a GHE server
like <code>ghe.example.com</code>) via a global
<code>--hostname &lt;host&gt;</code> flag or the <code>GH_HOST</code>
env var; explicit <code>--hostname</code> wins. Like
<code>-R</code>/<code>--repo</code>, <code>--hostname</code> must come
<em>after</em> the command (the SDK rejects leading flags), and it is
stripped from the args before they reach the underlying <code>gh</code>
(it is never a subcommand flag). <code>src/cli.ts</code>'s
<code>resolveContext</code> sets <code>process.env.GH_HOST</code> only
when <code>--hostname</code> is present; the child <code>gh</code>
process inherits <code>process.env</code>, so no explicit env is
threaded through <code>gh.ts</code>. When no <code>--hostname</code> is
given, <code>GH_HOST</code> is left untouched, keeping the default
(github.com) behavior byte-for-byte identical.
<code>src/host.ts#resolveHost()</code> (flag &gt; <code>GH_HOST</code>
&gt; <code>github.com</code>) is the single source of truth for the
effective host used when <em>building or parsing</em> URLs —
<code>parseRemoteUrl</code> in <code>src/context.ts</code> matches the
configured host in <code>git remote</code> URLs, and
<code>issue transfer</code>'s fallback URL is built as
<code>https://&lt;host&gt;/...</code>. The <code>gh pr create</code>
output regex (<code>/pull/(\d+)/</code>) is already host-agnostic.</p>
<h2
id="secretvariable-value-input-srcsecretvaluets-srcstdints-ghtsghexecwithstdin">Secret/variable
value input (<code>src/secretValue.ts</code>, <code>src/stdin.ts</code>,
<code>gh.ts#ghExecWithStdin</code>)</h2>
<p><code>gh secret list</code>/<code>gh variable list</code> do not
support <code>--limit</code> or any pagination flag (unlike
<code>issue</code>/<code>pr</code>/<code>release</code> list), so
<code>secret.ts</code>/<code>variable.ts</code> list all results in one
call with no <code>--limit</code> flag of their own.</p>
<p>Secret values must never appear in argv (visible via <code>ps</code>)
or stdout. <code>secretCommand</code>'s <code>set</code> subcommand is
stdin-only: it rejects <code>--body</code>/<code>-b</code>, calls
<code>resolveValue(undefined, "secret")</code>, and pipes the resolved
value to <code>gh.ts#ghExecWithStdin</code> so the wrapped
<code>gh secret set</code> child also never receives the value in argv.
Variable values are not treated as secrets:
<code>variableCommand</code>'s <code>set</code> subcommand may resolve
the value from <code>--body</code>/<code>-b</code> or piped stdin
(<code>resolveValue</code> in <code>src/secretValue.ts</code>, backed by
<code>src/stdin.ts</code>), and <code>gh-axi variable list</code>
intentionally prints variable values. <code>variable set --body</code>
values are visible in the <code>gh-axi</code> process argv, but
<code>ghExecWithStdin</code> still keeps them out of the child
<code>gh variable set</code> argv. <code>resolveValue</code> throws
immediately instead of blocking when stdin is an interactive TTY and no
usable value source was provided, since AXI commands must never hang
waiting for interactive input.</p>
<p><code>secretCommand</code>'s
<code>list</code>/<code>set</code>/<code>delete</code> forward
<code>--env</code>/<code>-e &lt;environment&gt;</code> to
<code>gh secret ... --env</code> via <code>resolveScope</code> in
<code>src/commands/secret.ts</code>; the repo/host context flags are
already stripped in <code>cli.ts</code> before the command sees its
args, so <code>-R</code>/<code>--hostname</code> compose with
<code>--env</code> for free. <code>resolveScope</code> is deliberately
strict: a malformed <code>--env</code> (missing/empty value),
conflicting <code>--env</code> flags, gh's other scopes
(<code>--org</code>/<code>--user</code>/<code>--app</code>, plus the
value-channel <code>--env-file</code>), and any unknown flag all throw
loudly rather than silently falling back to repo scope. Unknown flags
are echoed by name only (the <code>=value</code> is stripped) so a
secret value can never leak into an error message.</p>
<h2
id="user-scoped-commands-srccommandsgistts-srccommandsprojectts">User-scoped
commands (<code>src/commands/gist.ts</code>,
<code>src/commands/project.ts</code>)</h2>
<p>Some GitHub API endpoints are user-scoped rather than repo-scoped:
<code>gh api /gists</code> and <code>gh project</code> have no
<code>--repo</code> flag and reject it if supplied.
<code>gh.ts#buildArgs</code> auto-appends
<code>--repo &lt;nwo&gt;</code> for any <code>RepoContext</code> whose
<code>source !== "git"</code>, so passing ctx to <code>ghJson</code>
from these handlers would inject a flag the CLI rejects. The fix is
structural: these command functions omit the <code>ctx</code> parameter
entirely (TypeScript accepts <code>(args: string[])</code> as
<code>CommandFn</code> because fewer params are always assignable).
<code>cli.ts</code>'s <code>withRepoContext</code> wrapper still
resolves a context for other commands — it just never reaches
<code>ghJson</code> in the user-scoped handlers. <code>gist.ts</code>
follows this pattern; <code>project.ts</code> does too (though it
additionally uses ctx?.owner for owner defaulting, it never forwards ctx
to <code>ghJson</code>).</p>
<h2 id="github-projects-gh-project-support-srccommandsprojectts">GitHub
Projects (<code>gh project</code>) support
(<code>src/commands/project.ts</code>)</h2>
<p>Unlike every other command family, <code>gh project</code> is
owner-scoped (<code>--owner &lt;login&gt;</code>), not repo-scoped — it
has no <code>--repo</code> flag at all. <code>project.ts</code>'s
subfunctions therefore never pass <code>RepoContext</code> as the second
arg to <code>ghJson</code> (matching <code>search.ts</code>'s existing
pattern) — see "User-scoped commands" above for why. Instead,
<code>resolveOwner()</code> defaults <code>--owner</code> to the current
repo's owner (<code>ctx?.owner</code>) when the flag is omitted and a
repo context is available, falling back to explicit <code>@me</code>
otherwise because <code>gh project</code> requires an owner in
non-interactive shells. <code>gh project</code> subcommands use
<code>--format json</code> (whole-object dump), not the
<code>--json field,field</code> selection style used by
<code>issue</code>/<code>pr</code>/<code>release</code>; list-shaped
responses come back wrapped (e.g.
<code>{ projects: [...], totalCount }</code>), not as a bare array.
Since Projects v2 items carry per-project custom fields (Status,
Priority, ...) with no fixed schema,
<code>item-list</code>/<code>field-list</code> render through bespoke
functions
(<code>renderProjectItems</code>/<code>renderProjectFields</code>) that
flatten any unknown scalar top-level key into its own column, rather
than a fixed <code>FieldDef</code> schema. Requires the
<code>project</code> (or <code>read:project</code>) OAuth scope on the
<code>gh</code> token; <code>src/errors.ts</code> matches gh's literal
<code>"authentication token is missing required scopes [...]"</code>
stderr (verified against a live token missing the scope) and maps it to
<code>FORBIDDEN</code> with a
<code>gh auth refresh -s &lt;scope&gt;</code> suggestion — this pattern
is generic, not project-specific, so it also covers other gh features
gated by OAuth scopes.</p>
<h2 id="repeatable-flags-srcargsts">Repeatable flags
(<code>src/args.ts</code>)</h2>
<p><code>gh</code> accepts <code>--label</code>,
<code>--assignee</code>, <code>--reviewer</code>,
<code>--project</code>, and the
<code>--add-*</code>/<code>--remove-*</code> variants once per value, so
gh-axi must collect <em>every</em> occurrence. Use
<code>getAllFlags</code>/<code>takeAllFlags</code> plus
<code>pushRepeated</code>; <code>getFlag</code>/<code>takeFlag</code>
keep only the first occurrence and silently discard the rest, which is
the bug that recurred as #55, #57, and #75. Both collectors reject a
dangling (<code>--label</code> with nothing after it) or blank
(<code>--label=</code>) value with a <code>VALIDATION_ERROR</code>
instead of dropping it. Pick the collector that matches the surrounding
file: <code>issue.ts</code> reads args non-destructively
(<code>getAllFlags</code>), <code>pr.ts</code> consumes them
(<code>takeAllFlags</code>). When a flag becomes repeatable, mark it
<code>(repeatable)</code> in that command's <code>*_HELP</code>
string.</p>
<h2 id="gh-stderr-classification-srcerrorsts">gh stderr classification
(<code>src/errors.ts</code>)</h2>
<p><code>mapGhError</code> walks <code>patterns</code> in order and
returns on the first regex hit, so <strong>order is the
contract</strong>: a narrow, specific pattern must sit ahead of any
broader one it would otherwise be swallowed by. gh sometimes embeds
remediation hints in errors with a different root cause, so check new
patterns against real stderr and place specific carriers of a generic
hint first rather than narrowing the generic match.
<code>test/errors.test.ts</code> pins the repo-resolution and
genuine-auth cases.</p>
<h2
id="--version-fast-path-bingh-axits-srcversionts"><code>--version</code>
fast path (<code>bin/gh-axi.ts</code>, <code>src/version.ts</code>)</h2>
<p><code>bin/gh-axi.ts</code> answers a bare
<code>-v</code>/<code>-V</code>/<code>--version</code> via
<code>tryFastPath</code> from <code>axi-sdk-js/fast-path</code> (a
dependency-free SDK subpath) and only
<code>await import("../src/cli.js")</code> otherwise, so the version
path never loads the command graph (~31ms -&gt; ~20ms, the node floor).
This only works because <code>src/version.ts</code> is a LEAF module
importing node builtins only - <code>cli.ts</code> imports
<code>VERSION</code> from it, never the reverse. Adding any non-builtin
import to <code>src/version.ts</code> silently undoes the speedup.
<code>test/version-fast-path.test.ts</code> guards it deterministically
with a <code>module.register()</code> load-hook trace
(<code>test/fixtures/module-trace-*.mjs</code>) plus a negative control
on <code>--help</code>. Do not add a wall-clock timing assertion; it was
proven flaky under CI contention.</p>
<h2 id="stacked-pr-support-srccommandsstackts">Stacked PR support
(<code>src/commands/stack.ts</code>)</h2>
<p><code>gh-axi stack</code> is deliberately a strict adapter over the
official <code>github/gh-stack</code> extension, not a second stack
engine. Keep local metadata, Git mutation, rebase recovery, and Stacks
API behavior upstream. Stack commands are cwd-bound.
<code>cli.ts#withLocalRepoContext</code> rejects explicit repo flags and
<code>GH_REPO</code>, strips the supported host flag, and never passes a
<code>RepoContext</code> to <code>ghRaw</code>, because the extension
does not accept <code>--repo</code>. Successful extension status is
commonly written to stderr, and exits 2-10 represent actionable stack
state. Preserve both streams and the exact
<code>StackError.exitCode</code>, which reaches the shell only through
<code>cli.ts</code>'s <code>formatError</code> hook; do not replace
<code>ghRaw</code> with <code>ghExec</code> or generic
<code>mapGhError</code>. Never expose an interactive path. Force
<code>view --json</code>, <code>submit --auto</code>, and
<code>merge --yes</code>; require arguments for commands that otherwise
prompt. Keep <code>modify</code>, <code>switch</code>,
<code>alias</code>, and <code>feedback</code> out unless upstream gains
a useful headless interface.</p>
<h2 id="raising-prs-to-upstream">Raising PRs to upstream</h2>
<p>Human-authored PRs targeting <code>main</code> must be raised through
<a
href="https://github.com/kunchenguid/no-mistakes"><code>no-mistakes</code></a>
(<code>no-mistakes init --fork-url git@github.com:onyx-space/gh-axi.git</code>,
then <code>git push no-mistakes</code>): the
<code>Require no-mistakes</code> workflow fails any PR whose body lacks
the pipeline's deterministic signature, and maintainer triage treats
hand-raised PRs as blocked. Do not push a PR branch straight to
<code>origin</code>. See CONTRIBUTING.md.</p>
<h2 id="maintaining-this-file">Maintaining this file</h2>
<p>Keep this file for knowledge useful to almost every future agent
session in this project. Do not repeat what the codebase already shows;
point to the authoritative file or command instead. Prefer rewriting or
pruning existing entries over appending new ones. When updating this
file, preserve this bar for all agents and keep entries concise.</p>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"288408c01898712f640288bfdcf96e55e2437172","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 221bbb6 288408c` — 确认改动仅 AGENTS.md 新增 &#39;## Raising PRs to upstream&#39; 一节（4 行）</code>
- <code>读取 `.github/workflows/no-mistakes-required.yml` — 确认 &#39;Require no-mistakes&#39; 工作流针对 `main` 分支 PR，body 缺确定性 marker 时 exit 1</code>
- `复刻工作流 grep 逻辑模拟两种 PR body（无签名 → FAIL 输出工作流报错文案；有签名 → PASS），证据见 workflow-signature-check.txt`
- <code>`no-mistakes init --help` — 确认 `--fork-url` 标志存在，与文档命令逐字匹配</code>
- `grep CONTRIBUTING.md — 确认存在且描述同一流程（init --fork-url / git push no-mistakes / Require no-mistakes 检查）`
- <code>`pandoc -f gfm -t html AGENTS.md` — 真实 markdown 消费者渲染成功，新章节 heading/code span/链接 href 正确解析</code>
- <code>`git status --short` — 验证测试后工作树干净，无遗留临时产物</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
