### PR TITLE
fix(repo): report real owner/name and harden name handling in repo create

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -61,15 +61,29 @@ function requireFlagValue(value: string, flag: string): string {
 /**
  * Like takeFlag, but throws VALIDATION_ERROR when the flag is present with a
  * missing or blank value, rather than silently returning undefined for it.
+ * A following option token (`--source --push`) is treated as a missing value,
+ * not consumed as one; use `--flag=value` for a dash-leading value.
  */
 export function takeRequiredFlag(
   args: string[],
   flag: string,
 ): string | undefined {
   const equalsPrefix = flagEqualsPrefix(flag);
-  if (!args.some((a) => a === flag || a.startsWith(equalsPrefix)))
-    return undefined;
-  return requireFlagValue(takeFlag(args, flag) ?? "", flag);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === flag) {
+      const val = args[i + 1];
+      if (val === undefined || val.startsWith("-"))
+        throw new AxiError(`${flag} requires a value`, "VALIDATION_ERROR");
+      args.splice(i, 2);
+      return requireFlagValue(val, flag);
+    }
+    if (arg.startsWith(equalsPrefix)) {
+      args.splice(i, 1);
+      return requireFlagValue(arg.slice(equalsPrefix.length), flag);
+    }
+  }
+  return undefined;
 }
 
 function collectAllFlags(

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -136,6 +136,10 @@ async function createRepo(args: string[], ctx?: RepoContext): Promise<string> {
     );
   }
 
+  if (name !== undefined && name.trim() === '') {
+    throw new AxiError('Repository name cannot be blank', 'VALIDATION_ERROR');
+  }
+
   if (source) {
     if (clone) throw new AxiError('--source cannot be combined with --clone', 'VALIDATION_ERROR');
     if (template) throw new AxiError('--source cannot be combined with --template', 'VALIDATION_ERROR');

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -146,7 +146,8 @@ async function createRepo(args: string[], ctx?: RepoContext): Promise<string> {
   }
 
   const ghArgs = ['repo', 'create'];
-  if (name) ghArgs.push(name);
+  const dashLeadingName = name !== undefined && name.startsWith('-');
+  if (name && !dashLeadingName) ghArgs.push(name);
   if (isPublic) ghArgs.push('--public');
   else if (isPrivate) ghArgs.push('--private');
   else if (isInternal) ghArgs.push('--internal');
@@ -159,6 +160,7 @@ async function createRepo(args: string[], ctx?: RepoContext): Promise<string> {
     if (clone) ghArgs.push('--clone');
     if (template) ghArgs.push('--template', template);
   }
+  if (dashLeadingName) ghArgs.push('--', name as string);
 
   const output = await ghExec(ghArgs);
   const suggestions = getSuggestions({ domain: 'repo', action: 'create', repo: ctx });

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -160,12 +160,17 @@ async function createRepo(args: string[], ctx?: RepoContext): Promise<string> {
     if (template) ghArgs.push('--template', template);
   }
 
-  await ghExec(ghArgs);
+  const output = await ghExec(ghArgs);
   const suggestions = getSuggestions({ domain: 'repo', action: 'create', repo: ctx });
+  // gh defaults the repo name to the source directory's name and normalizes it
+  // (e.g. "my app" -> "my-app"), so prefer the real owner/name from the
+  // created-repo URL gh prints; fall back to the raw basename if absent.
+  const urlNwo = name
+    ? undefined
+    : output.match(/https?:\/\/[^/\s]+\/([^/\s]+\/[^/\s]+)/)?.[1];
   const created: Record<string, unknown> = {
     created: 'ok',
-    // gh defaults the repo name to the source directory's name.
-    repo: name ?? basename(resolve(source as string)),
+    repo: name ?? urlNwo ?? basename(resolve(source as string)),
   };
   if (source) {
     if (isPublic) created.visibility = 'public';

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -96,6 +96,20 @@ describe("takeRequiredFlag", () => {
       new AxiError("--source requires a value", "VALIDATION_ERROR"),
     );
   });
+
+  it("throws VALIDATION_ERROR instead of consuming a following option token as the value", () => {
+    const args = ["--source", "--push"];
+    expect(() => takeRequiredFlag(args, "--source")).toThrow(
+      new AxiError("--source requires a value", "VALIDATION_ERROR"),
+    );
+    expect(args).toEqual(["--source", "--push"]);
+  });
+
+  it("accepts a dash-leading value via the --flag=value form", () => {
+    const args = ["--source=-dashy", "--push"];
+    expect(takeRequiredFlag(args, "--source")).toBe("-dashy");
+    expect(args).toEqual(["--push"]);
+  });
 });
 
 describe("hasFlag", () => {

--- a/test/commands/repo.test.ts
+++ b/test/commands/repo.test.ts
@@ -303,6 +303,20 @@ describe('repoCommand', () => {
       expect(mockedGhExec).not.toHaveBeenCalled();
     });
 
+    it('rejects --source followed by another option instead of consuming it as the value', async () => {
+      await expect(
+        repoCommand(['create', 'my-repo', '--source', '--push']),
+      ).rejects.toThrow('--source requires a value');
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it('rejects --remote followed by another option instead of consuming it as the value', async () => {
+      await expect(
+        repoCommand(['create', '--source', '.', '--remote', '--public']),
+      ).rejects.toThrow('--remote requires a value');
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
     it('rejects a duplicate --source instead of misreading its value as the name', async () => {
       await expect(
         repoCommand(['create', '--source', 'a', '--source', 'b']),

--- a/test/commands/repo.test.ts
+++ b/test/commands/repo.test.ts
@@ -186,6 +186,26 @@ describe('repoCommand', () => {
       expect(result).toContain('pushed: false');
     });
 
+    it('reports the actual owner/name from gh output when the name is defaulted', async () => {
+      mockedGhExec.mockResolvedValue(
+        '✓ Created repository simkimsia/my-app on GitHub\nhttps://github.com/simkimsia/my-app\n',
+      );
+
+      const result = await repoCommand(['create', '--public', '--source', '/tmp/my app']);
+
+      // GitHub normalized the directory name "my app" to "my-app".
+      expect(result).toContain('repo: simkimsia/my-app');
+    });
+
+    it('reports the explicit name unchanged even when gh output has a URL', async () => {
+      mockedGhExec.mockResolvedValue('https://github.com/simkimsia/named-repo\n');
+
+      const result = await repoCommand(['create', 'named-repo', '--public', '--source', '.']);
+
+      expect(result).toContain('repo: named-repo');
+      expect(result).not.toContain('simkimsia/named-repo');
+    });
+
     it('does not mistake the --source value for the name positional', async () => {
       mockedGhExec.mockResolvedValue('');
 

--- a/test/commands/repo.test.ts
+++ b/test/commands/repo.test.ts
@@ -234,6 +234,30 @@ describe('repoCommand', () => {
       ).rejects.toThrow('Unsupported extra argument for repo create: --push');
     });
 
+    it('forwards a dash-leading name behind a trailing -- so gh treats it as a positional', async () => {
+      mockedGhExec.mockResolvedValue('');
+
+      const result = await repoCommand(['create', '--public', '--', '-tool']);
+
+      expect(mockedGhExec).toHaveBeenCalledWith([
+        'repo', 'create', '--public', '--', '-tool',
+      ]);
+      expect(result).toContain('created: ok');
+      expect(result).toContain('-tool');
+    });
+
+    it('does not let a dash-leading name after -- turn into a gh flag in local-source mode', async () => {
+      mockedGhExec.mockResolvedValue('');
+
+      const result = await repoCommand(['create', '--source', '.', '--', '--public']);
+
+      expect(mockedGhExec).toHaveBeenCalledWith([
+        'repo', 'create', '--source', '.', '--', '--public',
+      ]);
+      expect(result).toContain('created: ok');
+      expect(result).toContain('--public');
+    });
+
     it('rejects --source combined with --clone', async () => {
       await expect(
         repoCommand(['create', 'my-repo', '--source', '.', '--clone']),

--- a/test/commands/repo.test.ts
+++ b/test/commands/repo.test.ts
@@ -316,6 +316,27 @@ describe('repoCommand', () => {
       ).rejects.toThrow('Unsupported extra argument for repo create: --push=true');
       expect(mockedGhExec).not.toHaveBeenCalled();
     });
+
+    it('rejects an empty-string name in local-source mode instead of silently dropping it', async () => {
+      await expect(
+        repoCommand(['create', '', '--source', '.']),
+      ).rejects.toThrow('Repository name cannot be blank');
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it('rejects a whitespace-only name in remote-first mode', async () => {
+      await expect(
+        repoCommand(['create', '  ', '--public']),
+      ).rejects.toThrow('Repository name cannot be blank');
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty-string name after the -- separator', async () => {
+      await expect(
+        repoCommand(['create', '--source', '.', '--', '']),
+      ).rejects.toThrow('Repository name cannot be blank');
+      expect(mockedGhExec).not.toHaveBeenCalled();
+    });
   });
 
   describe('list', () => {


### PR DESCRIPTION
## Intent

Implement gh-axi issue #134 (triaged ready-for-pr by the maintainer): forward gh repo create's local-source mode through gh-axi repo create so agent scaffold-then-publish workflows stay inside the wrapper instead of falling back to raw gh. Per the maintainer's triage comment: wrap --source, --push, and also --remote; with --source the name positional is optional and defaults to the source directory name; validate up front that --source conflicts with --clone and --template. Deliberate decisions: --push and --remote without --source are rejected with VALIDATION_ERROR; flags in createRepo are consumed destructively so a flag value like '--source .' is never mistaken for the name positional; dangling/blank --source/--remote values and leftover unconsumed tokens are rejected loudly (prior pipeline fix); the -- end-of-options separator is honored (prior pipeline fix); the TOON confirmation for local-source mode reports repo, visibility, source, remote (default 'origin'), and pushed boolean, while remote-first create output stays byte-for-byte unchanged (contract-class opt-in). NEW in this follow-up commit, per explicit author sign-off on the pipeline's earlier ask-user finding defaulted-name-normalization-mismatch: when the name positional is omitted, the confirmation's repo field now reports the real owner/name parsed from the created-repo URL in gh's stdout (GitHub normalizes names, e.g. directory 'my app' -> repo 'my-app'), falling back to basename(resolve(source)) only when no URL is present; explicit names are echoed unchanged. Also from the first run: a next-step hint added to the previously empty repo-create suggestions, and REPO_HELP updated. This branch already has open PR #135; this run validates the follow-up commit on top. Full suite: 969 tests pass.

## What Changed
- When the name positional is omitted in local-source `repo create`, the TOON confirmation's `repo` field now reports the real `owner/name` parsed from the created-repo URL in gh's stdout (GitHub normalizes names, e.g. directory `my app` -> repo `my-app`), falling back to `basename(resolve(source))` only when no URL is present; explicitly provided names are echoed unchanged.
- Dash-leading repo names are forwarded to `gh repo create` behind a trailing `--` end-of-options separator so gh treats them as the name positional instead of a flag, in both remote-first and local-source modes.
- Blank (empty or whitespace-only) name positionals are rejected with `VALIDATION_ERROR` before any gh invocation, including after the `--` separator; new tests in `test/commands/repo.test.ts` cover all three behaviors.

## Risk Assessment

✅ Low: Three small, well-tested follow-up commits that each close a previously identified defect exactly as authorized (blank-name rejection, dash-leading-name forwarding behind --, URL-parsed defaulted repo name with a safe basename fallback), with the explicit-name and remote-first paths verified byte-for-byte unchanged and no new silent-wrong-result path found under edge-case tracing.

## Testing

Ran the focused repo-command test file (40 tests, all passing) and then exercised the real gh-axi CLI end-to-end with a stub gh on PATH that logged the argv it received: the defaulted-name confirmation reports the real normalized owner/name from gh's URL, dash-leading names are forwarded to gh behind a -- separator, blank/whitespace names are rejected with VALIDATION_ERROR before gh is ever invoked, and the remote-first create output plus validation guards remain intact — full transcript and gh argv log captured as evidence, temp stubs removed, worktree left clean.

<details>
<summary>Evidence: E2E CLI transcript (gh-axi repo create scenarios with stubbed gh)</summary>

```text
=== E2E transcript: gh-axi repo create local-source mode (stubbed gh on PATH; argv log below) ===

--- 1. Defaulted name: gh normalizes dir 'my app' -> repo 'my-app'; confirmation reports real owner/name from gh URL ---
$ gh-axi repo create --public --source /tmp/ghaxi-e2e/my app --push
(node:25706) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
created: ok
repo: simkimsia/my-app
visibility: public
source: /tmp/ghaxi-e2e/my app
remote: origin
pushed: true
help[1]:
  Run `gh-axi repo view --repo <owner/name>` to see the new repository
[exit: 0]

--- 2. Explicit name echoed unchanged ---
$ gh-axi repo create named-repo --private --source .
(node:25729) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
created: ok
repo: named-repo
visibility: private
source: .
remote: origin
pushed: false
help[1]:
  Run `gh-axi repo view --repo <owner/name>` to see the new repository
[exit: 0]

--- 3. Dash-leading name behind -- forwarded to gh as positional ---
$ gh-axi repo create --public -- -tool
(node:25954) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
created: ok
repo: "-tool"
help[1]:
  Run `gh-axi repo view --repo <owner/name>` to see the new repository
[exit: 0]

--- 4. Blank name rejected loudly in local-source mode ---
$ gh-axi repo create  --source .
error: Repository name cannot be blank
code: VALIDATION_ERROR
(node:25977) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit: 2]

--- 5. Whitespace-only name rejected in remote-first mode ---
$ gh-axi repo create    --public
error: Repository name cannot be blank
code: VALIDATION_ERROR
(node:26000) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit: 2]

--- 6. --push without --source rejected ---
$ gh-axi repo create my-repo --push
error: "--push requires --source <path>"
code: VALIDATION_ERROR
(node:26020) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[exit: 2]

--- 7. Remote-first create (unchanged contract) ---
$ gh-axi repo create plain-repo --private
(node:26040) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
created: ok
repo: plain-repo
help[1]:
  Run `gh-axi repo view --repo <owner/name>` to see the new repository
[exit: 0]

=== gh argv log (what the child gh actually received) ===
gh repo create --public --source /tmp/ghaxi-e2e/my app --push
gh repo create named-repo --private --source .
gh repo create --public -- -tool
gh repo create plain-repo --private
```
</details>
<details>
<summary>Evidence: gh child-process argv log (proves forwarded argv and that rejected commands never reached gh)</summary>

<code>gh repo create --public --source /tmp/ghaxi-e2e/my app --push&#10;gh repo create named-repo --private --source .&#10;gh repo create --public -- -tool&#10;gh repo create plain-repo --private</code>

```text
gh repo create --public --source /tmp/ghaxi-e2e/my app --push
gh repo create named-repo --private --source .
gh repo create --public -- -tool
gh repo create plain-repo --private
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"45c4ccc83faafda6eb5b9bea69297ce96bf60370","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `src/commands/repo.ts:149` - The -- end-of-options separator is honored by gh-axi&#39;s parser but lost when forwarding to gh: a name taken from the tail after `--` is pushed as a bare positional (`if (name) ghArgs.push(name)`), so a dash-leading name is re-parsed by gh as a flag. Concrete silent-wrong path: `gh-axi repo create --source . -- --public` builds `gh repo create --public --source .` — gh creates a PUBLIC repo named after the source directory instead of a repo named &#39;--public&#39;, with no error, and the confirmation echoes `repo: --public`. Less contrived dash-leading names (e.g. `-tool`) fail loudly in gh with &#39;unknown shorthand flag&#39;, so legitimate dash-leading repo names cannot be created at all, defeating the separator&#39;s purpose. Fix mechanically: when the resolved name starts with &#39;-&#39;, append a literal &#39;--&#39; terminator followed by the name at the END of ghArgs (after all forwarded flags — placing &#39;--&#39; earlier would make gh treat subsequent flags as positionals); normal names keep the current argv byte-for-byte.

🔧 Fix: forward dash-leading repo names behind -- to gh
1 warning still open:

- ⚠️ `src/commands/repo.ts:145` - An explicit empty-string name positional in local-source mode is silently dropped instead of rejected, and the confirmation then reports a blank repo. Concrete trace: `gh-axi repo create &#34;&#34; --source .` (or `gh-axi repo create &#34;$NAME&#34; --source .` with an unset NAME, or `-- &#34;&#34;` after the separator) — the &#39;&#39; token passes rejectUnknownFlags and the `!a.startsWith(&#39;-&#39;)` name find (repo.ts:128-129), skips the leftovers rejection, and the source branch&#39;s validation block (139-141) never checks the name (only the else branch has `if (!name) throw`, line 145). Then `if (name &amp;&amp; !dashLeadingName)` (line 150) treats &#39;&#39; as falsy and omits it from ghArgs, so gh silently defaults the repo name to the source directory&#39;s basename; finally `repo: name ?? urlNwo ?? ...` (line 175) evaluates `&#39;&#39; ?? urlNwo` to &#39;&#39; because empty string is not nullish, so the TOON confirmation prints a blank `repo:` while gh actually created a directory-named repo — a state-changing command runs in a mode the user did not request and reports a wrong value, violating the loud-rejection principle this branch was explicitly hardened around. Fix mechanically: throw VALIDATION_ERROR when the extracted name is present but blank (mirroring requireFlagValue&#39;s blank check), before the mode branch, so both source and remote-first paths reject it identically.

🔧 Fix: reject blank repo-create name positional in both modes
1 info still open:

- ℹ️ `src/commands/repo.ts:145` - A blank `--template=` (and `--description=`) value is consumed by takeFlag and silently dropped, so `gh-axi repo create --source . --template=` bypasses the new &#39;--source cannot be combined with --template&#39; check instead of erroring. The practical impact is nil (a blank template carries no conflicting semantics and gh receives nothing), and this silent-drop behavior for these two flags is byte-identical to the pre-change getFlag code — the prior review decisions deliberately scoped requireFlagValue hardening to --source/--remote only. Noting for completeness; extending takeRequiredFlag to --template/--description would change pre-existing user-visible behavior and needs author intent, so no action is taken.

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm exec vitest run test/commands/repo.test.ts test/args.test.ts` (95 tests, all passing — covers --source/--push/--remote forwarding, defaulted-name URL parsing, explicit-name echo, -- separator, dash-leading names, dangling/blank/duplicate/leftover flag rejections, blank-name rejection in both modes)</code>
- <code>Manual E2E: ran `tsx bin/gh-axi.ts repo create ...` through 8 scenarios with a stubbed `gh` on PATH that logged exact argv and emitted a realistic created-repo URL — verified TOON confirmations (repo/visibility/source/remote/pushed + next-step hint), `repo: simkimsia/my-app` normalization when name is defaulted from source dir &#39;my app&#39;, byte-shape-unchanged remote-first output, VALIDATION_ERROR exit code 2 with zero gh invocations for --push-without---source / dangling --source / blank name / leftover --push=true, and `gh repo create --public -- -tool` argv for the dash-leading name</code>
- `Confirmed worktree left clean after removing the temp gh stub`

✅ No issues found.
- `pnpm exec vitest run test/commands/repo.test.ts (40 tests, all passing, including the 7 new tests from these commits)`
- <code>Manual E2E: ran `tsx bin/gh-axi.ts repo create --public --source &#34;/tmp/ghaxi-e2e/my app&#34; --push` with a stub `gh` on PATH — confirmation reported `repo: simkimsia/my-app` parsed from gh&#39;s created-repo URL instead of the raw basename `my app`</code>
- <code>Manual E2E: `repo create named-repo --private --source .` — explicit name echoed unchanged despite a URL in gh output</code>
- <code>Manual E2E: `repo create --public -- -tool` — stub argv log confirms gh received `repo create --public -- -tool` (name behind -- separator)</code>
- <code>Manual E2E: `repo create &#34;&#34; --source .` and `repo create &#34; &#34; --public` — both exit 2 with `VALIDATION_ERROR: Repository name cannot be blank`; argv log confirms gh was never invoked</code>
- <code>Manual E2E: `repo create my-repo --push` rejected (--push requires --source) and `repo create plain-repo --private` remote-first output unchanged; next-step `repo view --repo` hint present in all create confirmations</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found ✅</summary>

- ℹ️ `src/commands/repo.ts` - Prettier --check flags src/commands/repo.ts and test/commands/repo.test.ts, but both were already unclean at the base commit and 14 files repo-wide fail the check; Prettier has no config, no lint script, and is absent from CI (AGENTS.md documents it only for pnpm-lock.yaml formatting), so it is not an enforced source formatter. Deliberately left unformatted to avoid whole-file churn unrelated to this change; ESLint and tsc both pass.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>
