### PR TITLE
ci: bind the no-mistakes attestation to the current PR head

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -43,6 +43,7 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -eu
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
@@ -169,7 +170,31 @@ jobs:
             exit 1
           fi
 
-          echo "Attestation head_sha: $(printf '%s' "$payload" | jq -r '.head_sha // "(absent)"')"
+          attested_head="$(printf '%s' "$payload" | jq -r '.head_sha // ""')"
+          echo "Attestation head_sha: ${attested_head:-(absent)}"
+
+          # Head binding. The attestation describes the commit no-mistakes ran
+          # its steps on; a later push moves the PR head without rewriting the
+          # body, so an attestation that does not name the current head proves
+          # nothing about the code being merged. A `synchronize` whose body was
+          # NOT rewritten by no-mistakes going red is the intended contract, not
+          # a false positive.
+          if [ -z "$attested_head" ] || [ -z "${PR_HEAD_SHA:-}" ] || [ "$attested_head" != "$PR_HEAD_SHA" ]; then
+            echo "::error::The no-mistakes pipeline attestation is STALE for the current head of PR #${PR_NUMBER}."
+            {
+              echo
+              echo "Attestation head_sha: ${attested_head:-(absent)}"
+              echo "PR head sha:          ${PR_HEAD_SHA:-(absent)}"
+              echo
+              echo "A commit was pushed after the no-mistakes run, so the attestation does not"
+              echo "describe the code this PR now proposes to merge."
+              echo
+              echo "Re-run 'git push no-mistakes' to refresh it."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
 
           tab="$(printf '\t')"
           gate_status=0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ Human-authored PRs targeting `main` must be raised through [`no-mistakes`](https
 
 `.github/workflows/no-mistakes-required.yml` enforces that in two layers: the human-readable `Updates from [git push no-mistakes]` signature, and the machine-readable `<!-- no-mistakes-pipeline-attestation:v1 {...} -->` comment no-mistakes >= 1.46.0 writes beside it, whose `steps[]` must record `review`, `test`, and `document` as `completed`.
 The attestation's only per-step fields are `step` and `status` (contract: `docs/reference/pipeline-steps.md#pipeline-step-attestation` in kunchenguid/no-mistakes), so every skip route - `--skip`, a gate skip, an automatic skip, an exhausted agent - lands on `skipped` and an unusable agent lands on `failed`; the gate additionally fails closed on a skip-shaped sibling key so a future schema cannot smuggle a skip past a `completed` status.
+The gate is also head-bound: the attestation's `head_sha` must equal the PR's current `head.sha` (`PR_HEAD_SHA`), so a commit pushed after a no-mistakes run fails until `git push no-mistakes` rewrites the body - a red `synchronize` is the contract, not a bug.
 The gate is one self-contained inline `run:` block because the whole file is mirrored into sibling repositories; `test/no-mistakes-gate.test.ts` extracts and executes that exact block, so edit the workflow and re-run the test rather than reimplementing the parser.
 
 ## Maintaining this file

--- a/test/no-mistakes-gate.test.ts
+++ b/test/no-mistakes-gate.test.ts
@@ -46,13 +46,17 @@ if (process.env.CI && !runnable) {
   );
 }
 
-function runGate(body: string): { code: number; output: string } {
+function runGate(
+  body: string,
+  headSha: string = HEAD_SHA,
+): { code: number; output: string } {
   const result = spawnSync("bash", [scriptPath], {
     env: {
       ...process.env,
       PR_BODY: body,
       PR_AUTHOR: "somedev",
       PR_NUMBER: "42",
+      PR_HEAD_SHA: headSha,
     },
     encoding: "utf8",
   });
@@ -81,9 +85,12 @@ function prBody(attestationPayload?: string): string {
   ].join("\n");
 }
 
-function attestation(steps: Array<[string, string]>): string {
+function attestation(
+  steps: Array<[string, string]>,
+  headSha: string = HEAD_SHA,
+): string {
   return JSON.stringify({
-    head_sha: HEAD_SHA,
+    head_sha: headSha,
     steps: steps.map(([step, status]) => ({ step, status })),
   });
 }
@@ -180,6 +187,48 @@ describe.runIf(runnable)("no-mistakes PR gate", () => {
       expect(output).toContain(`skip indicator(s) [${key}]`);
     });
   }
+
+  // Head binding: the attestation must name the commit this PR now proposes to
+  // merge. A synchronize whose body was not rewritten by no-mistakes going red
+  // is the contract, not a false positive.
+  it("accepts an attestation whose head_sha is the PR's current head", () => {
+    const { code, output } = runGate(
+      prBody(attestation(HEALTHY_STEPS, HEAD_SHA)),
+      HEAD_SHA,
+    );
+    expect(code).toBe(0);
+    expect(output).toContain(`Attestation head_sha: ${HEAD_SHA}`);
+  });
+
+  it("rejects an attestation whose head_sha is not the PR's current head", () => {
+    const staleSha = "0000000000000000000000000000000000000000";
+    const { code, output } = runGate(
+      prBody(attestation(HEALTHY_STEPS, staleSha)),
+      HEAD_SHA,
+    );
+    expect(code).toBe(1);
+    expect(output).toContain("attestation is STALE for the current head");
+    expect(output).toContain("Re-run 'git push no-mistakes' to refresh it");
+    expect(output).toContain(staleSha);
+    expect(output).toContain(HEAD_SHA);
+  });
+
+  it("fails closed when the attestation carries no head_sha at all", () => {
+    const payload = JSON.stringify({
+      steps: HEALTHY_STEPS.map(([step, status]) => ({ step, status })),
+    });
+    const { code, output } = runGate(prBody(payload), HEAD_SHA);
+    expect(code).toBe(1);
+    expect(output).toContain("attestation is STALE for the current head");
+    expect(output).toContain("Attestation head_sha: (absent)");
+  });
+
+  it("fails closed when the PR head sha is unavailable", () => {
+    const { code, output } = runGate(prBody(attestation(HEALTHY_STEPS)), "");
+    expect(code).toBe(1);
+    expect(output).toContain("attestation is STALE for the current head");
+    expect(output).toMatch(/PR head sha: +\(absent\)/);
+  });
 
   it("fails closed on an attestation payload that is not valid JSON", () => {
     const { code, output } = runGate(


### PR DESCRIPTION
## What changed

The gate parsed the `no-mistakes-pipeline-attestation:v1` payload and required
review/test/document = `completed`, but never checked that the attestation
describes the commit the PR now proposes to merge. It extracted `head_sha` only
to echo it. A commit pushed directly after a no-mistakes run therefore passed the
gate on a stale attestation.

This mirrors the head-binding that landed on lavish-axi `main` (PR #271):

- `PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}` added to the gate step's `env:`.
- After parsing, the gate fails unless the attestation's `head_sha` is non-empty,
  `PR_HEAD_SHA` is non-empty, and the two are equal - printing an `::error::` that the
  attestation is STALE for the current head, both shas, and the fix
  (`re-run 'git push no-mistakes'`).

This is the attestation contract: a `synchronize` event whose PR body was NOT
rewritten by no-mistakes going red is the intended behavior, not a false positive.

Everything else is preserved: triggers, `paths-ignore`, the bot exemptions, the
job name, and the single self-contained inline `run:` block (the file is mirrored
into sibling repos, and `test/no-mistakes-gate.test.ts` extracts and executes that
exact block).

## Tests

`test/no-mistakes-gate.test.ts` now threads `PR_HEAD_SHA` through `runGate` and
`attestation` takes an overridable `head_sha`, plus four new cases: matching head
passes, stale head fails, missing `head_sha` fails closed, missing `PR_HEAD_SHA`
fails closed.

Negative control against the pre-change gate script (extracted from `HEAD`), fed a
stale attestation with all steps completed:

```
old gate exit (stale attestation): 0
```

Full suite on this branch:

```
$ pnpm run build
$ tsc

$ pnpm test
 ✓ test/no-mistakes-gate.test.ts (21 tests) 851ms
 ✓ test/version-fast-path.test.ts (5 tests) 1212ms

 Test Files  37 passed | 1 skipped (38)
      Tests  953 passed | 5 skipped (958)

$ pnpm exec prettier --check .github/workflows/no-mistakes-required.yml test/no-mistakes-gate.test.ts
Checking formatting...
All matched files use Prettier code style!
```

Note: the `Require no-mistakes` advisory gate will fail on this PR itself - it was
raised directly and carries no signature/attestation. Expected and non-blocking;
build/test/guard are the real checks.
