### PR TITLE
feat(repo): support local-source create with --source, --push, and --remote

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -58,6 +58,20 @@ function requireFlagValue(value: string, flag: string): string {
   return value;
 }
 
+/**
+ * Like takeFlag, but throws VALIDATION_ERROR when the flag is present with a
+ * missing or blank value, rather than silently returning undefined for it.
+ */
+export function takeRequiredFlag(
+  args: string[],
+  flag: string,
+): string | undefined {
+  const equalsPrefix = flagEqualsPrefix(flag);
+  if (!args.some((a) => a === flag || a.startsWith(equalsPrefix)))
+    return undefined;
+  return requireFlagValue(takeFlag(args, flag) ?? "", flag);
+}
+
 function collectAllFlags(
   args: string[],
   flag: string,

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -2,7 +2,8 @@ import { encode } from '@toon-format/toon';
 import type { RepoContext } from '../context.js';
 import { ghJson, ghExec } from '../gh.js';
 import { AxiError } from '../errors.js';
-import { getFlag, hasFlag, rejectUnknownFlags } from '../args.js';
+import { basename, resolve } from 'node:path';
+import { getFlag, hasFlag, takeFlag, takeBoolFlag, rejectUnknownFlags } from '../args.js';
 import {
   field,
   lower,
@@ -23,7 +24,7 @@ const REPO_FLAGS: Record<string, readonly string[]> = {
   view: [],
   create: [
     '--public', '--private', '--internal', '--description', '--clone',
-    '--template',
+    '--template', '--source', '--push', '--remote',
   ],
   edit: [
     '--description', '--visibility', '--default-branch', '--enable-issues',
@@ -36,11 +37,12 @@ const REPO_FLAGS: Record<string, readonly string[]> = {
 
 export const REPO_HELP = `usage: gh-axi repo <subcommand> [flags]
 subcommands[6]:
-  view [owner/name], create <name>, edit, clone <repo>, fork [repo], list [owner]
+  view [owner/name], create [name], edit, clone <repo>, fork [repo], list [owner]
 flags{view}:
   --repo <owner/name> or exactly one positional owner/name; choose one selector
 flags{create}:
   --public, --private, --internal, --description, --clone, --template
+  --source <path> (publish existing local repo; name defaults to source dir name), --push, --remote <name> (both require --source)
 flags{edit}:
   --description, --visibility, --default-branch, --enable-issues, --enable-wiki
 flags{fork}:
@@ -52,6 +54,7 @@ examples:
   gh-axi repo view --repo owner/name
   gh-axi repo view owner/name
   gh-axi repo create my-project --public --description "A new project"
+  gh-axi repo create --public --source . --push
   gh-axi repo list --visibility public --language TypeScript`;
 
 const viewSchema: FieldDef[] = [
@@ -107,24 +110,61 @@ async function viewRepo(args: string[], ctx?: RepoContext): Promise<string> {
 }
 
 async function createRepo(args: string[], ctx?: RepoContext): Promise<string> {
-  const positionals = args.filter((a) => !a.startsWith('--'));
-  const name = positionals[1];
-  if (!name) throw new AxiError('Repository name is required: gh-axi repo create <name>', 'VALIDATION_ERROR');
+  // Consume flags destructively so a flag value (e.g. `--source .`) is never
+  // mistaken for the name positional.
+  const rest = args.slice(1);
+  const isPublic = takeBoolFlag(rest, '--public');
+  const isPrivate = takeBoolFlag(rest, '--private');
+  const isInternal = takeBoolFlag(rest, '--internal');
+  const description = takeFlag(rest, '--description');
+  const clone = takeBoolFlag(rest, '--clone');
+  const template = takeFlag(rest, '--template');
+  const source = takeFlag(rest, '--source');
+  const push = takeBoolFlag(rest, '--push');
+  const remote = takeFlag(rest, '--remote');
+  const name = rest.find((a) => !a.startsWith('-'));
 
-  const ghArgs = ['repo', 'create', name];
-  if (hasFlag(args, '--public')) ghArgs.push('--public');
-  else if (hasFlag(args, '--private')) ghArgs.push('--private');
-  else if (hasFlag(args, '--internal')) ghArgs.push('--internal');
-  const description = getFlag(args, '--description');
+  if (source) {
+    if (clone) throw new AxiError('--source cannot be combined with --clone', 'VALIDATION_ERROR');
+    if (template) throw new AxiError('--source cannot be combined with --template', 'VALIDATION_ERROR');
+  } else {
+    if (push) throw new AxiError('--push requires --source <path>', 'VALIDATION_ERROR');
+    if (remote) throw new AxiError('--remote requires --source <path>', 'VALIDATION_ERROR');
+    if (!name) throw new AxiError('Repository name is required: gh-axi repo create <name>', 'VALIDATION_ERROR');
+  }
+
+  const ghArgs = ['repo', 'create'];
+  if (name) ghArgs.push(name);
+  if (isPublic) ghArgs.push('--public');
+  else if (isPrivate) ghArgs.push('--private');
+  else if (isInternal) ghArgs.push('--internal');
   if (description) ghArgs.push('--description', description);
-  if (hasFlag(args, '--clone')) ghArgs.push('--clone');
-  const template = getFlag(args, '--template');
-  if (template) ghArgs.push('--template', template);
+  if (source) {
+    ghArgs.push('--source', source);
+    if (remote) ghArgs.push('--remote', remote);
+    if (push) ghArgs.push('--push');
+  } else {
+    if (clone) ghArgs.push('--clone');
+    if (template) ghArgs.push('--template', template);
+  }
 
   await ghExec(ghArgs);
   const suggestions = getSuggestions({ domain: 'repo', action: 'create', repo: ctx });
+  const created: Record<string, unknown> = {
+    created: 'ok',
+    // gh defaults the repo name to the source directory's name.
+    repo: name ?? basename(resolve(source as string)),
+  };
+  if (source) {
+    if (isPublic) created.visibility = 'public';
+    else if (isPrivate) created.visibility = 'private';
+    else if (isInternal) created.visibility = 'internal';
+    created.source = source;
+    created.remote = remote ?? 'origin';
+    created.pushed = push;
+  }
   return renderOutput([
-    encode({ created: 'ok', repo: name }),
+    encode(created),
     renderHelp(suggestions),
   ]);
 }

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -3,7 +3,7 @@ import type { RepoContext } from '../context.js';
 import { ghJson, ghExec } from '../gh.js';
 import { AxiError } from '../errors.js';
 import { basename, resolve } from 'node:path';
-import { getFlag, hasFlag, takeFlag, takeBoolFlag, rejectUnknownFlags } from '../args.js';
+import { getFlag, hasFlag, takeFlag, takeRequiredFlag, takeBoolFlag, rejectUnknownFlags } from '../args.js';
 import {
   field,
   lower,
@@ -119,10 +119,18 @@ async function createRepo(args: string[], ctx?: RepoContext): Promise<string> {
   const description = takeFlag(rest, '--description');
   const clone = takeBoolFlag(rest, '--clone');
   const template = takeFlag(rest, '--template');
-  const source = takeFlag(rest, '--source');
+  const source = takeRequiredFlag(rest, '--source');
   const push = takeBoolFlag(rest, '--push');
-  const remote = takeFlag(rest, '--remote');
-  const name = rest.find((a) => !a.startsWith('-'));
+  const remote = takeRequiredFlag(rest, '--remote');
+  const nameIdx = rest.findIndex((a) => !a.startsWith('-'));
+  const name = nameIdx === -1 ? undefined : rest.splice(nameIdx, 1)[0];
+  if (rest.length > 0) {
+    throw new AxiError(
+      `Unsupported extra argument${rest.length > 1 ? 's' : ''} for repo create: ${rest.join(', ')}`,
+      'VALIDATION_ERROR',
+      ['gh-axi repo create --help'],
+    );
+  }
 
   if (source) {
     if (clone) throw new AxiError('--source cannot be combined with --clone', 'VALIDATION_ERROR');

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -113,6 +113,9 @@ async function createRepo(args: string[], ctx?: RepoContext): Promise<string> {
   // Consume flags destructively so a flag value (e.g. `--source .`) is never
   // mistaken for the name positional.
   const rest = args.slice(1);
+  // `--` ends flag parsing; everything after it is positional.
+  const sepIdx = rest.indexOf('--');
+  const tail = sepIdx === -1 ? [] : rest.splice(sepIdx).slice(1);
   const isPublic = takeBoolFlag(rest, '--public');
   const isPrivate = takeBoolFlag(rest, '--private');
   const isInternal = takeBoolFlag(rest, '--internal');
@@ -123,10 +126,11 @@ async function createRepo(args: string[], ctx?: RepoContext): Promise<string> {
   const push = takeBoolFlag(rest, '--push');
   const remote = takeRequiredFlag(rest, '--remote');
   const nameIdx = rest.findIndex((a) => !a.startsWith('-'));
-  const name = nameIdx === -1 ? undefined : rest.splice(nameIdx, 1)[0];
-  if (rest.length > 0) {
+  const name = nameIdx === -1 ? tail.shift() : rest.splice(nameIdx, 1)[0];
+  const leftovers = [...rest, ...tail];
+  if (leftovers.length > 0) {
     throw new AxiError(
-      `Unsupported extra argument${rest.length > 1 ? 's' : ''} for repo create: ${rest.join(', ')}`,
+      `Unsupported extra argument${leftovers.length > 1 ? 's' : ''} for repo create: ${leftovers.join(', ')}`,
       'VALIDATION_ERROR',
       ['gh-axi repo create --help'],
     );

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -476,7 +476,9 @@ const table: SuggestionEntry[] = [
   // Repo create
   {
     match: (c) => c.domain === "repo" && c.action === "create",
-    lines: () => [],
+    lines: () => [
+      `Run \`gh-axi repo view --repo <owner/name>\` to see the new repository`,
+    ],
   },
 
   // Repo list

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   getFlag,
   takeFlag,
+  takeRequiredFlag,
   hasFlag,
   takeBoolFlag,
   getAllFlags,
@@ -68,6 +69,32 @@ describe("takeFlag", () => {
     const val = takeFlag(args, "--flag");
     expect(val).toBe("val");
     expect(args).toEqual(["--other"]);
+  });
+});
+
+describe("takeRequiredFlag", () => {
+  it("returns value and removes flag+value from args", () => {
+    const args = ["--source", ".", "--push"];
+    expect(takeRequiredFlag(args, "--source")).toBe(".");
+    expect(args).toEqual(["--push"]);
+  });
+
+  it("returns undefined when flag is absent", () => {
+    const args = ["--push"];
+    expect(takeRequiredFlag(args, "--source")).toBeUndefined();
+    expect(args).toEqual(["--push"]);
+  });
+
+  it("throws VALIDATION_ERROR for a dangling flag with no value", () => {
+    expect(() => takeRequiredFlag(["--push", "--source"], "--source")).toThrow(
+      new AxiError("--source requires a value", "VALIDATION_ERROR"),
+    );
+  });
+
+  it("throws VALIDATION_ERROR for a blank --flag= value", () => {
+    expect(() => takeRequiredFlag(["--source="], "--source")).toThrow(
+      new AxiError("--source requires a value", "VALIDATION_ERROR"),
+    );
   });
 });
 

--- a/test/commands/repo.test.ts
+++ b/test/commands/repo.test.ts
@@ -156,6 +156,69 @@ describe('repoCommand', () => {
         expect.arrayContaining(['--public']),
       );
     });
+
+    it('forwards --source, --push, and --remote for local-source mode', async () => {
+      mockedGhExec.mockResolvedValue('');
+
+      const result = await repoCommand([
+        'create', 'my-repo', '--public', '--source', '.', '--push', '--remote', 'upstream',
+      ]);
+
+      expect(mockedGhExec).toHaveBeenCalledWith([
+        'repo', 'create', 'my-repo', '--public',
+        '--source', '.', '--remote', 'upstream', '--push',
+      ]);
+      expect(result).toContain('created: ok');
+      expect(result).toContain('pushed: true');
+      expect(result).toContain('remote: upstream');
+    });
+
+    it('defaults the name to the source directory name when omitted', async () => {
+      mockedGhExec.mockResolvedValue('');
+
+      const result = await repoCommand(['create', '--public', '--source', '/tmp/scaffolded-app']);
+
+      // No name positional is forwarded; gh resolves it from --source.
+      expect(mockedGhExec).toHaveBeenCalledWith([
+        'repo', 'create', '--public', '--source', '/tmp/scaffolded-app',
+      ]);
+      expect(result).toContain('repo: scaffolded-app');
+      expect(result).toContain('pushed: false');
+    });
+
+    it('does not mistake the --source value for the name positional', async () => {
+      mockedGhExec.mockResolvedValue('');
+
+      await repoCommand(['create', '--source', '/tmp/scaffolded-app', '--private', 'named-repo']);
+
+      expect(mockedGhExec).toHaveBeenCalledWith([
+        'repo', 'create', 'named-repo', '--private', '--source', '/tmp/scaffolded-app',
+      ]);
+    });
+
+    it('rejects --source combined with --clone', async () => {
+      await expect(
+        repoCommand(['create', 'my-repo', '--source', '.', '--clone']),
+      ).rejects.toThrow('--source cannot be combined with --clone');
+    });
+
+    it('rejects --source combined with --template', async () => {
+      await expect(
+        repoCommand(['create', 'my-repo', '--source', '.', '--template', 'owner/tpl']),
+      ).rejects.toThrow('--source cannot be combined with --template');
+    });
+
+    it('rejects --push without --source', async () => {
+      await expect(
+        repoCommand(['create', 'my-repo', '--push']),
+      ).rejects.toThrow('--push requires --source');
+    });
+
+    it('rejects --remote without --source', async () => {
+      await expect(
+        repoCommand(['create', 'my-repo', '--remote', 'upstream']),
+      ).rejects.toThrow('--remote requires --source');
+    });
   });
 
   describe('list', () => {

--- a/test/commands/repo.test.ts
+++ b/test/commands/repo.test.ts
@@ -219,6 +219,41 @@ describe('repoCommand', () => {
         repoCommand(['create', 'my-repo', '--remote', 'upstream']),
       ).rejects.toThrow('--remote requires --source');
     });
+
+    it('rejects a dangling --source instead of creating remote-first', async () => {
+      await expect(
+        repoCommand(['create', 'my-repo', '--source']),
+      ).rejects.toThrow('--source requires a value');
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it('rejects a blank --source= instead of creating remote-first', async () => {
+      await expect(
+        repoCommand(['create', 'my-repo', '--source=']),
+      ).rejects.toThrow('--source requires a value');
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it('rejects a dangling --remote', async () => {
+      await expect(
+        repoCommand(['create', '--source', '.', '--remote']),
+      ).rejects.toThrow('--remote requires a value');
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it('rejects a duplicate --source instead of misreading its value as the name', async () => {
+      await expect(
+        repoCommand(['create', '--source', 'a', '--source', 'b']),
+      ).rejects.toThrow('Unsupported extra argument for repo create: --source');
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it('rejects unconsumed --flag=value forms instead of silently dropping them', async () => {
+      await expect(
+        repoCommand(['create', '--source', '.', '--push=true']),
+      ).rejects.toThrow('Unsupported extra argument for repo create: --push=true');
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
   });
 
   describe('list', () => {

--- a/test/commands/repo.test.ts
+++ b/test/commands/repo.test.ts
@@ -196,6 +196,24 @@ describe('repoCommand', () => {
       ]);
     });
 
+    it('accepts a name after the -- end-of-options separator', async () => {
+      mockedGhExec.mockResolvedValue('');
+
+      const result = await repoCommand(['create', '--public', '--', 'my-repo']);
+
+      expect(mockedGhExec).toHaveBeenCalledWith([
+        'repo', 'create', 'my-repo', '--public',
+      ]);
+      expect(result).toContain('created: ok');
+      expect(result).toContain('my-repo');
+    });
+
+    it('does not parse tokens after -- as flags', async () => {
+      await expect(
+        repoCommand(['create', 'my-repo', '--', '--push']),
+      ).rejects.toThrow('Unsupported extra argument for repo create: --push');
+    });
+
     it('rejects --source combined with --clone', async () => {
       await expect(
         repoCommand(['create', 'my-repo', '--source', '.', '--clone']),


### PR DESCRIPTION
## Intent

Implement gh-axi issue #134 (triaged ready-for-pr by the maintainer): forward gh repo create's local-source mode through gh-axi repo create so agent scaffold-then-publish workflows stay inside the wrapper instead of falling back to raw gh. Per the maintainer's triage comment: wrap --source, --push, and also --remote; with --source the name positional is optional and defaults to the source directory name; validate up front that --source conflicts with --clone and --template. Additional deliberate decisions: --push and --remote without --source are rejected with VALIDATION_ERROR (they only make sense in local-source mode); flags in createRepo are now consumed destructively (takeFlag/takeBoolFlag on a copy) so a flag value like '--source .' is never mistaken for the name positional; the TOON confirmation for local-source mode reports repo, visibility (when a visibility flag was given), source, remote (defaulting to 'origin', gh's default remote name), and pushed boolean - the existing remote-first create output stays byte-for-byte unchanged (contract-class opt-in per the triage). A generic next-step hint (repo view --repo <owner/name>) was added to the previously empty repo-create suggestions. REPO_HELP updated (create [name], new flags line, new example). No pushed-branch field in the confirmation: deriving it would require running git in the source dir, which repo.ts deliberately never does. skills/gh-axi/SKILL.md regenerated via build:skill with no drift; full test suite passes (956 tests).

## What Changed

- `gh-axi repo create` now forwards `gh repo create`'s local-source mode: `--source <path>` (name positional becomes optional, defaulting to the source directory name), plus `--push` and `--remote <name>`. Validation rejects `--source` combined with `--clone`/`--template`, rejects `--push`/`--remote` without `--source`, and rejects leftover positional arguments; local-source creates get an extended TOON confirmation (repo, visibility, source, remote defaulting to `origin`, pushed) while the remote-first output is unchanged.
- `createRepo` now consumes flags destructively (`takeFlag`/`takeBoolFlag`/new `takeRequiredFlag` in `src/args.ts`, which throws `VALIDATION_ERROR` on dangling or blank values) so flag values like `--source .` can no longer be mistaken for the name positional.
- The previously empty repo-create suggestions now emit a `gh-axi repo view --repo <owner/name>` next-step hint, `REPO_HELP` documents the new flags with an example, and tests cover the new arg helper and create paths in `test/args.test.ts` and `test/commands/repo.test.ts`.

## Risk Assessment

✅ Low: Both prior auto-fix findings are verifiably fixed with behavioral tests reproducing each rejected shape, the change conforms to every required intent constraint (including byte-identical remote-first output and SKILL.md no-drift), and the only remaining issue is an info-level pre-existing silent-drop on two low-stakes flags.

## Testing

Ran the four targeted vitest files (148 tests, all green) covering the new local-source create logic, takeRequiredFlag, help examples, and suggestions, then demonstrated the feature end-to-end by driving the real gh-axi CLI with a fake gh shim: all happy-path confirmations, argv forwarding, name defaulting, the unchanged remote-first output, and all eight rejection shapes (including both review-round fixes) behaved exactly per the intent, with zero gh invocations on rejection paths; also verified the updated repo help text and that build:skill produces no SKILL.md drift. No visual evidence applies — this is a terminal CLI, so the transcript is the end-user surface.

<details>
<summary>Evidence: End-to-end CLI transcript: gh-axi repo create --source (13 scenarios incl. gh argv log)</summary>

```text
gh-axi repo create --source end-to-end CLI transcript
======================================================
Setup: real gh-axi CLI (tsx bin/gh-axi.ts) run with a fake `gh` shim on PATH
that records its argv and returns success, against a real scaffolded local git
repo at /tmp/gh-axi-e2e/scaffolded-app. No real GitHub repos were created.
(tsx DeprecationWarning noise stripped.)

=== 1. Local-source publish: name defaults to source dir name ===
$ gh-axi repo create --public --source /tmp/gh-axi-e2e/scaffolded-app --push
created: ok
repo: scaffolded-app
visibility: public
source: /tmp/gh-axi-e2e/scaffolded-app
remote: origin
pushed: true
help[1]:
  Run `gh-axi repo view --repo <owner/name>` to see the new repository
(exit 0)

=== 2. Local-source publish with explicit name + custom remote ===
$ gh-axi repo create my-repo --private --source /tmp/gh-axi-e2e/scaffolded-app --remote upstream
created: ok
repo: my-repo
visibility: private
source: /tmp/gh-axi-e2e/scaffolded-app
remote: upstream
pushed: false
help[1]:
  Run `gh-axi repo view --repo <owner/name>` to see the new repository
(exit 0)

=== 3. Existing remote-first create (TOON confirmation unchanged; help line is the intended new suggestion) ===
$ gh-axi repo create my-repo --private
created: ok
repo: my-repo
help[1]:
  Run `gh-axi repo view --repo <owner/name>` to see the new repository
(exit 0)

=== argv the wrapped 'gh' actually received for 1-3 ===
FAKE-GH received argv: repo create --public --source /tmp/gh-axi-e2e/scaffolded-app --push
FAKE-GH received argv: repo create my-repo --private --source /tmp/gh-axi-e2e/scaffolded-app --remote upstream
FAKE-GH received argv: repo create my-repo --private

=== 4. Dangling --source is rejected (no silent mode flip) ===
$ gh-axi repo create my-repo --source
error: "--source requires a value"
code: VALIDATION_ERROR
(exit 2)

=== 5. Blank --source= is rejected ===
$ gh-axi repo create my-repo --source=
error: "--source requires a value"
code: VALIDATION_ERROR
(exit 2)

=== 6. --push without --source is rejected ===
$ gh-axi repo create my-repo --push
error: "--push requires --source <path>"
code: VALIDATION_ERROR
(exit 2)

=== 7. --remote without --source is rejected ===
$ gh-axi repo create my-repo --remote upstream
error: "--remote requires --source <path>"
code: VALIDATION_ERROR
(exit 2)

=== 8. --source conflicts with --clone ===
$ gh-axi repo create my-repo --source /tmp/gh-axi-e2e/scaffolded-app --clone
error: "--source cannot be combined with --clone"
code: VALIDATION_ERROR
(exit 2)

=== 9. --source conflicts with --template ===
$ gh-axi repo create my-repo --source /tmp/gh-axi-e2e/scaffolded-app --template owner/tpl
error: "--source cannot be combined with --template"
code: VALIDATION_ERROR
(exit 2)

=== 10. Duplicate --source is rejected (second value not misread as name) ===
$ gh-axi repo create --source a --source b
error: "Unsupported extra argument for repo create: --source"
code: VALIDATION_ERROR
help[1]: gh-axi repo create --help
(exit 2)

=== 11. Unconsumed --push=true is rejected (not silently dropped) ===
$ gh-axi repo create --source /tmp/gh-axi-e2e/scaffolded-app --push=true
error: "Unsupported extra argument for repo create: --push=true"
code: VALIDATION_ERROR
help[1]: gh-axi repo create --help
(exit 2)

=== gh invocations during error scenarios 4-11 ===
(no gh invocations - the state-changing gh command never ran on any rejection)

=== 12. Updated REPO_HELP (gh-axi repo --help) ===
$ gh-axi repo --help
usage: gh-axi repo <subcommand> [flags]
subcommands[6]:
  view [owner/name], create [name], edit, clone <repo>, fork [repo], list [owner]
flags{view}:
  --repo <owner/name> or exactly one positional owner/name; choose one selector
flags{create}:
  --public, --private, --internal, --description, --clone, --template
  --source <path> (publish existing local repo; name defaults to source dir name), --push, --remote <name> (both require --source)
flags{edit}:
  --description, --visibility, --default-branch, --enable-issues, --enable-wiki
flags{fork}:
  --clone, --remote
flags{list}:
  --limit <n> (default 30), --visibility, --language, --archived
examples:
  gh-axi repo view
  gh-axi repo view --repo owner/name
  gh-axi repo view owner/name
  gh-axi repo create my-project --public --description "A new project"
  gh-axi repo create --public --source . --push
(exit 0)

=== 13. Skill regeneration drift check ===
$ pnpm run build:skill && git diff --quiet -- skills/
skill: no drift after build:skill
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0c3cb1c8b54713134fedfeb8c359dca4907f41bd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `src/commands/repo.ts:122` - A dangling or blank --source value silently flips a local-source publish into a plain remote-first create. takeFlag returns undefined for a trailing `--source` (and &#39;&#39; for `--source=`), both falsy, so `gh-axi repo create my-repo --source` executes `gh repo create my-repo` — a state-changing command runs in the wrong mode with no error, violating the codebase&#39;s stated &#39;never silently drop&#39; principle (args.ts already has requireFlagValue precedent for this). Fix: throw VALIDATION_ERROR when --source (and --remote) is present with a missing or blank value.
- ⚠️ `src/commands/repo.ts:125` - Leftover unconsumed tokens in `rest` are misinterpreted as the name positional or silently dropped. Concrete cases: (1) `repo create --source a --source b` — takeFlag removes only the first occurrence, so `b` survives and `rest.find(a =&gt; !a.startsWith(&#39;-&#39;))` makes it the repo NAME, creating a repo named &#39;b&#39; with source &#39;a&#39;; (2) `repo create --source . --push=true` — rejectUnknownFlags matches flag names only so `--push=true` passes as known, but takeBoolFlag matches the exact token, so it is never consumed, skipped by the name find, and the repo is created without pushing (confirmation says pushed: false) with no error. Fix: after extracting the single name positional, reject any remaining tokens in rest with VALIDATION_ERROR.
- ℹ️ `src/commands/repo.ts:156` - The confirmation&#39;s defaulted repo name can diverge from the repo actually created: GitHub normalizes repository names (directory &#39;my app&#39; becomes repo &#39;my-app&#39;), so `created.repo = basename(resolve(source))` may report a name that does not exist, and the new `repo view --repo &lt;owner/name&gt;` suggestion would then target it. ghExec already returns gh&#39;s stdout containing the real created-repo URL, but createRepo discards it. The remedy (parsing gh&#39;s stdout for the true owner/name, or replicating gh&#39;s normalization) changes the deliberate confirmation design stated in the intent, so it needs author authorization rather than an auto-fix; the same echo-the-input behavior pre-exists for explicitly named creates.

🔧 Fix: reject dangling/blank --source/--remote and leftover create args
1 info still open:

- ℹ️ `src/commands/repo.ts:119` - Residual instance of the silent-drop class fixed for --source/--remote: `--description` and `--template` are still parsed with plain takeFlag, so a dangling `--description` (e.g. `repo create my-repo --description`) or blank `--description=` silently creates the repo with no description and exits 0, and a dangling `--template` on `--source . --template` both skips the source/template conflict check and drops the flag without error. This behavior pre-existed via getFlag for the remote-first path and was outside the prior fix round&#39;s explicitly scoped instruction (--source/--remote plus leftover tokens), so it is not a regression; the mechanical remedy is swapping these two to takeRequiredFlag in a follow-up.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm vitest run test/commands/repo.test.ts test/args.test.ts test/help-examples.test.ts test/suggestions.test.ts` (148 tests, all passing, including the 13 new create/local-source tests and takeRequiredFlag tests)</code>
- <code>End-to-end CLI: `gh-axi repo create --public --source &lt;dir&gt; --push` with a fake `gh` shim on PATH — confirmed name defaults to source dir basename, TOON reports visibility/source/remote(origin)/pushed, and gh received `repo create --public --source &lt;dir&gt; --push`</code>
- <code>End-to-end CLI: explicit name + `--remote upstream` forwarding, and plain `gh-axi repo create my-repo --private` remote-first output unchanged (plus the intended new `repo view` suggestion line)</code>
- <code>End-to-end CLI rejection scenarios: dangling `--source`, blank `--source=`, `--push`/`--remote` without `--source`, `--source`+`--clone`, `--source`+`--template`, duplicate `--source`, and leftover `--push=true` — each exits 2 with VALIDATION_ERROR and the fake gh log confirms the state-changing gh command never ran</code>
- <code>Captured `gh-axi repo --help` showing the updated create flags line and new example; ran `pnpm run build:skill` and verified `git diff --quiet -- skills/` (no drift)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
