### PR TITLE
fix(api): support -X method flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ The release and dependency bots are exempt so their automation keeps working, bu
 6. Run `no-mistakes` to attach to the pipeline, watch findings, and auto-fix or review as needed.
 7. Once the pipeline passes, it pushes the branch to your fork and opens the PR against this repo for you.
 
-Fork routing requires no-mistakes **v1.30.1** or newer.
+The required pipeline attestation and fork routing require no-mistakes **v1.46.0** or newer.
 
 See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Gist visibility is fixed at creation; a secret gist is unlisted (anyone with the
 Two file-on-disk input forms are available: positional paths (`gist create a.py b.py`) or repeatable `--file` flags (`gist create --file a.py --file b.py`); mixing the two is an error.
 To create a gist from piped content, use `--filename <name>` together with a pipe (`echo "..." | gh-axi gist create --filename foo.txt --public`).
 
-`gh-axi api` accepts `--field`, `--header`, `--paginate`, `--jq <expression>`, `--template <format>`, and `--full`; any other flag, an extra positional argument, or a repeated `--jq`/`--template` is rejected with a clear error instead of being silently dropped.
+`gh-axi api` accepts `-X <method>`, `--field`, `--header`, `--paginate`, `--jq <expression>`, `--template <format>`, and `--full`; any other flag, an extra positional argument, or a repeated `--jq`/`--template` is rejected with a clear error instead of being silently dropped.
 JSON responses are normally stripped of noisy fields before TOON encoding, but a response you shaped yourself with `--jq` or `--template` keeps every key and value verbatim — only over-long strings are still truncated so one field cannot flood an agent's context.
 `--full` is an explicit opt-in escape hatch: it keeps every field and every complete value, and it also returns non-JSON response bodies without the length cap. `--full` is a gh-axi flag only, and gh-axi does not send it to `gh`. Compact output stays the default without `--full`.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ Gist visibility is fixed at creation; a secret gist is unlisted (anyone with the
 Two file-on-disk input forms are available: positional paths (`gist create a.py b.py`) or repeatable `--file` flags (`gist create --file a.py --file b.py`); mixing the two is an error.
 To create a gist from piped content, use `--filename <name>` together with a pipe (`echo "..." | gh-axi gist create --filename foo.txt --public`).
 
-`gh-axi api` accepts `-X <method>`, `--field`, `--header`, `--paginate`, `--jq <expression>`, `--template <format>`, and `--full`; any other flag, an extra positional argument, or a repeated `--jq`/`--template` is rejected with a clear error instead of being silently dropped.
+`gh-axi api` accepts `-X <method>` and `-X=<method>` as alternatives to the positional HTTP method, plus `--field`, `--header`, `--paginate`, `--jq <expression>`, `--template <format>`, and `--full`.
+Giving `-X` more than once or together with a positional method is rejected, as is any other unsupported flag, extra positional argument, or repeated `--jq`/`--template`.
 JSON responses are normally stripped of noisy fields before TOON encoding, but a response you shaped yourself with `--jq` or `--template` keeps every key and value verbatim — only over-long strings are still truncated so one field cannot flood an agent's context.
 `--full` is an explicit opt-in escape hatch: it keeps every field and every complete value, and it also returns non-JSON response bodies without the length cap. `--full` is a gh-axi flag only, and gh-axi does not send it to `gh`. Compact output stays the default without `--full`.
 

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -9,7 +9,7 @@ description: Make an authenticated GitHub API request. Defaults to GET if no met
 methods[6]:
   GET, POST, PUT, PATCH, DELETE, HEAD
 flags[7]:
-  -X <method> (alias for the positional method, e.g. -X POST), --field <key=value> (repeatable), --header <key:value> (repeatable), --paginate, --jq <expression>, --template <format>, --full (preserve complete field values and response bodies without truncation)
+  -X <method> or -X=<method> (alias for the positional method; give once and do not combine with a positional method), --field <key=value> (repeatable), --header <key:value> (repeatable), --paginate, --jq <expression>, --template <format>, --full (preserve complete field values and response bodies without truncation)
 examples:
   gh-axi api /repos/{owner}/{repo}
   gh-axi api POST /repos/{owner}/{repo}/issues --field title="Bug report"

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -1,8 +1,8 @@
-import { encode } from '@toon-format/toon';
-import type { RepoContext } from '../context.js';
-import { ghExec } from '../gh.js';
-import { AxiError } from '../errors.js';
-import { cleanBody } from '../body.js';
+import { encode } from "@toon-format/toon";
+import type { RepoContext } from "../context.js";
+import { ghExec } from "../gh.js";
+import { AxiError } from "../errors.js";
+import { cleanBody } from "../body.js";
 
 export const API_HELP = `usage: gh-axi api [<method>] <path>
 description: Make an authenticated GitHub API request. Defaults to GET if no method specified.
@@ -17,22 +17,22 @@ examples:
   gh-axi api /repos/{owner}/{repo}/pulls --paginate
   gh-axi api /repos/{owner}/{repo}/issues/1 --jq '[.labels[].name]'`;
 
-const HTTP_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD']);
+const HTTP_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]);
 
 /** The `gh api` short flag for HTTP method, equivalent to the positional method. */
-const METHOD_FLAG = '-X';
+const METHOD_FLAG = "-X";
 
 /** Value flags that may be given more than once, each occurrence forwarded to gh. */
-const REPEATABLE_VALUE_FLAGS = new Set(['--field', '--header']);
+const REPEATABLE_VALUE_FLAGS = new Set(["--field", "--header"]);
 
 /** Value flags that gh accepts only one of, so a repeat is a caller mistake. */
-const SINGLE_VALUE_FLAGS = new Set(['--jq', '--template']);
+const SINGLE_VALUE_FLAGS = new Set(["--jq", "--template"]);
 
 /** Flags that stand alone and must not consume the following argument, and are forwarded to gh. */
-const BOOL_FLAGS = new Set(['--paginate']);
+const BOOL_FLAGS = new Set(["--paginate"]);
 
 /** Flags that stand alone, are gh-axi-only, and must not be forwarded to gh. */
-const LOCAL_BOOL_FLAGS = new Set(['--full']);
+const LOCAL_BOOL_FLAGS = new Set(["--full"]);
 
 const SUPPORTED_FLAGS = [
   METHOD_FLAG,
@@ -44,7 +44,7 @@ const SUPPORTED_FLAGS = [
 
 /** The flag's name without any `=value` suffix, so errors never echo a value. */
 function flagName(arg: string): string {
-  const equals = arg.indexOf('=');
+  const equals = arg.indexOf("=");
   return equals === -1 ? arg : arg.slice(0, equals);
 }
 
@@ -84,20 +84,20 @@ function parseArgs(args: string[]): ParsedApiArgs {
   };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    if (!arg.startsWith('-')) {
+    if (!arg.startsWith("-")) {
       parsed.positionals.push(arg);
       continue;
     }
     const name = flagName(arg);
     if (BOOL_FLAGS.has(name)) {
       if (name !== arg)
-        throw new AxiError(`${name} does not take a value`, 'VALIDATION_ERROR');
+        throw new AxiError(`${name} does not take a value`, "VALIDATION_ERROR");
       parsed.paginate = true;
       continue;
     }
     if (LOCAL_BOOL_FLAGS.has(name)) {
       if (name !== arg)
-        throw new AxiError(`${name} does not take a value`, 'VALIDATION_ERROR');
+        throw new AxiError(`${name} does not take a value`, "VALIDATION_ERROR");
       parsed.full = true;
       continue;
     }
@@ -107,44 +107,50 @@ function parseArgs(args: string[]): ParsedApiArgs {
       !SINGLE_VALUE_FLAGS.has(name)
     ) {
       throw new AxiError(
-        `unknown flag ${name} for gh-axi api. Supported flags: ${SUPPORTED_FLAGS.join(', ')}`,
-        'VALIDATION_ERROR',
+        `unknown flag ${name} for gh-axi api. Supported flags: ${SUPPORTED_FLAGS.join(", ")}`,
+        "VALIDATION_ERROR",
       );
     }
     // `--flag=value` carries its own value; `--flag value` consumes the next arg.
     let value: string;
     if (name === arg) {
       if (i + 1 >= args.length)
-        throw new AxiError(`${name} requires a value`, 'VALIDATION_ERROR');
+        throw new AxiError(`${name} requires a value`, "VALIDATION_ERROR");
       value = args[++i];
     } else {
       value = arg.slice(name.length + 1);
     }
     if (name === METHOD_FLAG) {
       if (parsed.method !== undefined)
-        throw new AxiError(`${name} may only be given once`, 'VALIDATION_ERROR');
+        throw new AxiError(
+          `${name} may only be given once`,
+          "VALIDATION_ERROR",
+        );
       const upper = value.toUpperCase();
       if (!HTTP_METHODS.has(upper)) {
         throw new AxiError(
-          `${name} ${value} is not a supported HTTP method. Supported: ${[...HTTP_METHODS].join(', ')}`,
-          'VALIDATION_ERROR',
+          `${name} ${value} is not a supported HTTP method. Supported: ${[...HTTP_METHODS].join(", ")}`,
+          "VALIDATION_ERROR",
         );
       }
       parsed.method = upper;
-    } else if (name === '--field') {
+    } else if (name === "--field") {
       parsed.fields.push(value);
-    } else if (name === '--header') {
+    } else if (name === "--header") {
       parsed.headers.push(value);
     } else {
       // gh takes the last occurrence; discarding the earlier expression silently
       // is the same failure this parser exists to prevent, so reject instead.
-      const key = name === '--jq' ? 'jq' : 'template';
+      const key = name === "--jq" ? "jq" : "template";
       if (parsed[key] !== undefined)
-        throw new AxiError(`${name} may only be given once`, 'VALIDATION_ERROR');
+        throw new AxiError(
+          `${name} may only be given once`,
+          "VALIDATION_ERROR",
+        );
       // An empty value (an unset shell variable) is a no-op filter for gh that
       // would still suppress the default field stripping here.
-      if (value.trim() === '')
-        throw new AxiError(`${name} requires a value`, 'VALIDATION_ERROR');
+      if (value.trim() === "")
+        throw new AxiError(`${name} requires a value`, "VALIDATION_ERROR");
       parsed[key] = value;
     }
   }
@@ -160,16 +166,26 @@ const LONG_STRING_CLEANUP_THRESHOLD = 200;
 /** Maximum length for cleaned string values before truncation. */
 const STRING_VALUE_TRUNCATION_LIMIT = 2000;
 
+export async function apiCommand(
+  args: string[],
+  ctx?: RepoContext,
+): Promise<string> {
+  if (args[0] === "--help" || args.length === 0) return API_HELP;
 
-export async function apiCommand(args: string[], ctx?: RepoContext): Promise<string> {
-  if (args[0] === '--help' || args.length === 0) return API_HELP;
-
-  const { positionals, fields, headers, jq, template, method: methodFlag, paginate, full } =
-    parseArgs(args);
+  const {
+    positionals,
+    fields,
+    headers,
+    jq,
+    template,
+    method: methodFlag,
+    paginate,
+    full,
+  } = parseArgs(args);
 
   const pathRequired = new AxiError(
-    'API path is required: gh-axi api [<method>] <path>',
-    'VALIDATION_ERROR',
+    "API path is required: gh-axi api [<method>] <path>",
+    "VALIDATION_ERROR",
   );
   if (positionals.length === 0) throw pathRequired;
 
@@ -178,36 +194,37 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
   const methodGiven = HTTP_METHODS.has(positionals[0].toUpperCase());
   if (methodFlag !== undefined && methodGiven) {
     throw new AxiError(
-      'method given twice: use either -X <method> or the positional method, not both',
-      'VALIDATION_ERROR',
+      "method given twice: use either -X <method> or the positional method, not both",
+      "VALIDATION_ERROR",
     );
   }
   if (positionals.length > (methodGiven ? 2 : 1)) {
     throw new AxiError(
-      'too many arguments for gh-axi api: expected [<method>] <path>',
-      'VALIDATION_ERROR',
+      "too many arguments for gh-axi api: expected [<method>] <path>",
+      "VALIDATION_ERROR",
     );
   }
   if (methodGiven && positionals.length < 2) throw pathRequired;
 
-  const method = methodFlag ?? (methodGiven ? positionals[0].toUpperCase() : 'GET');
+  const method =
+    methodFlag ?? (methodGiven ? positionals[0].toUpperCase() : "GET");
   const path = methodGiven ? positionals[1] : positionals[0];
 
-  const ghArgs = ['api', path, '--method', method];
+  const ghArgs = ["api", path, "--method", method];
 
   for (const f of fields) {
-    ghArgs.push('--field', f);
+    ghArgs.push("--field", f);
   }
 
   for (const h of headers) {
-    ghArgs.push('--header', h);
+    ghArgs.push("--header", h);
   }
 
-  if (paginate) ghArgs.push('--paginate');
+  if (paginate) ghArgs.push("--paginate");
 
-  if (jq !== undefined) ghArgs.push('--jq', jq);
+  if (jq !== undefined) ghArgs.push("--jq", jq);
 
-  if (template !== undefined) ghArgs.push('--template', template);
+  if (template !== undefined) ghArgs.push("--template", template);
 
   // A caller who wrote a jq expression or template already chose the exact shape
   // they want, so noisy-field stripping would silently delete fields they asked
@@ -232,12 +249,15 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
     const truncated = !full && trimmed.length > RAW_OUTPUT_TRUNCATION_LIMIT;
     const result: Record<string, unknown> = {
       api_response: {
-        body: truncated ? trimmed.slice(0, RAW_OUTPUT_TRUNCATION_LIMIT) : trimmed,
+        body: truncated
+          ? trimmed.slice(0, RAW_OUTPUT_TRUNCATION_LIMIT)
+          : trimmed,
         truncated,
       },
     };
     if (truncated) {
-      (result.api_response as Record<string, unknown>).original_length = trimmed.length;
+      (result.api_response as Record<string, unknown>).original_length =
+        trimmed.length;
     }
     return encode(result);
   }
@@ -245,30 +265,57 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
 
 /** Fields from raw GitHub API responses that are noisy/useless for agents */
 const NOISY_KEYS = new Set([
-  'avatar_url', 'gravatar_id', 'followers_url', 'following_url',
-  'gists_url', 'starred_url', 'subscriptions_url', 'organizations_url',
-  'repos_url', 'events_url', 'received_events_url', 'labels_url',
-  'comments_url', 'events_url', 'timeline_url', 'performed_via_github_app',
-  'node_id', 'url', 'repository_url', 'html_url',
-  'reactions', 'user_view_type', 'site_admin',
-  'issue_dependencies_summary', 'sub_issues_summary', 'pinned_comment',
-  'score', 'permissions', 'verification', '_links',
+  "avatar_url",
+  "gravatar_id",
+  "followers_url",
+  "following_url",
+  "gists_url",
+  "starred_url",
+  "subscriptions_url",
+  "organizations_url",
+  "repos_url",
+  "events_url",
+  "received_events_url",
+  "labels_url",
+  "comments_url",
+  "events_url",
+  "timeline_url",
+  "performed_via_github_app",
+  "node_id",
+  "url",
+  "repository_url",
+  "html_url",
+  "reactions",
+  "user_view_type",
+  "site_admin",
+  "issue_dependencies_summary",
+  "sub_issues_summary",
+  "pinned_comment",
+  "score",
+  "permissions",
+  "verification",
+  "_links",
 ]);
 
 /** Keys ending in _url that are template URLs agents never use */
 function isTemplateUrlKey(key: string): boolean {
-  if (!key.endsWith('_url')) return false;
+  if (!key.endsWith("_url")) return false;
   // Keep a few meaningful URL keys
   const KEEP_URL_KEYS = new Set([
-    'diff_url', 'patch_url', 'clone_url', 'ssh_url', 'git_url', 'svn_url',
-    'commit_url', // useful for linking to specific commits
+    "diff_url",
+    "patch_url",
+    "clone_url",
+    "ssh_url",
+    "git_url",
+    "svn_url",
+    "commit_url", // useful for linking to specific commits
   ]);
   return !KEEP_URL_KEYS.has(key);
 }
 
 /** Collapse repo/repository objects to essential fields only */
 function collapseRepo(obj: Record<string, unknown>): Record<string, unknown> {
-  if ('full_name' in obj) {
+  if ("full_name" in obj) {
     const collapsed: Record<string, unknown> = { full_name: obj.full_name };
     if (obj.default_branch) collapsed.default_branch = obj.default_branch;
     if (obj.private) collapsed.private = obj.private;
@@ -280,7 +327,7 @@ function collapseRepo(obj: Record<string, unknown>): Record<string, unknown> {
 /** Bound a string value's length, leaving its content untouched. */
 function truncateString(value: string): string {
   if (value.length <= STRING_VALUE_TRUNCATION_LIMIT) return value;
-  return value.slice(0, STRING_VALUE_TRUNCATION_LIMIT) + '... (truncated)';
+  return value.slice(0, STRING_VALUE_TRUNCATION_LIMIT) + "... (truncated)";
 }
 
 /** Clean and truncate a long string value (e.g. bodies, comments, blobs). */
@@ -310,31 +357,50 @@ function shapeOutput(
       shapeOutput(item, stripNoisyKeys, truncateValues, depth + 1),
     );
   }
-  if (obj !== null && typeof obj === 'object') {
+  if (obj !== null && typeof obj === "object") {
     const record = obj as Record<string, unknown>;
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(record)) {
       if (!stripNoisyKeys) {
-        result[key] = shapeOutput(value, stripNoisyKeys, truncateValues, depth + 1);
+        result[key] = shapeOutput(
+          value,
+          stripNoisyKeys,
+          truncateValues,
+          depth + 1,
+        );
         continue;
       }
       if (NOISY_KEYS.has(key)) continue;
       if (isTemplateUrlKey(key)) continue;
       // Strip nested user objects down to just login
-      if (key === 'user' && value && typeof value === 'object' && 'login' in (value as Record<string, unknown>)) {
+      if (
+        key === "user" &&
+        value &&
+        typeof value === "object" &&
+        "login" in (value as Record<string, unknown>)
+      ) {
         result[key] = (value as Record<string, unknown>).login;
         continue;
       }
       // Collapse repo/repository objects to essential fields
-      if ((key === 'repo' || key === 'repository') && value && typeof value === 'object') {
+      if (
+        (key === "repo" || key === "repository") &&
+        value &&
+        typeof value === "object"
+      ) {
         result[key] = collapseRepo(value as Record<string, unknown>);
         continue;
       }
-      result[key] = shapeOutput(value, stripNoisyKeys, truncateValues, depth + 1);
+      result[key] = shapeOutput(
+        value,
+        stripNoisyKeys,
+        truncateValues,
+        depth + 1,
+      );
     }
     return result;
   }
-  if (typeof obj === 'string') {
+  if (typeof obj === "string") {
     if (!truncateValues) return obj;
     return stripNoisyKeys ? clampString(obj) : truncateString(obj);
   }

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -1,8 +1,8 @@
-import { encode } from "@toon-format/toon";
-import type { RepoContext } from "../context.js";
-import { ghExec } from "../gh.js";
-import { AxiError } from "../errors.js";
-import { cleanBody } from "../body.js";
+import { encode } from '@toon-format/toon';
+import type { RepoContext } from '../context.js';
+import { ghExec } from '../gh.js';
+import { AxiError } from '../errors.js';
+import { cleanBody } from '../body.js';
 
 export const API_HELP = `usage: gh-axi api [<method>] <path>
 description: Make an authenticated GitHub API request. Defaults to GET if no method specified.
@@ -17,22 +17,22 @@ examples:
   gh-axi api /repos/{owner}/{repo}/pulls --paginate
   gh-axi api /repos/{owner}/{repo}/issues/1 --jq '[.labels[].name]'`;
 
-const HTTP_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]);
+const HTTP_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD']);
 
 /** The `gh api` short flag for HTTP method, equivalent to the positional method. */
-const METHOD_FLAG = "-X";
+const METHOD_FLAG = '-X';
 
 /** Value flags that may be given more than once, each occurrence forwarded to gh. */
-const REPEATABLE_VALUE_FLAGS = new Set(["--field", "--header"]);
+const REPEATABLE_VALUE_FLAGS = new Set(['--field', '--header']);
 
 /** Value flags that gh accepts only one of, so a repeat is a caller mistake. */
-const SINGLE_VALUE_FLAGS = new Set(["--jq", "--template"]);
+const SINGLE_VALUE_FLAGS = new Set(['--jq', '--template']);
 
 /** Flags that stand alone and must not consume the following argument, and are forwarded to gh. */
-const BOOL_FLAGS = new Set(["--paginate"]);
+const BOOL_FLAGS = new Set(['--paginate']);
 
 /** Flags that stand alone, are gh-axi-only, and must not be forwarded to gh. */
-const LOCAL_BOOL_FLAGS = new Set(["--full"]);
+const LOCAL_BOOL_FLAGS = new Set(['--full']);
 
 const SUPPORTED_FLAGS = [
   METHOD_FLAG,
@@ -44,7 +44,7 @@ const SUPPORTED_FLAGS = [
 
 /** The flag's name without any `=value` suffix, so errors never echo a value. */
 function flagName(arg: string): string {
-  const equals = arg.indexOf("=");
+  const equals = arg.indexOf('=');
   return equals === -1 ? arg : arg.slice(0, equals);
 }
 
@@ -84,20 +84,20 @@ function parseArgs(args: string[]): ParsedApiArgs {
   };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    if (!arg.startsWith("-")) {
+    if (!arg.startsWith('-')) {
       parsed.positionals.push(arg);
       continue;
     }
     const name = flagName(arg);
     if (BOOL_FLAGS.has(name)) {
       if (name !== arg)
-        throw new AxiError(`${name} does not take a value`, "VALIDATION_ERROR");
+        throw new AxiError(`${name} does not take a value`, 'VALIDATION_ERROR');
       parsed.paginate = true;
       continue;
     }
     if (LOCAL_BOOL_FLAGS.has(name)) {
       if (name !== arg)
-        throw new AxiError(`${name} does not take a value`, "VALIDATION_ERROR");
+        throw new AxiError(`${name} does not take a value`, 'VALIDATION_ERROR');
       parsed.full = true;
       continue;
     }
@@ -107,50 +107,44 @@ function parseArgs(args: string[]): ParsedApiArgs {
       !SINGLE_VALUE_FLAGS.has(name)
     ) {
       throw new AxiError(
-        `unknown flag ${name} for gh-axi api. Supported flags: ${SUPPORTED_FLAGS.join(", ")}`,
-        "VALIDATION_ERROR",
+        `unknown flag ${name} for gh-axi api. Supported flags: ${SUPPORTED_FLAGS.join(', ')}`,
+        'VALIDATION_ERROR',
       );
     }
     // `--flag=value` carries its own value; `--flag value` consumes the next arg.
     let value: string;
     if (name === arg) {
       if (i + 1 >= args.length)
-        throw new AxiError(`${name} requires a value`, "VALIDATION_ERROR");
+        throw new AxiError(`${name} requires a value`, 'VALIDATION_ERROR');
       value = args[++i];
     } else {
       value = arg.slice(name.length + 1);
     }
     if (name === METHOD_FLAG) {
       if (parsed.method !== undefined)
-        throw new AxiError(
-          `${name} may only be given once`,
-          "VALIDATION_ERROR",
-        );
+        throw new AxiError(`${name} may only be given once`, 'VALIDATION_ERROR');
       const upper = value.toUpperCase();
       if (!HTTP_METHODS.has(upper)) {
         throw new AxiError(
-          `${name} ${value} is not a supported HTTP method. Supported: ${[...HTTP_METHODS].join(", ")}`,
-          "VALIDATION_ERROR",
+          `${name} ${value} is not a supported HTTP method. Supported: ${[...HTTP_METHODS].join(', ')}`,
+          'VALIDATION_ERROR',
         );
       }
       parsed.method = upper;
-    } else if (name === "--field") {
+    } else if (name === '--field') {
       parsed.fields.push(value);
-    } else if (name === "--header") {
+    } else if (name === '--header') {
       parsed.headers.push(value);
     } else {
       // gh takes the last occurrence; discarding the earlier expression silently
       // is the same failure this parser exists to prevent, so reject instead.
-      const key = name === "--jq" ? "jq" : "template";
+      const key = name === '--jq' ? 'jq' : 'template';
       if (parsed[key] !== undefined)
-        throw new AxiError(
-          `${name} may only be given once`,
-          "VALIDATION_ERROR",
-        );
+        throw new AxiError(`${name} may only be given once`, 'VALIDATION_ERROR');
       // An empty value (an unset shell variable) is a no-op filter for gh that
       // would still suppress the default field stripping here.
-      if (value.trim() === "")
-        throw new AxiError(`${name} requires a value`, "VALIDATION_ERROR");
+      if (value.trim() === '')
+        throw new AxiError(`${name} requires a value`, 'VALIDATION_ERROR');
       parsed[key] = value;
     }
   }
@@ -166,26 +160,16 @@ const LONG_STRING_CLEANUP_THRESHOLD = 200;
 /** Maximum length for cleaned string values before truncation. */
 const STRING_VALUE_TRUNCATION_LIMIT = 2000;
 
-export async function apiCommand(
-  args: string[],
-  ctx?: RepoContext,
-): Promise<string> {
-  if (args[0] === "--help" || args.length === 0) return API_HELP;
 
-  const {
-    positionals,
-    fields,
-    headers,
-    jq,
-    template,
-    method: methodFlag,
-    paginate,
-    full,
-  } = parseArgs(args);
+export async function apiCommand(args: string[], ctx?: RepoContext): Promise<string> {
+  if (args[0] === '--help' || args.length === 0) return API_HELP;
+
+  const { positionals, fields, headers, jq, template, method: methodFlag, paginate, full } =
+    parseArgs(args);
 
   const pathRequired = new AxiError(
-    "API path is required: gh-axi api [<method>] <path>",
-    "VALIDATION_ERROR",
+    'API path is required: gh-axi api [<method>] <path>',
+    'VALIDATION_ERROR',
   );
   if (positionals.length === 0) throw pathRequired;
 
@@ -194,37 +178,36 @@ export async function apiCommand(
   const methodGiven = HTTP_METHODS.has(positionals[0].toUpperCase());
   if (methodFlag !== undefined && methodGiven) {
     throw new AxiError(
-      "method given twice: use either -X <method> or the positional method, not both",
-      "VALIDATION_ERROR",
+      'method given twice: use either -X <method> or the positional method, not both',
+      'VALIDATION_ERROR',
     );
   }
   if (positionals.length > (methodGiven ? 2 : 1)) {
     throw new AxiError(
-      "too many arguments for gh-axi api: expected [<method>] <path>",
-      "VALIDATION_ERROR",
+      'too many arguments for gh-axi api: expected [<method>] <path>',
+      'VALIDATION_ERROR',
     );
   }
   if (methodGiven && positionals.length < 2) throw pathRequired;
 
-  const method =
-    methodFlag ?? (methodGiven ? positionals[0].toUpperCase() : "GET");
+  const method = methodFlag ?? (methodGiven ? positionals[0].toUpperCase() : 'GET');
   const path = methodGiven ? positionals[1] : positionals[0];
 
-  const ghArgs = ["api", path, "--method", method];
+  const ghArgs = ['api', path, '--method', method];
 
   for (const f of fields) {
-    ghArgs.push("--field", f);
+    ghArgs.push('--field', f);
   }
 
   for (const h of headers) {
-    ghArgs.push("--header", h);
+    ghArgs.push('--header', h);
   }
 
-  if (paginate) ghArgs.push("--paginate");
+  if (paginate) ghArgs.push('--paginate');
 
-  if (jq !== undefined) ghArgs.push("--jq", jq);
+  if (jq !== undefined) ghArgs.push('--jq', jq);
 
-  if (template !== undefined) ghArgs.push("--template", template);
+  if (template !== undefined) ghArgs.push('--template', template);
 
   // A caller who wrote a jq expression or template already chose the exact shape
   // they want, so noisy-field stripping would silently delete fields they asked
@@ -249,15 +232,12 @@ export async function apiCommand(
     const truncated = !full && trimmed.length > RAW_OUTPUT_TRUNCATION_LIMIT;
     const result: Record<string, unknown> = {
       api_response: {
-        body: truncated
-          ? trimmed.slice(0, RAW_OUTPUT_TRUNCATION_LIMIT)
-          : trimmed,
+        body: truncated ? trimmed.slice(0, RAW_OUTPUT_TRUNCATION_LIMIT) : trimmed,
         truncated,
       },
     };
     if (truncated) {
-      (result.api_response as Record<string, unknown>).original_length =
-        trimmed.length;
+      (result.api_response as Record<string, unknown>).original_length = trimmed.length;
     }
     return encode(result);
   }
@@ -265,57 +245,30 @@ export async function apiCommand(
 
 /** Fields from raw GitHub API responses that are noisy/useless for agents */
 const NOISY_KEYS = new Set([
-  "avatar_url",
-  "gravatar_id",
-  "followers_url",
-  "following_url",
-  "gists_url",
-  "starred_url",
-  "subscriptions_url",
-  "organizations_url",
-  "repos_url",
-  "events_url",
-  "received_events_url",
-  "labels_url",
-  "comments_url",
-  "events_url",
-  "timeline_url",
-  "performed_via_github_app",
-  "node_id",
-  "url",
-  "repository_url",
-  "html_url",
-  "reactions",
-  "user_view_type",
-  "site_admin",
-  "issue_dependencies_summary",
-  "sub_issues_summary",
-  "pinned_comment",
-  "score",
-  "permissions",
-  "verification",
-  "_links",
+  'avatar_url', 'gravatar_id', 'followers_url', 'following_url',
+  'gists_url', 'starred_url', 'subscriptions_url', 'organizations_url',
+  'repos_url', 'events_url', 'received_events_url', 'labels_url',
+  'comments_url', 'events_url', 'timeline_url', 'performed_via_github_app',
+  'node_id', 'url', 'repository_url', 'html_url',
+  'reactions', 'user_view_type', 'site_admin',
+  'issue_dependencies_summary', 'sub_issues_summary', 'pinned_comment',
+  'score', 'permissions', 'verification', '_links',
 ]);
 
 /** Keys ending in _url that are template URLs agents never use */
 function isTemplateUrlKey(key: string): boolean {
-  if (!key.endsWith("_url")) return false;
+  if (!key.endsWith('_url')) return false;
   // Keep a few meaningful URL keys
   const KEEP_URL_KEYS = new Set([
-    "diff_url",
-    "patch_url",
-    "clone_url",
-    "ssh_url",
-    "git_url",
-    "svn_url",
-    "commit_url", // useful for linking to specific commits
+    'diff_url', 'patch_url', 'clone_url', 'ssh_url', 'git_url', 'svn_url',
+    'commit_url', // useful for linking to specific commits
   ]);
   return !KEEP_URL_KEYS.has(key);
 }
 
 /** Collapse repo/repository objects to essential fields only */
 function collapseRepo(obj: Record<string, unknown>): Record<string, unknown> {
-  if ("full_name" in obj) {
+  if ('full_name' in obj) {
     const collapsed: Record<string, unknown> = { full_name: obj.full_name };
     if (obj.default_branch) collapsed.default_branch = obj.default_branch;
     if (obj.private) collapsed.private = obj.private;
@@ -327,7 +280,7 @@ function collapseRepo(obj: Record<string, unknown>): Record<string, unknown> {
 /** Bound a string value's length, leaving its content untouched. */
 function truncateString(value: string): string {
   if (value.length <= STRING_VALUE_TRUNCATION_LIMIT) return value;
-  return value.slice(0, STRING_VALUE_TRUNCATION_LIMIT) + "... (truncated)";
+  return value.slice(0, STRING_VALUE_TRUNCATION_LIMIT) + '... (truncated)';
 }
 
 /** Clean and truncate a long string value (e.g. bodies, comments, blobs). */
@@ -357,50 +310,31 @@ function shapeOutput(
       shapeOutput(item, stripNoisyKeys, truncateValues, depth + 1),
     );
   }
-  if (obj !== null && typeof obj === "object") {
+  if (obj !== null && typeof obj === 'object') {
     const record = obj as Record<string, unknown>;
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(record)) {
       if (!stripNoisyKeys) {
-        result[key] = shapeOutput(
-          value,
-          stripNoisyKeys,
-          truncateValues,
-          depth + 1,
-        );
+        result[key] = shapeOutput(value, stripNoisyKeys, truncateValues, depth + 1);
         continue;
       }
       if (NOISY_KEYS.has(key)) continue;
       if (isTemplateUrlKey(key)) continue;
       // Strip nested user objects down to just login
-      if (
-        key === "user" &&
-        value &&
-        typeof value === "object" &&
-        "login" in (value as Record<string, unknown>)
-      ) {
+      if (key === 'user' && value && typeof value === 'object' && 'login' in (value as Record<string, unknown>)) {
         result[key] = (value as Record<string, unknown>).login;
         continue;
       }
       // Collapse repo/repository objects to essential fields
-      if (
-        (key === "repo" || key === "repository") &&
-        value &&
-        typeof value === "object"
-      ) {
+      if ((key === 'repo' || key === 'repository') && value && typeof value === 'object') {
         result[key] = collapseRepo(value as Record<string, unknown>);
         continue;
       }
-      result[key] = shapeOutput(
-        value,
-        stripNoisyKeys,
-        truncateValues,
-        depth + 1,
-      );
+      result[key] = shapeOutput(value, stripNoisyKeys, truncateValues, depth + 1);
     }
     return result;
   }
-  if (typeof obj === "string") {
+  if (typeof obj === 'string') {
     if (!truncateValues) return obj;
     return stripNoisyKeys ? clampString(obj) : truncateString(obj);
   }

--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -8,15 +8,19 @@ export const API_HELP = `usage: gh-axi api [<method>] <path>
 description: Make an authenticated GitHub API request. Defaults to GET if no method specified.
 methods[6]:
   GET, POST, PUT, PATCH, DELETE, HEAD
-flags[6]:
-  --field <key=value> (repeatable), --header <key:value> (repeatable), --paginate, --jq <expression>, --template <format>, --full (preserve complete field values and response bodies without truncation)
+flags[7]:
+  -X <method> (alias for the positional method, e.g. -X POST), --field <key=value> (repeatable), --header <key:value> (repeatable), --paginate, --jq <expression>, --template <format>, --full (preserve complete field values and response bodies without truncation)
 examples:
   gh-axi api /repos/{owner}/{repo}
   gh-axi api POST /repos/{owner}/{repo}/issues --field title="Bug report"
+  gh-axi api -X POST /repos/{owner}/{repo}/issues --field title="Bug report"
   gh-axi api /repos/{owner}/{repo}/pulls --paginate
   gh-axi api /repos/{owner}/{repo}/issues/1 --jq '[.labels[].name]'`;
 
 const HTTP_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD']);
+
+/** The `gh api` short flag for HTTP method, equivalent to the positional method. */
+const METHOD_FLAG = '-X';
 
 /** Value flags that may be given more than once, each occurrence forwarded to gh. */
 const REPEATABLE_VALUE_FLAGS = new Set(['--field', '--header']);
@@ -31,6 +35,7 @@ const BOOL_FLAGS = new Set(['--paginate']);
 const LOCAL_BOOL_FLAGS = new Set(['--full']);
 
 const SUPPORTED_FLAGS = [
+  METHOD_FLAG,
   ...REPEATABLE_VALUE_FLAGS,
   ...SINGLE_VALUE_FLAGS,
   ...BOOL_FLAGS,
@@ -49,6 +54,7 @@ interface ParsedApiArgs {
   headers: string[];
   jq?: string;
   template?: string;
+  method?: string;
   paginate: boolean;
   full: boolean;
 }
@@ -95,7 +101,11 @@ function parseArgs(args: string[]): ParsedApiArgs {
       parsed.full = true;
       continue;
     }
-    if (!REPEATABLE_VALUE_FLAGS.has(name) && !SINGLE_VALUE_FLAGS.has(name)) {
+    if (
+      name !== METHOD_FLAG &&
+      !REPEATABLE_VALUE_FLAGS.has(name) &&
+      !SINGLE_VALUE_FLAGS.has(name)
+    ) {
       throw new AxiError(
         `unknown flag ${name} for gh-axi api. Supported flags: ${SUPPORTED_FLAGS.join(', ')}`,
         'VALIDATION_ERROR',
@@ -110,7 +120,18 @@ function parseArgs(args: string[]): ParsedApiArgs {
     } else {
       value = arg.slice(name.length + 1);
     }
-    if (name === '--field') {
+    if (name === METHOD_FLAG) {
+      if (parsed.method !== undefined)
+        throw new AxiError(`${name} may only be given once`, 'VALIDATION_ERROR');
+      const upper = value.toUpperCase();
+      if (!HTTP_METHODS.has(upper)) {
+        throw new AxiError(
+          `${name} ${value} is not a supported HTTP method. Supported: ${[...HTTP_METHODS].join(', ')}`,
+          'VALIDATION_ERROR',
+        );
+      }
+      parsed.method = upper;
+    } else if (name === '--field') {
       parsed.fields.push(value);
     } else if (name === '--header') {
       parsed.headers.push(value);
@@ -143,7 +164,7 @@ const STRING_VALUE_TRUNCATION_LIMIT = 2000;
 export async function apiCommand(args: string[], ctx?: RepoContext): Promise<string> {
   if (args[0] === '--help' || args.length === 0) return API_HELP;
 
-  const { positionals, fields, headers, jq, template, paginate, full } =
+  const { positionals, fields, headers, jq, template, method: methodFlag, paginate, full } =
     parseArgs(args);
 
   const pathRequired = new AxiError(
@@ -155,6 +176,12 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
   // A positional the command cannot place is a caller typo, and dropping it
   // silently requests a different endpoint than the one that was asked for.
   const methodGiven = HTTP_METHODS.has(positionals[0].toUpperCase());
+  if (methodFlag !== undefined && methodGiven) {
+    throw new AxiError(
+      'method given twice: use either -X <method> or the positional method, not both',
+      'VALIDATION_ERROR',
+    );
+  }
   if (positionals.length > (methodGiven ? 2 : 1)) {
     throw new AxiError(
       'too many arguments for gh-axi api: expected [<method>] <path>',
@@ -163,7 +190,7 @@ export async function apiCommand(args: string[], ctx?: RepoContext): Promise<str
   }
   if (methodGiven && positionals.length < 2) throw pathRequired;
 
-  const method = methodGiven ? positionals[0].toUpperCase() : 'GET';
+  const method = methodFlag ?? (methodGiven ? positionals[0].toUpperCase() : 'GET');
   const path = methodGiven ? positionals[1] : positionals[0];
 
   const ghArgs = ['api', path, '--method', method];

--- a/test/commands/api.test.ts
+++ b/test/commands/api.test.ts
@@ -48,6 +48,60 @@ describe('apiCommand', () => {
     );
   });
 
+  it('maps -X <method> to --method instead of silently sending GET', async () => {
+    mockedGhExec.mockResolvedValue('{}');
+
+    await apiCommand(['-X', 'POST', '/repos/octo/repo/pulls/1/requested_reviewers']);
+
+    expect(mockedGhExec).toHaveBeenCalledWith(
+      expect.arrayContaining(['api', '/repos/octo/repo/pulls/1/requested_reviewers', '--method', 'POST']),
+      undefined,
+    );
+    // The old bug forwarded no --method at all, defaulting gh itself to GET.
+    const ghArgs = mockedGhExec.mock.calls[0][0];
+    expect(ghArgs.filter((a) => a === '--method')).toHaveLength(1);
+    expect(ghArgs).not.toContain('-X');
+  });
+
+  it('supports -X=<method> form', async () => {
+    mockedGhExec.mockResolvedValue('{}');
+
+    await apiCommand(['-X=PUT', '/repos/octo/repo/topics']);
+
+    expect(mockedGhExec).toHaveBeenCalledWith(
+      expect.arrayContaining(['--method', 'PUT']),
+      undefined,
+    );
+  });
+
+  it('rejects an unsupported -X method instead of silently defaulting to GET', async () => {
+    await expect(apiCommand(['-X', 'BOGUS', '/repos/octo/repo'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it('rejects -X given together with a positional method', async () => {
+    await expect(
+      apiCommand(['-X', 'POST', 'PUT', '/repos/octo/repo']),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it('rejects a repeated -X instead of silently keeping the first', async () => {
+    await expect(
+      apiCommand(['-X', 'POST', '-X', 'PUT', '/repos/octo/repo']),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it('rejects -X with no value', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '-X'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
   it('passes --field flags', async () => {
     mockedGhExec.mockResolvedValue('{}');
 

--- a/test/commands/api.test.ts
+++ b/test/commands/api.test.ts
@@ -1,395 +1,482 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from "vitest";
 
-vi.mock('../../src/gh.js', () => ({
+vi.mock("../../src/gh.js", () => ({
   ghJson: vi.fn(),
   ghExec: vi.fn(),
   ghRaw: vi.fn(),
 }));
 
-import { ghExec } from '../../src/gh.js';
-import { apiCommand, API_HELP } from '../../src/commands/api.js';
+import { ghExec } from "../../src/gh.js";
+import { apiCommand, API_HELP } from "../../src/commands/api.js";
 
 const mockedGhExec = vi.mocked(ghExec);
 
-describe('apiCommand', () => {
+describe("apiCommand", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  it('returns help when --help is passed', async () => {
-    const result = await apiCommand(['--help']);
+  it("returns help when --help is passed", async () => {
+    const result = await apiCommand(["--help"]);
     expect(result).toBe(API_HELP);
   });
 
-  it('returns help when no args are passed', async () => {
+  it("returns help when no args are passed", async () => {
     const result = await apiCommand([]);
     expect(result).toBe(API_HELP);
   });
 
-  it('defaults to GET method', async () => {
-    mockedGhExec.mockResolvedValue('{}');
+  it("defaults to GET method", async () => {
+    mockedGhExec.mockResolvedValue("{}");
 
-    await apiCommand(['/repos/octo/repo']);
+    await apiCommand(["/repos/octo/repo"]);
 
     expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(['api', '/repos/octo/repo', '--method', 'GET']),
+      expect.arrayContaining(["api", "/repos/octo/repo", "--method", "GET"]),
       undefined,
     );
   });
 
-  it('uses explicit method when provided', async () => {
-    mockedGhExec.mockResolvedValue('{}');
+  it("uses explicit method when provided", async () => {
+    mockedGhExec.mockResolvedValue("{}");
 
-    await apiCommand(['POST', '/repos/octo/repo/issues']);
+    await apiCommand(["POST", "/repos/octo/repo/issues"]);
 
     expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(['--method', 'POST']),
+      expect.arrayContaining(["--method", "POST"]),
       undefined,
     );
   });
 
-  it('maps -X <method> to --method instead of silently sending GET', async () => {
-    mockedGhExec.mockResolvedValue('{}');
-
-    await apiCommand(['-X', 'POST', '/repos/octo/repo/pulls/1/requested_reviewers']);
-
-    expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(['api', '/repos/octo/repo/pulls/1/requested_reviewers', '--method', 'POST']),
-      undefined,
-    );
-    // The old bug forwarded no --method at all, defaulting gh itself to GET.
-    const ghArgs = mockedGhExec.mock.calls[0][0];
-    expect(ghArgs.filter((a) => a === '--method')).toHaveLength(1);
-    expect(ghArgs).not.toContain('-X');
-  });
-
-  it('supports -X=<method> form', async () => {
-    mockedGhExec.mockResolvedValue('{}');
-
-    await apiCommand(['-X=PUT', '/repos/octo/repo/topics']);
-
-    expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(['--method', 'PUT']),
-      undefined,
-    );
-  });
-
-  it('rejects an unsupported -X method instead of silently defaulting to GET', async () => {
-    await expect(apiCommand(['-X', 'BOGUS', '/repos/octo/repo'])).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
-    });
-    expect(mockedGhExec).not.toHaveBeenCalled();
-  });
-
-  it('rejects -X given together with a positional method', async () => {
-    await expect(
-      apiCommand(['-X', 'POST', 'PUT', '/repos/octo/repo']),
-    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
-    expect(mockedGhExec).not.toHaveBeenCalled();
-  });
-
-  it('rejects a repeated -X instead of silently keeping the first', async () => {
-    await expect(
-      apiCommand(['-X', 'POST', '-X', 'PUT', '/repos/octo/repo']),
-    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
-    expect(mockedGhExec).not.toHaveBeenCalled();
-  });
-
-  it('rejects -X with no value', async () => {
-    await expect(apiCommand(['/repos/octo/repo', '-X'])).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
-    });
-    expect(mockedGhExec).not.toHaveBeenCalled();
-  });
-
-  it('passes --field flags', async () => {
-    mockedGhExec.mockResolvedValue('{}');
-
-    await apiCommand(['POST', '/repos/octo/repo/issues', '--field', 'title=Bug']);
-
-    expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(['--field', 'title=Bug']),
-      undefined,
-    );
-  });
-
-  it('passes --header flags', async () => {
-    mockedGhExec.mockResolvedValue('{}');
-
-    await apiCommand(['/repos/octo/repo', '--header', 'Accept:application/json']);
-
-    expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(['--header', 'Accept:application/json']),
-      undefined,
-    );
-  });
-
-  it('cleans JSON output by stripping noisy fields', async () => {
-    mockedGhExec.mockResolvedValue(JSON.stringify({
-      id: 1,
-      title: 'Test issue',
-      node_id: 'abc123',
-      avatar_url: 'https://avatars.example.com/u/123',
-      user: { login: 'alice', avatar_url: 'https://example.com', node_id: 'xyz' },
-    }));
-
-    const result = await apiCommand(['/repos/octo/repo/issues/1']);
-
-    expect(result).toContain('Test issue');
-    // node_id and avatar_url are noisy fields, should be stripped
-    expect(result).not.toContain('abc123');
-    expect(result).not.toContain('avatars.example.com');
-    // user should be collapsed to login
-    expect(result).toContain('alice');
-  });
-
-  it('wraps non-JSON output in TOON envelope', async () => {
-    mockedGhExec.mockResolvedValue('plain text response');
-
-    const result = await apiCommand(['/some/endpoint']);
-
-    // Should be wrapped in a TOON object, not raw text
-    expect(result).toContain('api_response:');
-    expect(result).toContain('plain text response');
-    expect(result).toContain('truncated: false');
-  });
-
-  it('forwards --jq to gh api', async () => {
-    mockedGhExec.mockResolvedValue('[]');
-
-    await apiCommand(['/repos/octo/repo/issues/1', '--jq', '[.labels[].name]']);
-
-    expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(['--jq', '[.labels[].name]']),
-      undefined,
-    );
-  });
-
-  it('forwards --template to gh api', async () => {
-    mockedGhExec.mockResolvedValue('out');
-
-    await apiCommand(['/repos/octo/repo', '--template', '{{.name}}']);
-
-    expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(['--template', '{{.name}}']),
-      undefined,
-    );
-  });
-
-  it('does not strip fields the caller explicitly selected with --jq', async () => {
-    // `url` is a noisy key by default, but selecting it by hand is deliberate.
-    mockedGhExec.mockResolvedValue(JSON.stringify({ url: 'https://api.github.com/x' }));
-
-    const result = await apiCommand(['/repos/octo/repo', '--jq', '{url: .url}']);
-
-    expect(result).toContain('https://api.github.com/x');
-  });
-
-  it('rejects an unknown flag instead of silently ignoring it', async () => {
-    await expect(apiCommand(['/repos/octo/repo', '--bogus', 'x'])).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
-    });
-    expect(mockedGhExec).not.toHaveBeenCalled();
-  });
-
-  it('names the offending flag without echoing its value', async () => {
-    await expect(apiCommand(['/repos/octo/repo', '--token=hunter2'])).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
-      message: expect.stringContaining('--token'),
-    });
-    await expect(apiCommand(['/repos/octo/repo', '--token=hunter2'])).rejects.not.toMatchObject({
-      message: expect.stringContaining('hunter2'),
-    });
-  });
-
-  it('does not consume the path when --paginate precedes it', async () => {
-    mockedGhExec.mockResolvedValue('{}');
-
-    await apiCommand(['--paginate', '/repos/octo/repo/pulls']);
-
-    expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(['api', '/repos/octo/repo/pulls', '--paginate']),
-      undefined,
-    );
-  });
-
-  it('rejects a repeated --jq instead of silently dropping one expression', async () => {
-    await expect(
-      apiCommand(['/repos/octo/repo', '--jq', '.name', '--jq', '.full_name']),
-    ).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
-      message: expect.stringContaining('--jq'),
-    });
-    expect(mockedGhExec).not.toHaveBeenCalled();
-  });
-
-  it('rejects a repeated --template without echoing either value', async () => {
-    await expect(
-      apiCommand(['/repos/octo/repo', '--template={{.name}}', '--template={{.id}}']),
-    ).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
-      message: expect.stringContaining('--template'),
-    });
-    await expect(
-      apiCommand(['/repos/octo/repo', '--template={{.name}}', '--template={{.id}}']),
-    ).rejects.not.toMatchObject({ message: expect.stringContaining('{{.name}}') });
-  });
-
-  it('does not forward a flag-shaped --header value as its own flag', async () => {
-    mockedGhExec.mockResolvedValue('{}');
-
-    await apiCommand(['/repos/octo/repo', '--header', '--jq=.x']);
-
-    const ghArgs = mockedGhExec.mock.calls[0][0];
-    expect(ghArgs).toEqual(expect.arrayContaining(['--header', '--jq=.x']));
-    expect(ghArgs).not.toContain('--jq');
-  });
-
-  it('truncates long string values in caller-shaped --jq output', async () => {
-    const blob = 'a'.repeat(50_000);
-    mockedGhExec.mockResolvedValue(JSON.stringify({ content: blob }));
-
-    const result = await apiCommand(['/repos/octo/repo/readme', '--jq', '{content: .content}']);
-
-    expect(result).toContain('... (truncated)');
-    expect(result.length).toBeLessThan(3000);
-  });
-
-  it('repeats --field and --header flags in order', async () => {
-    mockedGhExec.mockResolvedValue('{}');
+  it("maps -X <method> to --method instead of silently sending GET", async () => {
+    mockedGhExec.mockResolvedValue("{}");
 
     await apiCommand([
-      'POST', '/repos/octo/repo/issues',
-      '--field', 'title=Bug', '--field=body=Broken',
-      '--header', 'A:1', '--header', 'B:2',
+      "-X",
+      "POST",
+      "/repos/octo/repo/pulls/1/requested_reviewers",
     ]);
 
     expect(mockedGhExec).toHaveBeenCalledWith(
       expect.arrayContaining([
-        '--field', 'title=Bug', '--field', 'body=Broken',
-        '--header', 'A:1', '--header', 'B:2',
+        "api",
+        "/repos/octo/repo/pulls/1/requested_reviewers",
+        "--method",
+        "POST",
+      ]),
+      undefined,
+    );
+    // The old bug forwarded no --method at all, defaulting gh itself to GET.
+    const ghArgs = mockedGhExec.mock.calls[0][0];
+    expect(ghArgs.filter((a) => a === "--method")).toHaveLength(1);
+    expect(ghArgs).not.toContain("-X");
+  });
+
+  it("supports -X=<method> form", async () => {
+    mockedGhExec.mockResolvedValue("{}");
+
+    await apiCommand(["-X=PUT", "/repos/octo/repo/topics"]);
+
+    expect(mockedGhExec).toHaveBeenCalledWith(
+      expect.arrayContaining(["--method", "PUT"]),
+      undefined,
+    );
+  });
+
+  it("rejects an unsupported -X method instead of silently defaulting to GET", async () => {
+    await expect(
+      apiCommand(["-X", "BOGUS", "/repos/octo/repo"]),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it("rejects -X given together with a positional method", async () => {
+    await expect(
+      apiCommand(["-X", "POST", "PUT", "/repos/octo/repo"]),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it("rejects a repeated -X instead of silently keeping the first", async () => {
+    await expect(
+      apiCommand(["-X", "POST", "-X", "PUT", "/repos/octo/repo"]),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it("rejects -X with no value", async () => {
+    await expect(apiCommand(["/repos/octo/repo", "-X"])).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it("passes --field flags", async () => {
+    mockedGhExec.mockResolvedValue("{}");
+
+    await apiCommand([
+      "POST",
+      "/repos/octo/repo/issues",
+      "--field",
+      "title=Bug",
+    ]);
+
+    expect(mockedGhExec).toHaveBeenCalledWith(
+      expect.arrayContaining(["--field", "title=Bug"]),
+      undefined,
+    );
+  });
+
+  it("passes --header flags", async () => {
+    mockedGhExec.mockResolvedValue("{}");
+
+    await apiCommand([
+      "/repos/octo/repo",
+      "--header",
+      "Accept:application/json",
+    ]);
+
+    expect(mockedGhExec).toHaveBeenCalledWith(
+      expect.arrayContaining(["--header", "Accept:application/json"]),
+      undefined,
+    );
+  });
+
+  it("cleans JSON output by stripping noisy fields", async () => {
+    mockedGhExec.mockResolvedValue(
+      JSON.stringify({
+        id: 1,
+        title: "Test issue",
+        node_id: "abc123",
+        avatar_url: "https://avatars.example.com/u/123",
+        user: {
+          login: "alice",
+          avatar_url: "https://example.com",
+          node_id: "xyz",
+        },
+      }),
+    );
+
+    const result = await apiCommand(["/repos/octo/repo/issues/1"]);
+
+    expect(result).toContain("Test issue");
+    // node_id and avatar_url are noisy fields, should be stripped
+    expect(result).not.toContain("abc123");
+    expect(result).not.toContain("avatars.example.com");
+    // user should be collapsed to login
+    expect(result).toContain("alice");
+  });
+
+  it("wraps non-JSON output in TOON envelope", async () => {
+    mockedGhExec.mockResolvedValue("plain text response");
+
+    const result = await apiCommand(["/some/endpoint"]);
+
+    // Should be wrapped in a TOON object, not raw text
+    expect(result).toContain("api_response:");
+    expect(result).toContain("plain text response");
+    expect(result).toContain("truncated: false");
+  });
+
+  it("forwards --jq to gh api", async () => {
+    mockedGhExec.mockResolvedValue("[]");
+
+    await apiCommand(["/repos/octo/repo/issues/1", "--jq", "[.labels[].name]"]);
+
+    expect(mockedGhExec).toHaveBeenCalledWith(
+      expect.arrayContaining(["--jq", "[.labels[].name]"]),
+      undefined,
+    );
+  });
+
+  it("forwards --template to gh api", async () => {
+    mockedGhExec.mockResolvedValue("out");
+
+    await apiCommand(["/repos/octo/repo", "--template", "{{.name}}"]);
+
+    expect(mockedGhExec).toHaveBeenCalledWith(
+      expect.arrayContaining(["--template", "{{.name}}"]),
+      undefined,
+    );
+  });
+
+  it("does not strip fields the caller explicitly selected with --jq", async () => {
+    // `url` is a noisy key by default, but selecting it by hand is deliberate.
+    mockedGhExec.mockResolvedValue(
+      JSON.stringify({ url: "https://api.github.com/x" }),
+    );
+
+    const result = await apiCommand([
+      "/repos/octo/repo",
+      "--jq",
+      "{url: .url}",
+    ]);
+
+    expect(result).toContain("https://api.github.com/x");
+  });
+
+  it("rejects an unknown flag instead of silently ignoring it", async () => {
+    await expect(
+      apiCommand(["/repos/octo/repo", "--bogus", "x"]),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it("names the offending flag without echoing its value", async () => {
+    await expect(
+      apiCommand(["/repos/octo/repo", "--token=hunter2"]),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("--token"),
+    });
+    await expect(
+      apiCommand(["/repos/octo/repo", "--token=hunter2"]),
+    ).rejects.not.toMatchObject({
+      message: expect.stringContaining("hunter2"),
+    });
+  });
+
+  it("does not consume the path when --paginate precedes it", async () => {
+    mockedGhExec.mockResolvedValue("{}");
+
+    await apiCommand(["--paginate", "/repos/octo/repo/pulls"]);
+
+    expect(mockedGhExec).toHaveBeenCalledWith(
+      expect.arrayContaining(["api", "/repos/octo/repo/pulls", "--paginate"]),
+      undefined,
+    );
+  });
+
+  it("rejects a repeated --jq instead of silently dropping one expression", async () => {
+    await expect(
+      apiCommand(["/repos/octo/repo", "--jq", ".name", "--jq", ".full_name"]),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("--jq"),
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it("rejects a repeated --template without echoing either value", async () => {
+    await expect(
+      apiCommand([
+        "/repos/octo/repo",
+        "--template={{.name}}",
+        "--template={{.id}}",
+      ]),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("--template"),
+    });
+    await expect(
+      apiCommand([
+        "/repos/octo/repo",
+        "--template={{.name}}",
+        "--template={{.id}}",
+      ]),
+    ).rejects.not.toMatchObject({
+      message: expect.stringContaining("{{.name}}"),
+    });
+  });
+
+  it("does not forward a flag-shaped --header value as its own flag", async () => {
+    mockedGhExec.mockResolvedValue("{}");
+
+    await apiCommand(["/repos/octo/repo", "--header", "--jq=.x"]);
+
+    const ghArgs = mockedGhExec.mock.calls[0][0];
+    expect(ghArgs).toEqual(expect.arrayContaining(["--header", "--jq=.x"]));
+    expect(ghArgs).not.toContain("--jq");
+  });
+
+  it("truncates long string values in caller-shaped --jq output", async () => {
+    const blob = "a".repeat(50_000);
+    mockedGhExec.mockResolvedValue(JSON.stringify({ content: blob }));
+
+    const result = await apiCommand([
+      "/repos/octo/repo/readme",
+      "--jq",
+      "{content: .content}",
+    ]);
+
+    expect(result).toContain("... (truncated)");
+    expect(result.length).toBeLessThan(3000);
+  });
+
+  it("repeats --field and --header flags in order", async () => {
+    mockedGhExec.mockResolvedValue("{}");
+
+    await apiCommand([
+      "POST",
+      "/repos/octo/repo/issues",
+      "--field",
+      "title=Bug",
+      "--field=body=Broken",
+      "--header",
+      "A:1",
+      "--header",
+      "B:2",
+    ]);
+
+    expect(mockedGhExec).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        "--field",
+        "title=Bug",
+        "--field",
+        "body=Broken",
+        "--header",
+        "A:1",
+        "--header",
+        "B:2",
       ]),
       undefined,
     );
   });
 
-  it('rejects an empty --jq value instead of silently disabling field stripping', async () => {
-    await expect(apiCommand(['/repos/octo/repo', '--jq='])).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
-      message: expect.stringContaining('--jq'),
+  it("rejects an empty --jq value instead of silently disabling field stripping", async () => {
+    await expect(
+      apiCommand(["/repos/octo/repo", "--jq="]),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("--jq"),
     });
-    await expect(apiCommand(['/repos/octo/repo', '--jq', '   '])).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
-    });
-    expect(mockedGhExec).not.toHaveBeenCalled();
-  });
-
-  it('rejects an empty --template value', async () => {
-    await expect(apiCommand(['/repos/octo/repo', '--template='])).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
-      message: expect.stringContaining('--template'),
+    await expect(
+      apiCommand(["/repos/octo/repo", "--jq", "   "]),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
     });
     expect(mockedGhExec).not.toHaveBeenCalled();
   });
 
-  it('does not rewrite content of a long string on the --jq path', async () => {
-    const body = 'see https://github.com/octo/repo/pull/5 '.repeat(10);
+  it("rejects an empty --template value", async () => {
+    await expect(
+      apiCommand(["/repos/octo/repo", "--template="]),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("--template"),
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it("does not rewrite content of a long string on the --jq path", async () => {
+    const body = "see https://github.com/octo/repo/pull/5 ".repeat(10);
     mockedGhExec.mockResolvedValue(JSON.stringify({ body }));
 
-    const result = await apiCommand(['/repos/octo/repo/issues/1', '--jq', '{body: .body}']);
+    const result = await apiCommand([
+      "/repos/octo/repo/issues/1",
+      "--jq",
+      "{body: .body}",
+    ]);
 
     expect(body.length).toBeGreaterThan(200);
-    expect(result).toContain('https://github.com/octo/repo/pull/5');
-    expect(result).not.toContain('PR#5');
+    expect(result).toContain("https://github.com/octo/repo/pull/5");
+    expect(result).not.toContain("PR#5");
   });
 
-  it('still cleans long strings on the default path', async () => {
-    const body = 'see https://github.com/octo/repo/pull/5 '.repeat(10);
+  it("still cleans long strings on the default path", async () => {
+    const body = "see https://github.com/octo/repo/pull/5 ".repeat(10);
     mockedGhExec.mockResolvedValue(JSON.stringify({ body }));
 
-    const result = await apiCommand(['/repos/octo/repo/issues/1']);
+    const result = await apiCommand(["/repos/octo/repo/issues/1"]);
 
-    expect(result).toContain('PR#5');
+    expect(result).toContain("PR#5");
   });
 
-  it('rejects an extra positional instead of silently ignoring it', async () => {
-    await expect(apiCommand(['/repos/octo/repo', '/extra'])).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
+  it("rejects an extra positional instead of silently ignoring it", async () => {
+    await expect(
+      apiCommand(["/repos/octo/repo", "/extra"]),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
     });
-    await expect(apiCommand(['POST', '/repos/octo/repo', '/extra'])).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
-    });
-    expect(mockedGhExec).not.toHaveBeenCalled();
-  });
-
-  it('rejects a lone HTTP method with no path', async () => {
-    await expect(apiCommand(['POST'])).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
-      message: expect.stringContaining('path is required'),
+    await expect(
+      apiCommand(["POST", "/repos/octo/repo", "/extra"]),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
     });
     expect(mockedGhExec).not.toHaveBeenCalled();
   });
 
-  it('rejects a value flag with no value', async () => {
-    await expect(apiCommand(['/repos/octo/repo', '--jq'])).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
+  it("rejects a lone HTTP method with no path", async () => {
+    await expect(apiCommand(["POST"])).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: expect.stringContaining("path is required"),
+    });
+    expect(mockedGhExec).not.toHaveBeenCalled();
+  });
+
+  it("rejects a value flag with no value", async () => {
+    await expect(
+      apiCommand(["/repos/octo/repo", "--jq"]),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
     });
   });
 
-  it('wraps truncated non-JSON output in TOON envelope with truncation metadata', async () => {
-    const longText = 'x'.repeat(5000);
+  it("wraps truncated non-JSON output in TOON envelope with truncation metadata", async () => {
+    const longText = "x".repeat(5000);
     mockedGhExec.mockResolvedValue(longText);
 
-    const result = await apiCommand(['/some/endpoint']);
+    const result = await apiCommand(["/some/endpoint"]);
 
-    expect(result).toContain('api_response:');
-    expect(result).toContain('truncated: true');
-    expect(result).toContain('original_length: 5000');
+    expect(result).toContain("api_response:");
+    expect(result).toContain("truncated: true");
+    expect(result).toContain("original_length: 5000");
     // The body itself should be truncated
     expect(result.length).toBeLessThan(5000);
   });
 
-  it('preserves complete string values and noisy fields with --full', async () => {
-    const blob = 'a'.repeat(5000);
-    mockedGhExec.mockResolvedValue(JSON.stringify({
-      content: blob,
-      node_id: 'abc123',
-      avatar_url: 'https://avatars.example.com/u/123',
-    }));
+  it("preserves complete string values and noisy fields with --full", async () => {
+    const blob = "a".repeat(5000);
+    mockedGhExec.mockResolvedValue(
+      JSON.stringify({
+        content: blob,
+        node_id: "abc123",
+        avatar_url: "https://avatars.example.com/u/123",
+      }),
+    );
 
-    const result = await apiCommand(['/repos/octo/repo/contents/README.md', '--full']);
+    const result = await apiCommand([
+      "/repos/octo/repo/contents/README.md",
+      "--full",
+    ]);
 
     expect(result).toContain(blob);
-    expect(result).not.toContain('... (truncated)');
+    expect(result).not.toContain("... (truncated)");
     // --full preserves every field, including ones the compact default strips.
-    expect(result).toContain('abc123');
-    expect(result).toContain('avatars.example.com');
+    expect(result).toContain("abc123");
+    expect(result).toContain("avatars.example.com");
   });
 
-  it('does not forward --full to gh', async () => {
-    mockedGhExec.mockResolvedValue('{}');
+  it("does not forward --full to gh", async () => {
+    mockedGhExec.mockResolvedValue("{}");
 
-    await apiCommand(['/repos/octo/repo', '--full']);
+    await apiCommand(["/repos/octo/repo", "--full"]);
 
     const ghArgs = mockedGhExec.mock.calls[0][0];
-    expect(ghArgs).not.toContain('--full');
+    expect(ghArgs).not.toContain("--full");
   });
 
-  it('preserves the complete non-JSON body with --full', async () => {
-    const longText = 'x'.repeat(5000);
+  it("preserves the complete non-JSON body with --full", async () => {
+    const longText = "x".repeat(5000);
     mockedGhExec.mockResolvedValue(longText);
 
-    const result = await apiCommand(['/some/endpoint', '--full']);
+    const result = await apiCommand(["/some/endpoint", "--full"]);
 
-    expect(result).toContain('api_response:');
-    expect(result).toContain('truncated: false');
-    expect(result).not.toContain('original_length:');
+    expect(result).toContain("api_response:");
+    expect(result).toContain("truncated: false");
+    expect(result).not.toContain("original_length:");
     expect(result.length).toBeGreaterThan(5000);
   });
 
-  it('rejects --full with a value', async () => {
-    await expect(apiCommand(['/repos/octo/repo', '--full=true'])).rejects.toMatchObject({
-      code: 'VALIDATION_ERROR',
+  it("rejects --full with a value", async () => {
+    await expect(
+      apiCommand(["/repos/octo/repo", "--full=true"]),
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
     });
   });
 });

--- a/test/commands/api.test.ts
+++ b/test/commands/api.test.ts
@@ -1,482 +1,395 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 
-vi.mock("../../src/gh.js", () => ({
+vi.mock('../../src/gh.js', () => ({
   ghJson: vi.fn(),
   ghExec: vi.fn(),
   ghRaw: vi.fn(),
 }));
 
-import { ghExec } from "../../src/gh.js";
-import { apiCommand, API_HELP } from "../../src/commands/api.js";
+import { ghExec } from '../../src/gh.js';
+import { apiCommand, API_HELP } from '../../src/commands/api.js';
 
 const mockedGhExec = vi.mocked(ghExec);
 
-describe("apiCommand", () => {
+describe('apiCommand', () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  it("returns help when --help is passed", async () => {
-    const result = await apiCommand(["--help"]);
+  it('returns help when --help is passed', async () => {
+    const result = await apiCommand(['--help']);
     expect(result).toBe(API_HELP);
   });
 
-  it("returns help when no args are passed", async () => {
+  it('returns help when no args are passed', async () => {
     const result = await apiCommand([]);
     expect(result).toBe(API_HELP);
   });
 
-  it("defaults to GET method", async () => {
-    mockedGhExec.mockResolvedValue("{}");
+  it('defaults to GET method', async () => {
+    mockedGhExec.mockResolvedValue('{}');
 
-    await apiCommand(["/repos/octo/repo"]);
+    await apiCommand(['/repos/octo/repo']);
 
     expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(["api", "/repos/octo/repo", "--method", "GET"]),
+      expect.arrayContaining(['api', '/repos/octo/repo', '--method', 'GET']),
       undefined,
     );
   });
 
-  it("uses explicit method when provided", async () => {
-    mockedGhExec.mockResolvedValue("{}");
+  it('uses explicit method when provided', async () => {
+    mockedGhExec.mockResolvedValue('{}');
 
-    await apiCommand(["POST", "/repos/octo/repo/issues"]);
+    await apiCommand(['POST', '/repos/octo/repo/issues']);
 
     expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(["--method", "POST"]),
+      expect.arrayContaining(['--method', 'POST']),
       undefined,
     );
   });
 
-  it("maps -X <method> to --method instead of silently sending GET", async () => {
-    mockedGhExec.mockResolvedValue("{}");
+  it('maps -X <method> to --method instead of silently sending GET', async () => {
+    mockedGhExec.mockResolvedValue('{}');
 
-    await apiCommand([
-      "-X",
-      "POST",
-      "/repos/octo/repo/pulls/1/requested_reviewers",
-    ]);
+    await apiCommand(['-X', 'POST', '/repos/octo/repo/pulls/1/requested_reviewers']);
 
     expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        "api",
-        "/repos/octo/repo/pulls/1/requested_reviewers",
-        "--method",
-        "POST",
-      ]),
+      expect.arrayContaining(['api', '/repos/octo/repo/pulls/1/requested_reviewers', '--method', 'POST']),
       undefined,
     );
     // The old bug forwarded no --method at all, defaulting gh itself to GET.
     const ghArgs = mockedGhExec.mock.calls[0][0];
-    expect(ghArgs.filter((a) => a === "--method")).toHaveLength(1);
-    expect(ghArgs).not.toContain("-X");
+    expect(ghArgs.filter((a) => a === '--method')).toHaveLength(1);
+    expect(ghArgs).not.toContain('-X');
   });
 
-  it("supports -X=<method> form", async () => {
-    mockedGhExec.mockResolvedValue("{}");
+  it('supports -X=<method> form', async () => {
+    mockedGhExec.mockResolvedValue('{}');
 
-    await apiCommand(["-X=PUT", "/repos/octo/repo/topics"]);
+    await apiCommand(['-X=PUT', '/repos/octo/repo/topics']);
 
     expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(["--method", "PUT"]),
+      expect.arrayContaining(['--method', 'PUT']),
       undefined,
     );
   });
 
-  it("rejects an unsupported -X method instead of silently defaulting to GET", async () => {
-    await expect(
-      apiCommand(["-X", "BOGUS", "/repos/octo/repo"]),
-    ).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
+  it('rejects an unsupported -X method instead of silently defaulting to GET', async () => {
+    await expect(apiCommand(['-X', 'BOGUS', '/repos/octo/repo'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
     });
     expect(mockedGhExec).not.toHaveBeenCalled();
   });
 
-  it("rejects -X given together with a positional method", async () => {
+  it('rejects -X given together with a positional method', async () => {
     await expect(
-      apiCommand(["-X", "POST", "PUT", "/repos/octo/repo"]),
-    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+      apiCommand(['-X', 'POST', 'PUT', '/repos/octo/repo']),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
     expect(mockedGhExec).not.toHaveBeenCalled();
   });
 
-  it("rejects a repeated -X instead of silently keeping the first", async () => {
+  it('rejects a repeated -X instead of silently keeping the first', async () => {
     await expect(
-      apiCommand(["-X", "POST", "-X", "PUT", "/repos/octo/repo"]),
-    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+      apiCommand(['-X', 'POST', '-X', 'PUT', '/repos/octo/repo']),
+    ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
     expect(mockedGhExec).not.toHaveBeenCalled();
   });
 
-  it("rejects -X with no value", async () => {
-    await expect(apiCommand(["/repos/octo/repo", "-X"])).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
+  it('rejects -X with no value', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '-X'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
     });
     expect(mockedGhExec).not.toHaveBeenCalled();
   });
 
-  it("passes --field flags", async () => {
-    mockedGhExec.mockResolvedValue("{}");
+  it('passes --field flags', async () => {
+    mockedGhExec.mockResolvedValue('{}');
 
-    await apiCommand([
-      "POST",
-      "/repos/octo/repo/issues",
-      "--field",
-      "title=Bug",
-    ]);
+    await apiCommand(['POST', '/repos/octo/repo/issues', '--field', 'title=Bug']);
 
     expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(["--field", "title=Bug"]),
+      expect.arrayContaining(['--field', 'title=Bug']),
       undefined,
     );
   });
 
-  it("passes --header flags", async () => {
-    mockedGhExec.mockResolvedValue("{}");
+  it('passes --header flags', async () => {
+    mockedGhExec.mockResolvedValue('{}');
 
-    await apiCommand([
-      "/repos/octo/repo",
-      "--header",
-      "Accept:application/json",
-    ]);
+    await apiCommand(['/repos/octo/repo', '--header', 'Accept:application/json']);
 
     expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(["--header", "Accept:application/json"]),
+      expect.arrayContaining(['--header', 'Accept:application/json']),
       undefined,
     );
   });
 
-  it("cleans JSON output by stripping noisy fields", async () => {
-    mockedGhExec.mockResolvedValue(
-      JSON.stringify({
-        id: 1,
-        title: "Test issue",
-        node_id: "abc123",
-        avatar_url: "https://avatars.example.com/u/123",
-        user: {
-          login: "alice",
-          avatar_url: "https://example.com",
-          node_id: "xyz",
-        },
-      }),
-    );
+  it('cleans JSON output by stripping noisy fields', async () => {
+    mockedGhExec.mockResolvedValue(JSON.stringify({
+      id: 1,
+      title: 'Test issue',
+      node_id: 'abc123',
+      avatar_url: 'https://avatars.example.com/u/123',
+      user: { login: 'alice', avatar_url: 'https://example.com', node_id: 'xyz' },
+    }));
 
-    const result = await apiCommand(["/repos/octo/repo/issues/1"]);
+    const result = await apiCommand(['/repos/octo/repo/issues/1']);
 
-    expect(result).toContain("Test issue");
+    expect(result).toContain('Test issue');
     // node_id and avatar_url are noisy fields, should be stripped
-    expect(result).not.toContain("abc123");
-    expect(result).not.toContain("avatars.example.com");
+    expect(result).not.toContain('abc123');
+    expect(result).not.toContain('avatars.example.com');
     // user should be collapsed to login
-    expect(result).toContain("alice");
+    expect(result).toContain('alice');
   });
 
-  it("wraps non-JSON output in TOON envelope", async () => {
-    mockedGhExec.mockResolvedValue("plain text response");
+  it('wraps non-JSON output in TOON envelope', async () => {
+    mockedGhExec.mockResolvedValue('plain text response');
 
-    const result = await apiCommand(["/some/endpoint"]);
+    const result = await apiCommand(['/some/endpoint']);
 
     // Should be wrapped in a TOON object, not raw text
-    expect(result).toContain("api_response:");
-    expect(result).toContain("plain text response");
-    expect(result).toContain("truncated: false");
+    expect(result).toContain('api_response:');
+    expect(result).toContain('plain text response');
+    expect(result).toContain('truncated: false');
   });
 
-  it("forwards --jq to gh api", async () => {
-    mockedGhExec.mockResolvedValue("[]");
+  it('forwards --jq to gh api', async () => {
+    mockedGhExec.mockResolvedValue('[]');
 
-    await apiCommand(["/repos/octo/repo/issues/1", "--jq", "[.labels[].name]"]);
+    await apiCommand(['/repos/octo/repo/issues/1', '--jq', '[.labels[].name]']);
 
     expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(["--jq", "[.labels[].name]"]),
+      expect.arrayContaining(['--jq', '[.labels[].name]']),
       undefined,
     );
   });
 
-  it("forwards --template to gh api", async () => {
-    mockedGhExec.mockResolvedValue("out");
+  it('forwards --template to gh api', async () => {
+    mockedGhExec.mockResolvedValue('out');
 
-    await apiCommand(["/repos/octo/repo", "--template", "{{.name}}"]);
+    await apiCommand(['/repos/octo/repo', '--template', '{{.name}}']);
 
     expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(["--template", "{{.name}}"]),
+      expect.arrayContaining(['--template', '{{.name}}']),
       undefined,
     );
   });
 
-  it("does not strip fields the caller explicitly selected with --jq", async () => {
+  it('does not strip fields the caller explicitly selected with --jq', async () => {
     // `url` is a noisy key by default, but selecting it by hand is deliberate.
-    mockedGhExec.mockResolvedValue(
-      JSON.stringify({ url: "https://api.github.com/x" }),
-    );
+    mockedGhExec.mockResolvedValue(JSON.stringify({ url: 'https://api.github.com/x' }));
 
-    const result = await apiCommand([
-      "/repos/octo/repo",
-      "--jq",
-      "{url: .url}",
-    ]);
+    const result = await apiCommand(['/repos/octo/repo', '--jq', '{url: .url}']);
 
-    expect(result).toContain("https://api.github.com/x");
+    expect(result).toContain('https://api.github.com/x');
   });
 
-  it("rejects an unknown flag instead of silently ignoring it", async () => {
-    await expect(
-      apiCommand(["/repos/octo/repo", "--bogus", "x"]),
-    ).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
+  it('rejects an unknown flag instead of silently ignoring it', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '--bogus', 'x'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
     });
     expect(mockedGhExec).not.toHaveBeenCalled();
   });
 
-  it("names the offending flag without echoing its value", async () => {
-    await expect(
-      apiCommand(["/repos/octo/repo", "--token=hunter2"]),
-    ).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
-      message: expect.stringContaining("--token"),
+  it('names the offending flag without echoing its value', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '--token=hunter2'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('--token'),
     });
-    await expect(
-      apiCommand(["/repos/octo/repo", "--token=hunter2"]),
-    ).rejects.not.toMatchObject({
-      message: expect.stringContaining("hunter2"),
+    await expect(apiCommand(['/repos/octo/repo', '--token=hunter2'])).rejects.not.toMatchObject({
+      message: expect.stringContaining('hunter2'),
     });
   });
 
-  it("does not consume the path when --paginate precedes it", async () => {
-    mockedGhExec.mockResolvedValue("{}");
+  it('does not consume the path when --paginate precedes it', async () => {
+    mockedGhExec.mockResolvedValue('{}');
 
-    await apiCommand(["--paginate", "/repos/octo/repo/pulls"]);
+    await apiCommand(['--paginate', '/repos/octo/repo/pulls']);
 
     expect(mockedGhExec).toHaveBeenCalledWith(
-      expect.arrayContaining(["api", "/repos/octo/repo/pulls", "--paginate"]),
+      expect.arrayContaining(['api', '/repos/octo/repo/pulls', '--paginate']),
       undefined,
     );
   });
 
-  it("rejects a repeated --jq instead of silently dropping one expression", async () => {
+  it('rejects a repeated --jq instead of silently dropping one expression', async () => {
     await expect(
-      apiCommand(["/repos/octo/repo", "--jq", ".name", "--jq", ".full_name"]),
+      apiCommand(['/repos/octo/repo', '--jq', '.name', '--jq', '.full_name']),
     ).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
-      message: expect.stringContaining("--jq"),
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('--jq'),
     });
     expect(mockedGhExec).not.toHaveBeenCalled();
   });
 
-  it("rejects a repeated --template without echoing either value", async () => {
+  it('rejects a repeated --template without echoing either value', async () => {
     await expect(
-      apiCommand([
-        "/repos/octo/repo",
-        "--template={{.name}}",
-        "--template={{.id}}",
-      ]),
+      apiCommand(['/repos/octo/repo', '--template={{.name}}', '--template={{.id}}']),
     ).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
-      message: expect.stringContaining("--template"),
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('--template'),
     });
     await expect(
-      apiCommand([
-        "/repos/octo/repo",
-        "--template={{.name}}",
-        "--template={{.id}}",
-      ]),
-    ).rejects.not.toMatchObject({
-      message: expect.stringContaining("{{.name}}"),
-    });
+      apiCommand(['/repos/octo/repo', '--template={{.name}}', '--template={{.id}}']),
+    ).rejects.not.toMatchObject({ message: expect.stringContaining('{{.name}}') });
   });
 
-  it("does not forward a flag-shaped --header value as its own flag", async () => {
-    mockedGhExec.mockResolvedValue("{}");
+  it('does not forward a flag-shaped --header value as its own flag', async () => {
+    mockedGhExec.mockResolvedValue('{}');
 
-    await apiCommand(["/repos/octo/repo", "--header", "--jq=.x"]);
+    await apiCommand(['/repos/octo/repo', '--header', '--jq=.x']);
 
     const ghArgs = mockedGhExec.mock.calls[0][0];
-    expect(ghArgs).toEqual(expect.arrayContaining(["--header", "--jq=.x"]));
-    expect(ghArgs).not.toContain("--jq");
+    expect(ghArgs).toEqual(expect.arrayContaining(['--header', '--jq=.x']));
+    expect(ghArgs).not.toContain('--jq');
   });
 
-  it("truncates long string values in caller-shaped --jq output", async () => {
-    const blob = "a".repeat(50_000);
+  it('truncates long string values in caller-shaped --jq output', async () => {
+    const blob = 'a'.repeat(50_000);
     mockedGhExec.mockResolvedValue(JSON.stringify({ content: blob }));
 
-    const result = await apiCommand([
-      "/repos/octo/repo/readme",
-      "--jq",
-      "{content: .content}",
-    ]);
+    const result = await apiCommand(['/repos/octo/repo/readme', '--jq', '{content: .content}']);
 
-    expect(result).toContain("... (truncated)");
+    expect(result).toContain('... (truncated)');
     expect(result.length).toBeLessThan(3000);
   });
 
-  it("repeats --field and --header flags in order", async () => {
-    mockedGhExec.mockResolvedValue("{}");
+  it('repeats --field and --header flags in order', async () => {
+    mockedGhExec.mockResolvedValue('{}');
 
     await apiCommand([
-      "POST",
-      "/repos/octo/repo/issues",
-      "--field",
-      "title=Bug",
-      "--field=body=Broken",
-      "--header",
-      "A:1",
-      "--header",
-      "B:2",
+      'POST', '/repos/octo/repo/issues',
+      '--field', 'title=Bug', '--field=body=Broken',
+      '--header', 'A:1', '--header', 'B:2',
     ]);
 
     expect(mockedGhExec).toHaveBeenCalledWith(
       expect.arrayContaining([
-        "--field",
-        "title=Bug",
-        "--field",
-        "body=Broken",
-        "--header",
-        "A:1",
-        "--header",
-        "B:2",
+        '--field', 'title=Bug', '--field', 'body=Broken',
+        '--header', 'A:1', '--header', 'B:2',
       ]),
       undefined,
     );
   });
 
-  it("rejects an empty --jq value instead of silently disabling field stripping", async () => {
-    await expect(
-      apiCommand(["/repos/octo/repo", "--jq="]),
-    ).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
-      message: expect.stringContaining("--jq"),
+  it('rejects an empty --jq value instead of silently disabling field stripping', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '--jq='])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('--jq'),
     });
-    await expect(
-      apiCommand(["/repos/octo/repo", "--jq", "   "]),
-    ).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
+    await expect(apiCommand(['/repos/octo/repo', '--jq', '   '])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
     });
     expect(mockedGhExec).not.toHaveBeenCalled();
   });
 
-  it("rejects an empty --template value", async () => {
-    await expect(
-      apiCommand(["/repos/octo/repo", "--template="]),
-    ).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
-      message: expect.stringContaining("--template"),
+  it('rejects an empty --template value', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '--template='])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('--template'),
     });
     expect(mockedGhExec).not.toHaveBeenCalled();
   });
 
-  it("does not rewrite content of a long string on the --jq path", async () => {
-    const body = "see https://github.com/octo/repo/pull/5 ".repeat(10);
+  it('does not rewrite content of a long string on the --jq path', async () => {
+    const body = 'see https://github.com/octo/repo/pull/5 '.repeat(10);
     mockedGhExec.mockResolvedValue(JSON.stringify({ body }));
 
-    const result = await apiCommand([
-      "/repos/octo/repo/issues/1",
-      "--jq",
-      "{body: .body}",
-    ]);
+    const result = await apiCommand(['/repos/octo/repo/issues/1', '--jq', '{body: .body}']);
 
     expect(body.length).toBeGreaterThan(200);
-    expect(result).toContain("https://github.com/octo/repo/pull/5");
-    expect(result).not.toContain("PR#5");
+    expect(result).toContain('https://github.com/octo/repo/pull/5');
+    expect(result).not.toContain('PR#5');
   });
 
-  it("still cleans long strings on the default path", async () => {
-    const body = "see https://github.com/octo/repo/pull/5 ".repeat(10);
+  it('still cleans long strings on the default path', async () => {
+    const body = 'see https://github.com/octo/repo/pull/5 '.repeat(10);
     mockedGhExec.mockResolvedValue(JSON.stringify({ body }));
 
-    const result = await apiCommand(["/repos/octo/repo/issues/1"]);
+    const result = await apiCommand(['/repos/octo/repo/issues/1']);
 
-    expect(result).toContain("PR#5");
+    expect(result).toContain('PR#5');
   });
 
-  it("rejects an extra positional instead of silently ignoring it", async () => {
-    await expect(
-      apiCommand(["/repos/octo/repo", "/extra"]),
-    ).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
+  it('rejects an extra positional instead of silently ignoring it', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '/extra'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
     });
-    await expect(
-      apiCommand(["POST", "/repos/octo/repo", "/extra"]),
-    ).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
+    await expect(apiCommand(['POST', '/repos/octo/repo', '/extra'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
     });
     expect(mockedGhExec).not.toHaveBeenCalled();
   });
 
-  it("rejects a lone HTTP method with no path", async () => {
-    await expect(apiCommand(["POST"])).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
-      message: expect.stringContaining("path is required"),
+  it('rejects a lone HTTP method with no path', async () => {
+    await expect(apiCommand(['POST'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('path is required'),
     });
     expect(mockedGhExec).not.toHaveBeenCalled();
   });
 
-  it("rejects a value flag with no value", async () => {
-    await expect(
-      apiCommand(["/repos/octo/repo", "--jq"]),
-    ).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
+  it('rejects a value flag with no value', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '--jq'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
     });
   });
 
-  it("wraps truncated non-JSON output in TOON envelope with truncation metadata", async () => {
-    const longText = "x".repeat(5000);
+  it('wraps truncated non-JSON output in TOON envelope with truncation metadata', async () => {
+    const longText = 'x'.repeat(5000);
     mockedGhExec.mockResolvedValue(longText);
 
-    const result = await apiCommand(["/some/endpoint"]);
+    const result = await apiCommand(['/some/endpoint']);
 
-    expect(result).toContain("api_response:");
-    expect(result).toContain("truncated: true");
-    expect(result).toContain("original_length: 5000");
+    expect(result).toContain('api_response:');
+    expect(result).toContain('truncated: true');
+    expect(result).toContain('original_length: 5000');
     // The body itself should be truncated
     expect(result.length).toBeLessThan(5000);
   });
 
-  it("preserves complete string values and noisy fields with --full", async () => {
-    const blob = "a".repeat(5000);
-    mockedGhExec.mockResolvedValue(
-      JSON.stringify({
-        content: blob,
-        node_id: "abc123",
-        avatar_url: "https://avatars.example.com/u/123",
-      }),
-    );
+  it('preserves complete string values and noisy fields with --full', async () => {
+    const blob = 'a'.repeat(5000);
+    mockedGhExec.mockResolvedValue(JSON.stringify({
+      content: blob,
+      node_id: 'abc123',
+      avatar_url: 'https://avatars.example.com/u/123',
+    }));
 
-    const result = await apiCommand([
-      "/repos/octo/repo/contents/README.md",
-      "--full",
-    ]);
+    const result = await apiCommand(['/repos/octo/repo/contents/README.md', '--full']);
 
     expect(result).toContain(blob);
-    expect(result).not.toContain("... (truncated)");
+    expect(result).not.toContain('... (truncated)');
     // --full preserves every field, including ones the compact default strips.
-    expect(result).toContain("abc123");
-    expect(result).toContain("avatars.example.com");
+    expect(result).toContain('abc123');
+    expect(result).toContain('avatars.example.com');
   });
 
-  it("does not forward --full to gh", async () => {
-    mockedGhExec.mockResolvedValue("{}");
+  it('does not forward --full to gh', async () => {
+    mockedGhExec.mockResolvedValue('{}');
 
-    await apiCommand(["/repos/octo/repo", "--full"]);
+    await apiCommand(['/repos/octo/repo', '--full']);
 
     const ghArgs = mockedGhExec.mock.calls[0][0];
-    expect(ghArgs).not.toContain("--full");
+    expect(ghArgs).not.toContain('--full');
   });
 
-  it("preserves the complete non-JSON body with --full", async () => {
-    const longText = "x".repeat(5000);
+  it('preserves the complete non-JSON body with --full', async () => {
+    const longText = 'x'.repeat(5000);
     mockedGhExec.mockResolvedValue(longText);
 
-    const result = await apiCommand(["/some/endpoint", "--full"]);
+    const result = await apiCommand(['/some/endpoint', '--full']);
 
-    expect(result).toContain("api_response:");
-    expect(result).toContain("truncated: false");
-    expect(result).not.toContain("original_length:");
+    expect(result).toContain('api_response:');
+    expect(result).toContain('truncated: false');
+    expect(result).not.toContain('original_length:');
     expect(result.length).toBeGreaterThan(5000);
   });
 
-  it("rejects --full with a value", async () => {
-    await expect(
-      apiCommand(["/repos/octo/repo", "--full=true"]),
-    ).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
+  it('rejects --full with a value', async () => {
+    await expect(apiCommand(['/repos/octo/repo', '--full=true'])).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
     });
   });
 });


### PR DESCRIPTION
## What Changed
- Added `-X <method>` and `-X=<method>` support to `gh-axi api`, forwarding the selected HTTP method to `gh api --method`.
- Reject unsupported, repeated, or conflicting method forms, including `-X` combined with a positional method.
- Updated README/CONTRIBUTING docs and API command tests for the new method flag behavior and no-mistakes version requirement.

## Risk Assessment

✅ Low: The change is narrowly scoped to API argument parsing and docs, validates the new method flag before invoking `gh`, and I found no source-verifiable regressions.

## Testing

Installed locked dependencies for the isolated worktree, ran the targeted API command tests, exercised the actual `gh-axi` CLI with `-X` method forms through a fake `gh` to capture forwarded arguments and user-facing validation output, saved the transcript under the evidence directory, and removed generated dependency artifacts afterward.

<details>
<summary>Evidence: gh-axi api -X end-to-end transcript</summary>

```text
$ GH_AXI_CAPTURE=/home/cmckay/.no-mistakes/worktrees/fad2bb6182d2/01M0HA7A7PVHR6KRBHHJ9R6CBX/.nm-home/runtime/evidence/01M0HPJNBZE4RPDMWWV5PYXGC1/gh-argv.txt PATH=/home/cmckay/.no-mistakes/worktrees/fad2bb6182d2/01M0HA7A7PVHR6KRBHHJ9R6CBX/.nm-home/runtime/evidence/01M0HPJNBZE4RPDMWWV5PYXGC1/fake-bin:$PATH pnpm exec tsx bin/gh-axi.ts api -X POST /repos/octo/repo/issues --field title=Bug
ok: true
source: fake-gh
exit: 0

captured gh argv:
api
/repos/octo/repo/issues
--method
POST
--field
title=Bug

$ pnpm exec tsx bin/gh-axi.ts api -X POST PUT /repos/octo/repo
error: "method given twice: use either -X <method> or the positional method, not both"
code: VALIDATION_ERROR
exit: 2

$ GH_AXI_CAPTURE=/home/cmckay/.no-mistakes/worktrees/fad2bb6182d2/01M0HA7A7PVHR6KRBHHJ9R6CBX/.nm-home/runtime/evidence/01M0HPJNBZE4RPDMWWV5PYXGC1/gh-argv-equals.txt PATH=/home/cmckay/.no-mistakes/worktrees/fad2bb6182d2/01M0HA7A7PVHR6KRBHHJ9R6CBX/.nm-home/runtime/evidence/01M0HPJNBZE4RPDMWWV5PYXGC1/fake-bin:$PATH pnpm exec tsx bin/gh-axi.ts api -X=PUT /repos/octo/repo/topics
ok: true
source: fake-gh
exit: 0

captured gh argv for equals form:
api
/repos/octo/repo/topics
--method
PUT
```
</details>
<details>
<summary>Evidence: Captured gh argv for -X POST</summary>

```text
api
/repos/octo/repo/issues
--method
POST
--field
title=Bug
```
</details>
<details>
<summary>Evidence: Captured gh argv for -X=PUT</summary>

```text
api
/repos/octo/repo/topics
--method
PUT
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7b9b3e374dcbf88d3abf9669f69959000623ab63","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Setup: `pnpm install --frozen-lockfile`</code>
- <code>Automated: `pnpm exec vitest run test/commands/api.test.ts`</code>
- <code>Manual evidence: `GH_AXI_CAPTURE=... PATH=&lt;evidence&gt;/fake-bin:$PATH pnpm exec tsx bin/gh-axi.ts api -X POST /repos/octo/repo/issues --field title=Bug`</code>
- <code>Manual evidence: `GH_AXI_CAPTURE=... PATH=&lt;evidence&gt;/fake-bin:$PATH pnpm exec tsx bin/gh-axi.ts api -X=PUT /repos/octo/repo/topics`</code>
- <code>Manual evidence: `GH_AXI_CAPTURE=... PATH=&lt;evidence&gt;/fake-bin:$PATH pnpm exec tsx bin/gh-axi.ts api -X POST PUT /repos/octo/repo`</code>
- <code>Cleanup: removed generated `node_modules` from the worktree with `find node_modules -depth -mindepth 1 -delete` and `rmdir node_modules`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
