### PR TITLE
ci: require no-mistakes pipeline attestation in the gate

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -38,7 +38,7 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.user.login != 'release-please[bot]'
     steps:
-      - name: Verify no-mistakes signature in PR body
+      - name: Verify no-mistakes signature and pipeline attestation in PR body
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -48,19 +48,179 @@ jobs:
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
           if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
             echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
-            exit 0
+          else
+            {
+              echo "::error::This PR was not raised through no-mistakes."
+              echo
+              echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
+              echo "That pipeline runs the required review/test/lint/CI steps and writes a"
+              echo "deterministic '## Pipeline' section into the PR body containing:"
+              echo
+              echo "    $marker"
+              echo
+              echo "See CONTRIBUTING.md for setup and the full workflow."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
           fi
-          {
-            echo "::error::This PR was not raised through no-mistakes."
-            echo
-            echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
-            echo "That pipeline runs the required review/test/lint/CI steps and writes a"
-            echo "deterministic '## Pipeline' section into the PR body containing:"
-            echo
-            echo "    $marker"
-            echo
-            echo "See CONTRIBUTING.md for setup and the full workflow."
-            echo
-            echo "PR author: ${PR_AUTHOR}"
-          } >&2
-          exit 1
+
+          # The signature alone only proves the pipeline wrote the body. no-mistakes
+          # >= 1.46.0 also emits a machine-readable step attestation next to it; parse
+          # that to prove review, test, and document actually ran to completion.
+          # Contract: docs/reference/pipeline-steps.md#pipeline-step-attestation in
+          # kunchenguid/no-mistakes.
+          attestation_prefix='<!-- no-mistakes-pipeline-attestation:v1 '
+          attestation_suffix=' -->'
+
+          if ! printf '%s' "${PR_BODY:-}" | grep -qF -- "$attestation_prefix"; then
+            echo "::error::This PR carries the no-mistakes signature but no pipeline attestation."
+            {
+              echo
+              echo "no-mistakes >= 1.46.0 is required (PR 670). That release writes a"
+              echo "machine-readable comment next to the signature:"
+              echo
+              echo "    ${attestation_prefix}{\"head_sha\":\"...\",\"steps\":[...]}${attestation_suffix}"
+              echo
+              echo "Upgrade no-mistakes ('no-mistakes update'), then re-run"
+              echo "'git push no-mistakes' so the PR body is rewritten with the attestation."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          # Exact-substring extraction (no regex): first prefix, then the first
+          # closing token after it, mirroring how no-mistakes' own consumer test
+          # slices the payload.
+          payload="$(
+            printf '%s' "${PR_BODY:-}" | tr -d '\r' | awk -v pre="$attestation_prefix" -v suf="$attestation_suffix" '
+              found { next }
+              {
+                p = index($0, pre)
+                if (p == 0) next
+                rest = substr($0, p + length(pre))
+                s = index(rest, suf)
+                if (s == 0) next
+                print substr(rest, 1, s - 1)
+                found = 1
+              }
+            '
+          )"
+
+          if [ -z "$payload" ]; then
+            echo "::error::The no-mistakes pipeline attestation comment is malformed: no JSON payload could be extracted."
+            {
+              echo
+              echo "The '${attestation_prefix}' marker is present but is not closed by"
+              echo "'${attestation_suffix}' on the same line, or the payload is empty."
+              echo "This gate fails closed on an unreadable attestation."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          # Real JSON parsing. Emits one "<step>\t<verdict>\t<detail>" line per
+          # required step. A step recorded more than once must be completed in
+          # every record. Any skip-shaped sibling key (a future 'skipped',
+          # 'skip_reason', 'quota_...', '..._unavailable' field) with a meaningful
+          # value is rejected outright, so a skip can never ride along on a
+          # 'completed' status.
+          if ! report="$(
+            printf '%s' "$payload" | jq -r --argjson required '["review","test","document"]' '
+              if type != "object" then error("attestation payload is not a JSON object") else . end
+              | if (.steps | type) != "array" then error("attestation payload has no \"steps\" array") else . end
+              | . as $attestation
+              | $required[]
+              | . as $name
+              | [ $attestation.steps[] | select((type == "object") and ((.step? | tostring) == $name)) ] as $records
+              | if ($records | length) == 0 then
+                  "\($name)\tmissing\tno record in attestation"
+                else
+                  ([ $records[] | (.status? // null) | tostring ] | unique) as $statuses
+                  | ([ $records[]
+                       | to_entries[]
+                       | select((.key | ascii_downcase) | test("skip|quota|unavailable"))
+                       | select(.value != null and .value != false and .value != "")
+                       | .key ] | unique) as $skip_markers
+                  | if ($skip_markers | length) > 0 then
+                      "\($name)\tskip-marker\t\($skip_markers | join(","))"
+                    elif $statuses == ["completed"] then
+                      "\($name)\tok\tcompleted"
+                    else
+                      "\($name)\tbad\t\($statuses | join(","))"
+                    end
+                end
+            ' 2>&1
+          )"; then
+            echo "::error::The no-mistakes pipeline attestation payload could not be parsed as JSON."
+            {
+              echo
+              echo "jq reported:"
+              echo "$report"
+              echo
+              echo "Payload: $payload"
+              echo
+              echo "This gate fails closed on an unparseable attestation."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          echo "Attestation head_sha: $(printf '%s' "$payload" | jq -r '.head_sha // "(absent)"')"
+
+          tab="$(printf '\t')"
+          gate_status=0
+          checked=0
+          while IFS="$tab" read -r name verdict detail; do
+            [ -n "$name" ] || continue
+            checked=$((checked + 1))
+            case "$verdict" in
+              ok)
+                echo "  ok: ${name} = completed"
+                ;;
+              missing)
+                echo "::error::The no-mistakes pipeline attestation has no '${name}' step record; '${name}' must be recorded as completed."
+                gate_status=1
+                ;;
+              skip-marker)
+                echo "::error::The no-mistakes pipeline attestation marks '${name}' with skip indicator(s) [${detail}]; quota-exhaustion and agent-unavailability skips are not accepted."
+                gate_status=1
+                ;;
+              *)
+                echo "::error::The no-mistakes pipeline attestation records '${name}' as '${detail}', not 'completed'."
+                gate_status=1
+                ;;
+            esac
+          done <<REPORT
+          $report
+          REPORT
+
+          # A verdict per required step is the only shape jq can emit for a payload
+          # it accepted. Assert it anyway so an unexpected empty report fails closed
+          # instead of reporting nothing and passing.
+          if [ "$checked" -ne 3 ]; then
+            echo "::error::The no-mistakes attestation gate reached a verdict for ${checked} of the 3 required steps (review, test, document); failing closed."
+            gate_status=1
+          fi
+
+          if [ "$gate_status" -ne 0 ]; then
+            {
+              echo
+              echo "The no-mistakes review, test, and document steps must all be recorded as"
+              echo "'completed'. A step that was skipped (pre-skipped with --skip, skipped at a"
+              echo "gate, or skipped because the agent was unavailable or out of quota), failed,"
+              echo "or never finished is not accepted."
+              echo
+              echo "Re-run 'git push no-mistakes' and let review, test, and document run."
+              echo
+              echo "Attestation payload: $payload"
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          echo "no-mistakes pipeline attestation verified for PR #${PR_NUMBER}: review, test, and document all completed."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,10 @@ Never expose an interactive path. Force `view --json`, `submit --auto`, and `mer
 
 Human-authored PRs targeting `main` must be raised through [`no-mistakes`](https://github.com/kunchenguid/no-mistakes) (`no-mistakes init --fork-url git@github.com:<you>/gh-axi.git`, then `git push no-mistakes`): the `Require no-mistakes` workflow fails any PR whose body lacks the pipeline's deterministic signature, and maintainer triage treats hand-raised PRs as blocked. Do not push a PR branch straight to `origin`. See CONTRIBUTING.md.
 
+`.github/workflows/no-mistakes-required.yml` enforces that in two layers: the human-readable `Updates from [git push no-mistakes]` signature, and the machine-readable `<!-- no-mistakes-pipeline-attestation:v1 {...} -->` comment no-mistakes >= 1.46.0 writes beside it, whose `steps[]` must record `review`, `test`, and `document` as `completed`.
+The attestation's only per-step fields are `step` and `status` (contract: `docs/reference/pipeline-steps.md#pipeline-step-attestation` in kunchenguid/no-mistakes), so every skip route - `--skip`, a gate skip, an automatic skip, an exhausted agent - lands on `skipped` and an unusable agent lands on `failed`; the gate additionally fails closed on a skip-shaped sibling key so a future schema cannot smuggle a skip past a `completed` status.
+The gate is one self-contained inline `run:` block because the whole file is mirrored into sibling repositories; `test/no-mistakes-gate.test.ts` extracts and executes that exact block, so edit the workflow and re-run the test rather than reimplementing the parser.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/test/no-mistakes-gate.test.ts
+++ b/test/no-mistakes-gate.test.ts
@@ -1,0 +1,210 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const workflowPath = join(
+  root,
+  ".github",
+  "workflows",
+  "no-mistakes-required.yml",
+);
+
+/**
+ * The gate lives as an inline `run:` block so the whole file can be mirrored
+ * into sibling repositories as one unit. Extract that exact block and execute
+ * it, so these tests exercise what CI runs rather than a copy of it.
+ */
+function extractGateScript(): string {
+  const doc = parse(readFileSync(workflowPath, "utf8")) as {
+    jobs: { check: { steps: Array<{ run?: string }> } };
+  };
+  const script = doc.jobs.check.steps[0]?.run;
+  if (!script) throw new Error("no-mistakes gate step has no run block");
+  return script;
+}
+
+const scriptPath = join(mkdtempSync(join(tmpdir(), "nm-gate-")), "gate.sh");
+writeFileSync(scriptPath, extractGateScript());
+
+function hasCommand(command: string): boolean {
+  return spawnSync("sh", ["-c", `command -v ${command}`]).status === 0;
+}
+
+// The gate is a bash script that parses JSON with jq, exactly as the
+// ubuntu-latest runner does. Never skip on CI: a silently skipped gate test is
+// worse than no test. Locally, skip when jq is absent rather than failing a
+// contributor's `pnpm test` over an unrelated missing tool.
+const runnable = hasCommand("bash") && hasCommand("jq");
+if (process.env.CI && !runnable) {
+  throw new Error(
+    "CI must provide bash and jq to exercise the no-mistakes gate",
+  );
+}
+
+function runGate(body: string): { code: number; output: string } {
+  const result = spawnSync("bash", [scriptPath], {
+    env: {
+      ...process.env,
+      PR_BODY: body,
+      PR_AUTHOR: "somedev",
+      PR_NUMBER: "42",
+    },
+    encoding: "utf8",
+  });
+  return {
+    code: result.status ?? -1,
+    output: `${result.stdout}${result.stderr}`,
+  };
+}
+
+const SIGNATURE =
+  "Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)";
+const ATTESTATION_PREFIX = "<!-- no-mistakes-pipeline-attestation:v1 ";
+const ATTESTATION_SUFFIX = " -->";
+const HEAD_SHA = "12df13109c6ad8d64646b85ac7170b23afe6e9bf";
+
+/** A PR body shaped like the one no-mistakes writes. */
+function prBody(attestationPayload?: string): string {
+  const attestation =
+    attestationPayload === undefined
+      ? ""
+      : `${ATTESTATION_PREFIX}${attestationPayload}${ATTESTATION_SUFFIX}\n\n`;
+  return [
+    "## What Changed\n\n- something\n",
+    `## Pipeline\n\n${SIGNATURE}\n\n${attestation}`,
+    "<details>\n<summary>Review</summary>\n\nok\n\n</details>\n",
+  ].join("\n");
+}
+
+function attestation(steps: Array<[string, string]>): string {
+  return JSON.stringify({
+    head_sha: HEAD_SHA,
+    steps: steps.map(([step, status]) => ({ step, status })),
+  });
+}
+
+/** The step snapshot a healthy run produces when the PR body is written. */
+const HEALTHY_STEPS: Array<[string, string]> = [
+  ["intent", "completed"],
+  ["rebase", "completed"],
+  ["review", "completed"],
+  ["test", "completed"],
+  ["document", "completed"],
+  ["lint", "completed"],
+  ["push", "completed"],
+  ["pr", "running"],
+  ["ci", "pending"],
+];
+
+function withStatus(step: string, status: string): Array<[string, string]> {
+  return HEALTHY_STEPS.map(([name, current]) =>
+    name === step ? [name, status] : [name, current],
+  ) as Array<[string, string]>;
+}
+
+describe.runIf(runnable)("no-mistakes PR gate", () => {
+  it("accepts a body whose attestation completes review, test, and document", () => {
+    const { code, output } = runGate(prBody(attestation(HEALTHY_STEPS)));
+    expect(code).toBe(0);
+    expect(output).toContain("review, test, and document all completed");
+  });
+
+  it("still rejects a body with no no-mistakes signature", () => {
+    const { code, output } = runGate("## Intent\n\nhand-written body\n");
+    expect(code).toBe(1);
+    expect(output).toContain("was not raised through no-mistakes");
+    expect(output).toContain("git push no-mistakes");
+  });
+
+  it("rejects a signed body with no attestation and names the required version", () => {
+    const { code, output } = runGate(prBody());
+    expect(code).toBe(1);
+    expect(output).toContain("no pipeline attestation");
+    expect(output).toContain("no-mistakes >= 1.46.0 is required (PR 670)");
+  });
+
+  // Every skip route no-mistakes has - `--skip`, a user skip at a gate, an
+  // automatic pipeline skip, or a run that ran out of agent quota - lands on
+  // the raw `skipped` status, and an unavailable agent surfaces as `failed`.
+  for (const status of ["skipped", "failed", "running", "pending"]) {
+    it(`rejects an attestation whose test step is ${status}`, () => {
+      const { code, output } = runGate(
+        prBody(attestation(withStatus("test", status))),
+      );
+      expect(code).toBe(1);
+      expect(output).toContain(`records 'test' as '${status}'`);
+    });
+  }
+
+  it("rejects an attestation that omits a required step entirely", () => {
+    const steps = HEALTHY_STEPS.filter(([name]) => name !== "document");
+    const { code, output } = runGate(prBody(attestation(steps)));
+    expect(code).toBe(1);
+    expect(output).toContain("no 'document' step record");
+  });
+
+  it("rejects a required step recorded twice unless every record completed", () => {
+    const steps: Array<[string, string]> = [
+      ...HEALTHY_STEPS,
+      ["review", "skipped"],
+    ];
+    const { code, output } = runGate(prBody(attestation(steps)));
+    expect(code).toBe(1);
+    expect(output).toContain("records 'review' as 'completed,skipped'");
+  });
+
+  // v1 carries no skip sibling field, so `status` is the only skip channel
+  // today. Fail closed if a later schema ever hangs a skip reason off an
+  // otherwise-completed step instead of widening the gate silently.
+  for (const marker of [
+    { skip_reason: "quota exhausted" },
+    { skipped: true },
+    { agent_unavailable: true },
+    { quota_exhausted: true },
+  ]) {
+    const key = Object.keys(marker)[0];
+    it(`rejects a completed step carrying a ${key} marker`, () => {
+      const payload = JSON.stringify({
+        head_sha: HEAD_SHA,
+        steps: HEALTHY_STEPS.map(([step, status]) =>
+          step === "review" ? { step, status, ...marker } : { step, status },
+        ),
+      });
+      const { code, output } = runGate(prBody(payload));
+      expect(code).toBe(1);
+      expect(output).toContain(`skip indicator(s) [${key}]`);
+    });
+  }
+
+  it("fails closed on an attestation payload that is not valid JSON", () => {
+    const { code, output } = runGate(
+      prBody('{"head_sha":"abc","steps":[{"step":"review",'),
+    );
+    expect(code).toBe(1);
+    expect(output).toContain("could not be parsed as JSON");
+  });
+
+  it("fails closed when the payload has no steps array", () => {
+    const { code, output } = runGate(prBody('{"head_sha":"abc"}'));
+    expect(code).toBe(1);
+    expect(output).toContain("could not be parsed as JSON");
+  });
+
+  it("fails closed when the attestation comment is never closed", () => {
+    const body = `## Pipeline\n\n${SIGNATURE}\n\n${ATTESTATION_PREFIX}{"head_sha":"abc","steps":[]}\n`;
+    const { code, output } = runGate(body);
+    expect(code).toBe(1);
+    expect(output).toContain("no JSON payload could be extracted");
+  });
+
+  it("accepts a CRLF body", () => {
+    const body = prBody(attestation(HEALTHY_STEPS)).replace(/\n/g, "\r\n");
+    const { code } = runGate(body);
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
## What Changed

`.github/workflows/no-mistakes-required.yml` previously only looked for the human-readable `Updates from [git push no-mistakes](...)` signature. That proves the pipeline wrote the PR body; it says nothing about which pipeline steps actually ran.

no-mistakes >= 1.46.0 ([no-mistakes#670](https://github.com/kunchenguid/no-mistakes/pull/670)) additionally writes a machine-readable comment immediately after that signature:

```
<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"<sha>","steps":[{"step":"intent","status":"completed"},...]} -->
```

The gate now parses it and requires `review`, `test`, and `document` to each be `completed`.

Unchanged: triggers, `paths-ignore`, `concurrency`, the `github-actions[bot]` / `dependabot[bot]` / `release-please[bot]` exemptions, `permissions`, the job name (`PR must be raised via no-mistakes`), and the existing "signature missing entirely" failure path and its `git push no-mistakes` message. The only step-level change is the step's `name`, which now mentions the attestation.

This gate stays advisory (the repo ruleset requires no status checks); no branch protection or required-check changes are included.

### Failure paths (all `::error::` + nonzero exit)

| Condition | Result |
| --- | --- |
| Signature missing | fail, unchanged message |
| Signature present, attestation comment missing | fail, message states **`no-mistakes >= 1.46.0 is required (PR 670)`** |
| Attestation marker present but not closed by ` -->`, or empty payload | fail closed |
| Payload not valid JSON / not an object / no `steps` array | fail closed, jq's error is echoed |
| `review`, `test`, or `document` has no record in `steps[]` | fail |
| Any of those three has a status other than `completed` | fail |
| Any of those three recorded twice and not `completed` in every record | fail |
| Any of those three carries a skip-shaped sibling key | fail (see below) |
| Fewer than 3 verdicts produced | fail closed |

Exit 0 requires: signature present **and** attestation present **and** `review`/`test`/`document` all `completed` **and** no skip marker.

## Quota / agent skips: what I confirmed

Verified against the no-mistakes source and docs at `v1.56.0`, plus the live shape in [no-mistakes#790](https://github.com/kunchenguid/no-mistakes/pull/790):

1. **The v1 step object has exactly two fields.** `internal/pipeline/steps/prsummary.go`:

   ```go
   type pipelineAttestationStep struct {
       Step   types.StepName   `json:"step"`
       Status types.StepStatus `json:"status"`
   }
   ```

   `buildPipelineAttestation` copies `sr.StepName` / `sr.Status` straight off the DB step results with no filtering and no extra keys. **There is no sibling skip-reason, quota, or agent field** in v1, so a skip has no channel other than `status`.

2. **`status` is a closed enum** (`internal/types/types.go`, mirrored in `docs/reference/pipeline-steps.md#step-statuses`): `pending`, `running`, `awaiting_approval`, `fixing`, `fix_review`, `completed`, `skipped`, `failed`. `skipped` is documented as covering *"pre-skipped for the run, skipped by the user, or skipped automatically by the pipeline"* — that is the single representation for **every** skip route, including a run that stops feeding a step because the agent is out of quota.

3. **Agent unavailability is not a skip at all** — no-mistakes has no quota/usage-limit concept in the pipeline (the only agent-availability classification, `classifyFallbackReason` in `internal/pipeline/instrument.go`, is telemetry-only and never reaches a step status). An agent that cannot run surfaces as the step `failed`, or leaves it at `running` / `pending` in the snapshot. `executor.go` sets `status = completed` only on the success path, overriding to `skipped` when `stepSkipped`.

**Conclusion: there is no skip variant that reports `completed`.** Requiring `status == "completed"` therefore already rejects both quota-exhaustion and agent-unavailability skips (fixtures e1/e2 below).

Because the brief asks the gate to reject such a variant explicitly, and because a future schema could add one, the gate **also fails closed on any sibling key** on a required step whose name matches `skip|quota|unavailable` and whose value is not `null`/`false`/`""` — e.g. `{"step":"review","status":"completed","skip_reason":"quota exhausted"}` is rejected on the marker, not the status (fixtures e3/e4).

Note the gate deliberately does **not** require `pr` or `ci` to be completed: at the point no-mistakes writes the body those are normally `running` and `pending` (confirmed in no-mistakes#790's live attestation).

## Robustness notes

- **No regex on step statuses.** The payload is sliced out with exact-substring `index()` in `awk` (first prefix, then the first ` -->` after it — the same non-greedy slicing no-mistakes' own consumer test uses), then handed to `jq`, which does all structural and status evaluation.
- `tr -d '\r'` first, so a CRLF body parses.
- Every failure path emits a `::error::` annotation and `exit 1`; the offending payload is echoed for triage.
- The gate is one self-contained inline `run:` block on purpose, so the whole file mirrors into sibling repositories as a single unit.

## Testing

`test/no-mistakes-gate.test.ts` (new) **extracts the exact `run:` block from the workflow YAML and executes it** with `bash`, so the tests exercise what CI runs rather than a reimplementation. It hard-fails on CI if `bash`/`jq` are missing, and skips locally when `jq` is absent.

```
$ pnpm test
 Test Files  37 passed | 1 skipped (38)
      Tests  949 passed | 5 skipped (954)

$ pnpm exec vitest run test/no-mistakes-gate.test.ts
 ✓ test/no-mistakes-gate.test.ts (17 tests)
```

Standalone fixture transcript against the same extracted block (`exit` code vs expectation):

```
  (a) no no-mistakes signature at all -> fail
    => exit 1 (EXPECTED 1)  PASS
  (b) signature present, attestation missing -> fail (>= 1.46.0 / PR 670)
    => exit 1 (EXPECTED 1)  PASS
  (c) attestation present, review/test/document completed -> pass
    => exit 0 (EXPECTED 0)  PASS
  (d) test = skipped -> fail
    => exit 1 (EXPECTED 1)  PASS
  (d2) document = running -> fail
    => exit 1 (EXPECTED 1)  PASS
  (d3) review record absent from steps[] -> fail
    => exit 1 (EXPECTED 1)  PASS
  (e1) quota-exhaustion skip as recorded today (status=skipped) -> fail
    => exit 1 (EXPECTED 1)  PASS
  (e2) agent-unavailability surfacing as status=failed -> fail
    => exit 1 (EXPECTED 1)  PASS
  (e3) hypothetical future skip marker riding on status=completed -> fail
    => exit 1 (EXPECTED 1)  PASS
  (e4) hypothetical agent_unavailable:true on a completed step -> fail
    => exit 1 (EXPECTED 1)  PASS
  (f1) malformed attestation JSON -> fail closed
    => exit 1 (EXPECTED 1)  PASS
  (f2) attestation comment never closed -> fail closed
    => exit 1 (EXPECTED 1)  PASS
  (f3) valid JSON but steps is not an array -> fail closed
    => exit 1 (EXPECTED 1)  PASS
  (g) duplicate review records, one not completed -> fail
    => exit 1 (EXPECTED 1)  PASS
  (h) CRLF body, all three completed -> pass
    => exit 0 (EXPECTED 0)  PASS
════════ ALL FIXTURES PASSED
```

End-to-end against real PR bodies fetched from GitHub:

```
$ PR_BODY="$(gh api repos/kunchenguid/no-mistakes/pulls/790 --jq .body)" bash gate.sh
Found no-mistakes signature in PR #790 body.
Attestation head_sha: 12df13109c6ad8d64646b85ac7170b23afe6e9bf
  ok: review = completed
  ok: test = completed
  ok: document = completed
no-mistakes pipeline attestation verified for PR #790: review, test, and document all completed.
exit=0
```

## Risk

Low. The gate is advisory today, so a false negative cannot block a merge; every added path fails closed rather than open. The pass path was validated against a real no-mistakes >= 1.46.0 PR body.
